### PR TITLE
Expose presenter volume control

### DIFF
--- a/crates/kuroko/src/apple.rs
+++ b/crates/kuroko/src/apple.rs
@@ -21,7 +21,10 @@ pub enum AppleDecodeBackend {
 
 #[cfg(target_os = "macos")]
 pub mod coreaudio {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    };
 
     use coreaudio::audio_unit::audio_format::LinearPcmFlags;
     use coreaudio::audio_unit::render_callback::{self, data};
@@ -68,6 +71,7 @@ pub mod coreaudio {
         state: AudioOutputState,
         audio_unit: Option<AudioUnit>,
         buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
     }
 
     impl CoreAudioOutput {
@@ -76,6 +80,7 @@ pub mod coreaudio {
                 state: AudioOutputState::Stopped,
                 audio_unit: None,
                 buffer: Arc::new(Mutex::new(AudioRingBuffer::new(config.ring_buffer))),
+                volume: Arc::new(AtomicU32::new(1.0f32.to_bits())),
             }
         }
 
@@ -87,10 +92,23 @@ pub mod coreaudio {
                 Scope::Input,
                 Element::Output,
             )?;
-            install_render_callback(&mut audio_unit, Arc::clone(&self.buffer))?;
+            install_render_callback(
+                &mut audio_unit,
+                Arc::clone(&self.buffer),
+                Arc::clone(&self.volume),
+            )?;
             audio_unit.initialize()?;
             self.audio_unit = Some(audio_unit);
             Ok(())
+        }
+
+        pub fn set_volume(&mut self, volume: f32) {
+            self.volume
+                .store(normalize_volume(volume).to_bits(), Ordering::Relaxed);
+        }
+
+        pub fn volume(&self) -> f32 {
+            f32::from_bits(self.volume.load(Ordering::Relaxed))
         }
 
         pub fn start(&mut self) -> Result<()> {
@@ -215,6 +233,7 @@ pub mod coreaudio {
     fn install_render_callback(
         audio_unit: &mut AudioUnit,
         buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
     ) -> Result<()> {
         type Args = render_callback::Args<data::Interleaved<f32>>;
         audio_unit.set_render_callback(move |mut args: Args| {
@@ -222,6 +241,10 @@ pub mod coreaudio {
                 .lock()
                 .map_err(|_| ())
                 .and_then(|mut buffer| buffer.read_interleaved(args.data.buffer).map_err(|_| ()))?;
+            apply_volume(
+                args.data.buffer,
+                f32::from_bits(volume.load(Ordering::Relaxed)),
+            );
             if read_result.underflow_frames > 0 {
                 args.flags
                     .insert(render_callback::ActionFlags::OUTPUT_IS_SILENCE);
@@ -229,6 +252,24 @@ pub mod coreaudio {
             Ok(())
         })?;
         Ok(())
+    }
+
+    fn normalize_volume(volume: f32) -> f32 {
+        if volume.is_finite() {
+            volume.clamp(0.0, 1.0)
+        } else {
+            1.0
+        }
+    }
+
+    fn apply_volume(samples: &mut [f32], volume: f32) {
+        let volume = normalize_volume(volume);
+        if (volume - 1.0).abs() <= f32::EPSILON {
+            return;
+        }
+        for sample in samples {
+            *sample *= volume;
+        }
     }
 
     fn configure_buffer(buffer: &Arc<Mutex<AudioRingBuffer>>, format: PcmFormat) -> Result<()> {
@@ -244,5 +285,27 @@ pub mod coreaudio {
             .map_err(|_| CoreAudioOutputError::LockPoisoned)?;
         buffer.clear();
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn volume_is_clamped_and_applied_to_pcm_samples() {
+            let mut output = CoreAudioOutput::default();
+
+            assert_eq!(output.volume(), 1.0);
+            output.set_volume(0.25);
+            assert_eq!(output.volume(), 0.25);
+            output.set_volume(-1.0);
+            assert_eq!(output.volume(), 0.0);
+            output.set_volume(f32::NAN);
+            assert_eq!(output.volume(), 1.0);
+
+            let mut samples = [1.0, -0.5, 0.25, 0.0];
+            apply_volume(&mut samples, 0.5);
+            assert_eq!(samples, [0.5, -0.25, 0.125, 0.0]);
+        }
     }
 }

--- a/crates/kuroko/src/danmaku.rs
+++ b/crates/kuroko/src/danmaku.rs
@@ -1583,6 +1583,9 @@ impl DfmLayoutEngine {
 
     pub fn set_config(&mut self, config: DanmakuLayoutConfig) {
         let config = config.sanitized();
+        if self.config == config {
+            return;
+        }
         let font_changed = self.config.custom_font_family != config.custom_font_family
             || self.config.custom_font_file_path != config.custom_font_file_path;
         self.config = config;

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -301,6 +301,14 @@ impl PresenterRuntime {
         self.player.set_playback_rate(rate)
     }
 
+    pub fn set_volume(&mut self, volume: f64) {
+        self.audio_output.set_volume(volume as f32);
+    }
+
+    pub fn volume(&self) -> f64 {
+        self.audio_output.volume() as f64
+    }
+
     pub fn set_danmaku_timeline(&mut self, timeline: DanmakuTimeline) {
         self.danmaku_session.replace_default_track(
             timeline,
@@ -387,6 +395,9 @@ impl PresenterRuntime {
     }
 
     pub fn set_danmaku_config(&mut self, config: DanmakuLayoutConfig) {
+        if self.danmaku.config() == &config {
+            return;
+        }
         self.danmaku.set_config(config);
         self.current_danmaku = None;
         self.current_danmaku_viewport = None;
@@ -1326,6 +1337,19 @@ mod tests {
             written_frames: 24_000,
             underflow_frames: 0,
         }));
+    }
+
+    #[test]
+    fn presenter_volume_is_clamped() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+
+        assert_eq!(presenter.volume(), 1.0);
+        presenter.set_volume(0.4);
+        assert!((presenter.volume() - 0.4).abs() < 0.000_001);
+        presenter.set_volume(-1.0);
+        assert_eq!(presenter.volume(), 0.0);
+        presenter.set_volume(f64::NAN);
+        assert_eq!(presenter.volume(), 1.0);
     }
 
     #[test]

--- a/crates/kuroko_capi/include/kuroko.h
+++ b/crates/kuroko_capi/include/kuroko.h
@@ -242,6 +242,7 @@ KurokoStatus kuroko_presenter_stop(KurokoPresenterHandle *handle);
 KurokoStatus kuroko_presenter_close(KurokoPresenterHandle *handle);
 KurokoStatus kuroko_presenter_seek(KurokoPresenterHandle *handle, uint64_t position_micros);
 KurokoStatus kuroko_presenter_set_playback_rate(KurokoPresenterHandle *handle, double rate);
+KurokoStatus kuroko_presenter_set_volume(KurokoPresenterHandle *handle, double volume);
 KurokoStatus kuroko_presenter_add_external_subtitle(
     KurokoPresenterHandle *handle,
     const char *uri,
@@ -302,6 +303,9 @@ KurokoStatus kuroko_presenter_set_danmaku_config(
 KurokoStatus kuroko_presenter_set_danmaku_config_ptr(
     KurokoPresenterHandle *handle,
     const KurokoDanmakuConfig *config);
+KurokoStatus kuroko_presenter_get_danmaku_config(
+    KurokoPresenterHandle *handle,
+    KurokoDanmakuConfig *out_config);
 KurokoStatus kuroko_presenter_set_danmaku_font(
     KurokoPresenterHandle *handle,
     const char *family,

--- a/crates/kuroko_capi/src/lib.rs
+++ b/crates/kuroko_capi/src/lib.rs
@@ -705,6 +705,30 @@ fn danmaku_config_from_c(
     }
 }
 
+fn danmaku_config_to_c(config: &DanmakuLayoutConfig) -> KurokoDanmakuConfig {
+    KurokoDanmakuConfig {
+        enabled: config.enabled,
+        font_size: config.font_size,
+        opacity: config.opacity,
+        display_area: config.display_area,
+        scroll_duration_seconds: config.scroll_duration_seconds,
+        scroll_speed_factor: config.scroll_speed_factor,
+        track_gap_ratio: config.track_gap_ratio,
+        outline_width: config.outline_width,
+        shadow_offset_x: config.shadow_offset[0],
+        shadow_offset_y: config.shadow_offset[1],
+        merge_duplicates: config.merge_duplicates,
+        allow_stacking: config.allow_stacking,
+        allow_scroll_overwrite: config.allow_scroll_overwrite,
+        max_quantity: config.max_quantity.unwrap_or(0),
+        max_lines_per_mode: config.max_lines_per_mode.unwrap_or(0),
+        block_top: config.block_top,
+        block_bottom: config.block_bottom,
+        block_scroll: config.block_scroll,
+        shadow_style: config.shadow_style.code(),
+    }
+}
+
 fn danmaku_block_words_from_json(json: &str) -> Result<Vec<String>, KurokoStatus> {
     let value: serde_json::Value =
         serde_json::from_str(json).map_err(|_| KurokoStatus::PlayerError)?;
@@ -812,6 +836,18 @@ pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
 ) -> KurokoStatus {
     with_presenter_mut(handle, |handle| {
         status_from_player_result(handle.presenter.set_playback_rate(rate))
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_set_volume(
+    handle: *mut KurokoPresenterHandle,
+    volume: f64,
+) -> KurokoStatus {
+    with_presenter_mut(handle, |handle| {
+        handle.presenter.set_volume(volume);
+        KurokoStatus::Ok
     })
 }
 
@@ -1143,6 +1179,28 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
 
 #[cfg(target_os = "macos")]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
+    handle: *mut KurokoPresenterHandle,
+    out_config: *mut KurokoDanmakuConfig,
+) -> KurokoStatus {
+    if out_config.is_null() {
+        return KurokoStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        let config = handle
+            .presenter
+            .danmaku_config()
+            .map(danmaku_config_to_c)
+            .unwrap_or_default();
+        unsafe {
+            *out_config = config;
+        }
+        KurokoStatus::Ok
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     handle: *mut KurokoPresenterHandle,
     family: *const c_char,
@@ -1265,6 +1323,15 @@ pub unsafe extern "C" fn kuroko_presenter_tracks(
 pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     _handle: *mut std::ffi::c_void,
     _rate: f64,
+) -> KurokoStatus {
+    KurokoStatus::PlayerError
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_set_volume(
+    _handle: *mut std::ffi::c_void,
+    _volume: f64,
 ) -> KurokoStatus {
     KurokoStatus::PlayerError
 }
@@ -1402,6 +1469,18 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     config: *const KurokoDanmakuConfig,
 ) -> KurokoStatus {
     if config.is_null() {
+        return KurokoStatus::NullPointer;
+    }
+    KurokoStatus::PlayerError
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
+    _handle: *mut std::ffi::c_void,
+    out_config: *mut KurokoDanmakuConfig,
+) -> KurokoStatus {
+    if out_config.is_null() {
         return KurokoStatus::NullPointer;
     }
     KurokoStatus::PlayerError
@@ -2013,6 +2092,27 @@ mod tests {
         );
         let handle = kuroko_presenter_create();
         assert!(!handle.is_null());
+        unsafe { kuroko_presenter_destroy(handle) };
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn c_presenter_set_volume_accepts_valid_handle() {
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(std::ptr::null_mut(), 0.5) },
+            KurokoStatus::NullPointer
+        );
+
+        let handle = kuroko_presenter_create();
+        assert!(!handle.is_null());
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(handle, 0.5) },
+            KurokoStatus::Ok
+        );
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(handle, f64::NAN) },
+            KurokoStatus::Ok
+        );
         unsafe { kuroko_presenter_destroy(handle) };
     }
 

--- a/packages/kuroko_flutter/lib/src/kuroko_player.dart
+++ b/packages/kuroko_flutter/lib/src/kuroko_player.dart
@@ -127,6 +127,14 @@ class KurokoPlayer {
     });
   }
 
+  Future<void> setVolume(double volume) async {
+    final playerId = await ensureCreated();
+    await _invoke('setVolume', <String, Object?>{
+      'playerId': playerId,
+      'volume': volume.clamp(0.0, 1.0),
+    });
+  }
+
   Future<int> addExternalSubtitle(String uri) async {
     final playerId = await ensureCreated();
     final trackId = await _channel.invokeMethod<int>(

--- a/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
+++ b/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
@@ -152,6 +152,7 @@ private final class KurokoNativeLibrary {
   typealias CommandFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SeekFn = @convention(c) (UnsafeMutableRawPointer?, UInt64) -> Int32
   typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -170,6 +171,7 @@ private final class KurokoNativeLibrary {
   typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
   typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
+  typealias GetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuFontFn = @convention(c) (
     UnsafeMutableRawPointer?,
     UnsafePointer<CChar>?,
@@ -206,6 +208,7 @@ private final class KurokoNativeLibrary {
   let close: CommandFn
   let seek: SeekFn
   let setPlaybackRate: SetPlaybackRateFn?
+  let setVolume: SetVolumeFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -222,6 +225,7 @@ private final class KurokoNativeLibrary {
   let clearDanmaku: ClearDanmakuFn?
   let setDanmakuEnabled: SetDanmakuEnabledFn?
   let setDanmakuConfig: SetDanmakuConfigFn?
+  let getDanmakuConfig: GetDanmakuConfigFn?
   let setDanmakuFont: SetDanmakuFontFn?
   let setDanmakuBlockWords: SetDanmakuBlockWordsFn?
   let trackSelection: TrackSelectionFn
@@ -250,6 +254,7 @@ private final class KurokoNativeLibrary {
     close = try Self.load("kuroko_presenter_close", from: libraryHandle, as: CommandFn.self)
     seek = try Self.load("kuroko_presenter_seek", from: libraryHandle, as: SeekFn.self)
     setPlaybackRate = Self.loadOptional("kuroko_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
+    setVolume = Self.loadOptional("kuroko_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     selectAudioTrack = try Self.load("kuroko_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("kuroko_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("kuroko_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -266,6 +271,7 @@ private final class KurokoNativeLibrary {
     clearDanmaku = Self.loadOptional("kuroko_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
     setDanmakuEnabled = Self.loadOptional("kuroko_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
     setDanmakuConfig = Self.loadOptional("kuroko_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
+    getDanmakuConfig = Self.loadOptional("kuroko_presenter_get_danmaku_config", from: libraryHandle, as: GetDanmakuConfigFn.self)
     setDanmakuFont = Self.loadOptional("kuroko_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
     setDanmakuBlockWords = Self.loadOptional("kuroko_presenter_set_danmaku_block_words_json", from: libraryHandle, as: SetDanmakuBlockWordsFn.self)
     trackSelection = try Self.load("kuroko_presenter_track_selection", from: libraryHandle, as: TrackSelectionFn.self)
@@ -363,6 +369,7 @@ private final class KurokoPlayerHost {
   private weak var attachedView: KurokoMetalSurfaceView?
   private var displayTimer: Timer?
   private var startTimeSeconds: CFTimeInterval = CACurrentMediaTime()
+  private var currentDanmakuConfig = KurokoDanmakuConfigC()
 
   init(id: Int64, library: KurokoNativeLibrary, config: KurokoPresenterConfigC) throws {
     self.id = id
@@ -371,6 +378,7 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.presenterCreateFailed
     }
     self.handle = handle
+    refreshDanmakuConfigSnapshot()
   }
 
   deinit {
@@ -410,6 +418,14 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_playback_rate")
     }
     try check(setRate(handle, rate), operation: "set_playback_rate")
+  }
+
+  func setVolume(_ volume: Double) throws {
+    guard let setVolume = library.setVolume else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_volume")
+    }
+    let clampedVolume = volume.isFinite ? min(max(volume, 0.0), 1.0) : 1.0
+    try check(setVolume(handle, clampedVolume), operation: "set_volume")
   }
 
   func addExternalSubtitle(uri: String) throws -> Int64 {
@@ -542,6 +558,24 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_enabled")
     }
     try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
+    currentDanmakuConfig.enabled = enabled ? 1 : 0
+  }
+
+  func danmakuConfigSnapshot() -> KurokoDanmakuConfigC {
+    currentDanmakuConfig
+  }
+
+  private func refreshDanmakuConfigSnapshot() {
+    guard let getConfig = library.getDanmakuConfig else {
+      return
+    }
+    var config = KurokoDanmakuConfigC()
+    let status = withUnsafeMutablePointer(to: &config) { pointer in
+      getConfig(handle, UnsafeMutableRawPointer(pointer))
+    }
+    if status == 0 {
+      currentDanmakuConfig = config
+    }
   }
 
   func setDanmakuConfig(_ config: KurokoDanmakuConfigC) throws {
@@ -553,6 +587,7 @@ private final class KurokoPlayerHost {
       setConfig(handle, UnsafeRawPointer(pointer))
     }
     try check(status, operation: "set_danmaku_config")
+    currentDanmakuConfig = config
   }
 
   func setDanmakuFont(family: String?, filePath: String?) throws {
@@ -567,6 +602,7 @@ private final class KurokoPlayerHost {
       }
     }
     try check(status, operation: "set_danmaku_font")
+    refreshDanmakuConfigSnapshot()
   }
 
   func setDanmakuBlockWordsJson(_ json: String) throws {
@@ -576,6 +612,7 @@ private final class KurokoPlayerHost {
     try json.withCString { cString in
       try check(setBlockWords(handle, cString), operation: "set_danmaku_block_words")
     }
+    refreshDanmakuConfigSnapshot()
   }
 
   func selectAudioTrack(trackId: Int64?) throws {
@@ -1135,6 +1172,14 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         }
         try host.setPlaybackRate(rate)
         result(nil)
+      case "setVolume":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        guard let volume = doubleValue(args["volume"]) else {
+          throw KurokoPluginError.invalidArguments("volume is required.")
+        }
+        try host.setVolume(volume)
+        result(nil)
       case "addExternalSubtitle":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
@@ -1229,7 +1274,9 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       case "setDanmakuConfig":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
-        try host.setDanmakuConfig(danmakuConfig(from: args))
+        try host.setDanmakuConfig(
+          danmakuConfig(from: args, base: host.danmakuConfigSnapshot())
+        )
         if args.keys.contains("customFontFamily") || args.keys.contains("customFontFilePath") {
           try host.setDanmakuFont(
             family: args["customFontFamily"] as? String,
@@ -1591,8 +1638,11 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     return trackId >= 0 ? trackId : nil
   }
 
-  private func danmakuConfig(from args: [String: Any]) -> KurokoDanmakuConfigC {
-    var config = KurokoDanmakuConfigC()
+  private func danmakuConfig(
+    from args: [String: Any],
+    base: KurokoDanmakuConfigC
+  ) -> KurokoDanmakuConfigC {
+    var config = base
     if let value = boolValue(args["enabled"]) {
       config.enabled = value ? 1 : 0
     }


### PR DESCRIPTION
## Summary
- add presenter/CoreAudio volume control with clamping and PCM gain application
- expose `kuroko_presenter_set_volume` through the C ABI and Flutter macOS plugin
- keep partial danmaku config updates based on the current native config snapshot

## Validation
- `cargo fmt --check`
- `git diff --check`

Full cargo tests were not run here; earlier attempts require the local FFmpeg dependency path to be present in the worktree.