### PR TITLE
Improve native danmaku follow-ups and iOS Metal path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 name = "danmaku_perf_lab"
 version = "0.0.1"
 dependencies = [
+ "cc",
  "kuroko",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "danmaku_perf_lab"
+version = "0.0.1"
+dependencies = [
+ "kuroko",
+]
+
+[[package]]
 name = "danmaku_sync_smoke"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/player_tick",
   "examples/coreaudio_smoke",
   "examples/danmaku_sync_smoke",
+  "examples/danmaku_perf_lab",
   "examples/metal_presenter_check",
   "examples/ffmpeg_videotoolbox",
   "examples/metal_import_videotoolbox",

--- a/crates/kuroko/src/apple.rs
+++ b/crates/kuroko/src/apple.rs
@@ -33,7 +33,8 @@ pub mod coreaudio {
 
     use crate::audio::{
         AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult, AudioReadResult,
-        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats,
+        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats, apply_volume,
+        normalize_volume,
     };
     use crate::ffmpeg::{PcmAudioFrame, PcmFormat, PcmSampleFormat};
 
@@ -199,6 +200,14 @@ pub mod coreaudio {
         fn stop(&mut self) -> crate::audio::Result<()> {
             CoreAudioOutput::stop(self)
                 .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            CoreAudioOutput::set_volume(self, volume);
+        }
+
+        fn volume(&self) -> f32 {
+            CoreAudioOutput::volume(self)
         }
 
         fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {

--- a/crates/kuroko/src/apple.rs
+++ b/crates/kuroko/src/apple.rs
@@ -263,24 +263,6 @@ pub mod coreaudio {
         Ok(())
     }
 
-    fn normalize_volume(volume: f32) -> f32 {
-        if volume.is_finite() {
-            volume.clamp(0.0, 1.0)
-        } else {
-            1.0
-        }
-    }
-
-    fn apply_volume(samples: &mut [f32], volume: f32) {
-        let volume = normalize_volume(volume);
-        if (volume - 1.0).abs() <= f32::EPSILON {
-            return;
-        }
-        for sample in samples {
-            *sample *= volume;
-        }
-    }
-
     fn configure_buffer(buffer: &Arc<Mutex<AudioRingBuffer>>, format: PcmFormat) -> Result<()> {
         let mut buffer = buffer
             .lock()

--- a/crates/kuroko/src/apple.rs
+++ b/crates/kuroko/src/apple.rs
@@ -21,7 +21,10 @@ pub enum AppleDecodeBackend {
 
 #[cfg(target_os = "macos")]
 pub mod coreaudio {
-    use std::sync::{Arc, Mutex};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    };
 
     use coreaudio::audio_unit::audio_format::LinearPcmFlags;
     use coreaudio::audio_unit::render_callback::{self, data};
@@ -68,6 +71,7 @@ pub mod coreaudio {
         state: AudioOutputState,
         audio_unit: Option<AudioUnit>,
         buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
     }
 
     impl CoreAudioOutput {
@@ -76,6 +80,7 @@ pub mod coreaudio {
                 state: AudioOutputState::Stopped,
                 audio_unit: None,
                 buffer: Arc::new(Mutex::new(AudioRingBuffer::new(config.ring_buffer))),
+                volume: Arc::new(AtomicU32::new(1.0f32.to_bits())),
             }
         }
 
@@ -87,10 +92,23 @@ pub mod coreaudio {
                 Scope::Input,
                 Element::Output,
             )?;
-            install_render_callback(&mut audio_unit, Arc::clone(&self.buffer))?;
+            install_render_callback(
+                &mut audio_unit,
+                Arc::clone(&self.buffer),
+                Arc::clone(&self.volume),
+            )?;
             audio_unit.initialize()?;
             self.audio_unit = Some(audio_unit);
             Ok(())
+        }
+
+        pub fn set_volume(&mut self, volume: f32) {
+            self.volume
+                .store(normalize_volume(volume).to_bits(), Ordering::Relaxed);
+        }
+
+        pub fn volume(&self) -> f32 {
+            f32::from_bits(self.volume.load(Ordering::Relaxed))
         }
 
         pub fn start(&mut self) -> Result<()> {
@@ -215,6 +233,7 @@ pub mod coreaudio {
     fn install_render_callback(
         audio_unit: &mut AudioUnit,
         buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
     ) -> Result<()> {
         type Args = render_callback::Args<data::Interleaved<f32>>;
         audio_unit.set_render_callback(move |mut args: Args| {
@@ -222,6 +241,10 @@ pub mod coreaudio {
                 .lock()
                 .map_err(|_| ())
                 .and_then(|mut buffer| buffer.read_interleaved(args.data.buffer).map_err(|_| ()))?;
+            apply_volume(
+                args.data.buffer,
+                f32::from_bits(volume.load(Ordering::Relaxed)),
+            );
             if read_result.underflow_frames > 0 {
                 args.flags
                     .insert(render_callback::ActionFlags::OUTPUT_IS_SILENCE);
@@ -229,6 +252,24 @@ pub mod coreaudio {
             Ok(())
         })?;
         Ok(())
+    }
+
+    fn normalize_volume(volume: f32) -> f32 {
+        if volume.is_finite() {
+            volume.clamp(0.0, 1.0)
+        } else {
+            1.0
+        }
+    }
+
+    fn apply_volume(samples: &mut [f32], volume: f32) {
+        let volume = normalize_volume(volume);
+        if (volume - 1.0).abs() <= f32::EPSILON {
+            return;
+        }
+        for sample in samples {
+            *sample *= volume;
+        }
     }
 
     fn configure_buffer(buffer: &Arc<Mutex<AudioRingBuffer>>, format: PcmFormat) -> Result<()> {
@@ -244,5 +285,27 @@ pub mod coreaudio {
             .map_err(|_| CoreAudioOutputError::LockPoisoned)?;
         buffer.clear();
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn volume_is_clamped_and_applied_to_pcm_samples() {
+            let mut output = CoreAudioOutput::default();
+
+            assert_eq!(output.volume(), 1.0);
+            output.set_volume(0.25);
+            assert_eq!(output.volume(), 0.25);
+            output.set_volume(-1.0);
+            assert_eq!(output.volume(), 0.0);
+            output.set_volume(f32::NAN);
+            assert_eq!(output.volume(), 1.0);
+
+            let mut samples = [1.0, -0.5, 0.25, 0.0];
+            apply_volume(&mut samples, 0.5);
+            assert_eq!(samples, [0.5, -0.25, 0.125, 0.0]);
+        }
     }
 }

--- a/crates/kuroko/src/audio.rs
+++ b/crates/kuroko/src/audio.rs
@@ -323,6 +323,8 @@ pub trait AudioOutputBackend {
     fn start(&mut self) -> Result<()>;
     fn pause(&mut self) -> Result<()>;
     fn stop(&mut self) -> Result<()>;
+    fn set_volume(&mut self, volume: f32);
+    fn volume(&self) -> f32;
     fn push(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult>;
     fn state(&self) -> AudioOutputState;
     fn stats(&self) -> AudioRingBufferStats;
@@ -335,6 +337,7 @@ pub trait AudioOutputBackend {
 pub struct BufferedAudioOutput {
     state: AudioOutputState,
     buffer: AudioRingBuffer,
+    volume: f32,
 }
 
 impl BufferedAudioOutput {
@@ -342,6 +345,7 @@ impl BufferedAudioOutput {
         Self {
             state: AudioOutputState::Stopped,
             buffer: AudioRingBuffer::new(config),
+            volume: 1.0,
         }
     }
 
@@ -354,7 +358,9 @@ impl BufferedAudioOutput {
     }
 
     pub fn read_interleaved(&mut self, output: &mut [f32]) -> Result<AudioReadResult> {
-        self.buffer.read_interleaved(output)
+        let result = self.buffer.read_interleaved(output)?;
+        apply_volume(output, self.volume);
+        Ok(result)
     }
 
     pub fn clock_snapshot(&self) -> AudioClockSnapshot {
@@ -383,6 +389,14 @@ impl AudioOutputBackend for BufferedAudioOutput {
         Ok(())
     }
 
+    fn set_volume(&mut self, volume: f32) {
+        self.volume = normalize_volume(volume);
+    }
+
+    fn volume(&self) -> f32 {
+        self.volume
+    }
+
     fn push(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult> {
         self.buffer.push_frame(frame)
     }
@@ -397,6 +411,24 @@ impl AudioOutputBackend for BufferedAudioOutput {
 
     fn clock_snapshot(&self) -> Option<AudioClockSnapshot> {
         Some(self.buffer.clock_snapshot())
+    }
+}
+
+pub fn normalize_volume(volume: f32) -> f32 {
+    if volume.is_finite() {
+        volume.clamp(0.0, 1.0)
+    } else {
+        1.0
+    }
+}
+
+pub fn apply_volume(samples: &mut [f32], volume: f32) {
+    let volume = normalize_volume(volume);
+    if (volume - 1.0).abs() <= f32::EPSILON {
+        return;
+    }
+    for sample in samples {
+        *sample *= volume;
     }
 }
 
@@ -491,6 +523,31 @@ mod tests {
         assert_eq!(output.state(), AudioOutputState::Paused);
         output.stop().unwrap();
         assert_eq!(output.state(), AudioOutputState::Stopped);
+    }
+
+    #[test]
+    fn volume_helpers_clamp_and_apply_gain() {
+        assert_eq!(normalize_volume(1.0), 1.0);
+        assert_eq!(normalize_volume(-1.0), 0.0);
+        assert_eq!(normalize_volume(2.0), 1.0);
+        assert_eq!(normalize_volume(f32::NAN), 1.0);
+
+        let mut samples = [1.0, -0.5, 0.25, 0.0];
+        apply_volume(&mut samples, 0.5);
+        assert_eq!(samples, [0.5, -0.25, 0.125, 0.0]);
+    }
+
+    #[test]
+    fn buffered_audio_output_volume_is_clamped() {
+        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
+
+        assert_eq!(output.volume(), 1.0);
+        output.set_volume(0.25);
+        assert_eq!(output.volume(), 0.25);
+        output.set_volume(-1.0);
+        assert_eq!(output.volume(), 0.0);
+        output.set_volume(f32::NAN);
+        assert_eq!(output.volume(), 1.0);
     }
 
     #[test]

--- a/crates/kuroko/src/core.rs
+++ b/crates/kuroko/src/core.rs
@@ -413,6 +413,31 @@ pub trait RendererBackend {
     /// surface. Returns `false` if there is no current frame to draw, letting the
     /// caller fall back to a test frame.
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool>;
+
+    fn runtime_stats(&self) -> RendererRuntimeStats {
+        RendererRuntimeStats::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RendererRuntimeStats {
+    pub surface_width: u32,
+    pub surface_height: u32,
+    pub rendered_frames: u64,
+    pub offscreen_frames: u64,
+    pub prepared_overlay_frames: u64,
+    pub prepared_overlay_subtitle_planes: u64,
+    pub danmaku_passes: u64,
+    pub danmaku_draw_items: u64,
+    pub overlay_alpha_atlas_uploads: u64,
+    pub overlay_alpha_atlas_reuses: u64,
+    pub last_danmaku_atlas_duration: Duration,
+    pub last_danmaku_vertex_build_duration: Duration,
+    pub last_danmaku_vertex_copy_duration: Duration,
+    pub last_danmaku_encode_duration: Duration,
+    pub last_danmaku_vertex_bytes: usize,
+    pub last_danmaku_vertex_count: usize,
+    pub attached: bool,
 }
 
 struct PlayerInner {

--- a/crates/kuroko/src/danmaku.rs
+++ b/crates/kuroko/src/danmaku.rs
@@ -1583,6 +1583,9 @@ impl DfmLayoutEngine {
 
     pub fn set_config(&mut self, config: DanmakuLayoutConfig) {
         let config = config.sanitized();
+        if self.config == config {
+            return;
+        }
         let font_changed = self.config.custom_font_family != config.custom_font_family
             || self.config.custom_font_file_path != config.custom_font_file_path;
         self.config = config;

--- a/crates/kuroko/src/danmaku.rs
+++ b/crates/kuroko/src/danmaku.rs
@@ -1581,10 +1581,10 @@ impl DfmLayoutEngine {
         self.prepared = None;
     }
 
-    pub fn set_config(&mut self, config: DanmakuLayoutConfig) {
+    pub fn set_config(&mut self, config: DanmakuLayoutConfig) -> bool {
         let config = config.sanitized();
         if self.config == config {
-            return;
+            return false;
         }
         let font_changed = self.config.custom_font_family != config.custom_font_family
             || self.config.custom_font_file_path != config.custom_font_file_path;
@@ -1593,6 +1593,7 @@ impl DfmLayoutEngine {
             self.rasterizer = DanmakuTextRasterizer::for_config(&self.config);
         }
         self.prepared = None;
+        true
     }
 
     pub fn config(&self) -> &DanmakuLayoutConfig {

--- a/crates/kuroko/src/danmaku.rs
+++ b/crates/kuroko/src/danmaku.rs
@@ -7,7 +7,7 @@
 mod dfm;
 pub mod dfm_core;
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -31,6 +31,7 @@ const GLYPH_ATLAS_INITIAL_HEIGHT: u32 = 256;
 const DEFAULT_DANMAKU_TRACK_ID: u64 = 1;
 const TRACK_ID_SHIFT: u64 = 48;
 const ITEM_ID_MASK: u64 = (1u64 << TRACK_ID_SHIFT) - 1;
+pub const DANMAKU_DEBUG_BUCKETS: usize = 16;
 
 #[derive(Debug, Error)]
 pub enum DanmakuError {
@@ -710,6 +711,7 @@ pub struct DfmPreparedLayout {
     viewport: DanmakuViewport,
     config: DanmakuLayoutConfig,
     dfm_layout: dfm::PreparedLayout,
+    stats: DanmakuPreparedStats,
     scroll_duration: Duration,
     static_duration: Duration,
     item_times: Vec<f64>,
@@ -719,6 +721,10 @@ pub struct DfmPreparedLayout {
 impl DfmPreparedLayout {
     pub fn items(&self) -> &[PreparedDanmakuItem] {
         &self.items
+    }
+
+    pub fn stats(&self) -> DanmakuPreparedStats {
+        self.stats
     }
 
     pub fn frame_layout(&self, media_time: Duration, generation: u64) -> DanmakuFrameLayout {
@@ -739,6 +745,7 @@ impl DfmPreparedLayout {
                 item_id: item.id,
                 text: Arc::clone(&item.text),
                 mode: item.mode,
+                track_index: frame_item.track_index.max(0) as usize,
                 x: frame_item.x as f32,
                 y: frame_item.y as f32,
                 width: item.width,
@@ -757,6 +764,7 @@ impl DfmPreparedLayout {
             media_time,
             generation,
             viewport: self.viewport,
+            prepared_stats: self.stats,
             items,
         }
     }
@@ -767,6 +775,7 @@ pub struct DanmakuFrameLayout {
     pub media_time: Duration,
     pub generation: u64,
     pub viewport: DanmakuViewport,
+    pub prepared_stats: DanmakuPreparedStats,
     pub items: Vec<DanmakuPlacedItem>,
 }
 
@@ -776,6 +785,7 @@ impl DanmakuFrameLayout {
             media_time,
             generation,
             viewport,
+            prepared_stats: DanmakuPreparedStats::default(),
             items: Vec::new(),
         }
     }
@@ -786,6 +796,7 @@ pub struct DanmakuPlacedItem {
     pub item_id: u64,
     pub text: Arc<str>,
     pub mode: DanmakuMode,
+    pub track_index: usize,
     pub x: f32,
     pub y: f32,
     pub width: f32,
@@ -807,6 +818,7 @@ pub struct DanmakuRenderPlan {
     pub viewport: DanmakuViewport,
     pub atlas: Option<Arc<DanmakuGlyphAtlas>>,
     pub items: Vec<DanmakuGlyphInstance>,
+    pub frame_stats: DanmakuFrameStats,
 }
 
 impl DanmakuRenderPlan {
@@ -817,12 +829,166 @@ impl DanmakuRenderPlan {
             viewport,
             atlas: None,
             items: Vec::new(),
+            frame_stats: DanmakuFrameStats::default(),
         }
     }
 
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct DanmakuFrameStats {
+    pub prepared: DanmakuPreparedStats,
+    pub placed_items: usize,
+    pub scroll_items: usize,
+    pub top_items: usize,
+    pub bottom_items: usize,
+    pub scroll_rows: usize,
+    pub scroll_track_min: usize,
+    pub scroll_track_max: usize,
+    pub scroll_min_y: f32,
+    pub scroll_max_y: f32,
+    pub scroll_bucket_count: usize,
+    pub scroll_buckets: [DanmakuDebugBucket; DANMAKU_DEBUG_BUCKETS],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DanmakuDebugBucket {
+    pub key: i32,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct DanmakuPreparedStats {
+    pub source_items: usize,
+    pub supported_items: usize,
+    pub prepared_items: usize,
+    pub filtered_items: usize,
+    pub prepared_scroll_items: usize,
+    pub prepared_top_items: usize,
+    pub prepared_bottom_items: usize,
+    pub prepared_scroll_rows: usize,
+    pub prepared_scroll_min_y: f32,
+    pub prepared_scroll_max_y: f32,
+    pub expected_scroll_tracks: usize,
+    pub dfm_track_count: usize,
+    pub display_area_height: f32,
+    pub scroll_area_height: f32,
+    pub track_height: f32,
+    pub scroll_bucket_count: usize,
+    pub scroll_buckets: [DanmakuDebugBucket; DANMAKU_DEBUG_BUCKETS],
+}
+
+impl DanmakuFrameStats {
+    fn from_layout(layout: &DanmakuFrameLayout) -> Self {
+        let mut stats = Self::default();
+        stats.prepared = layout.prepared_stats;
+        let mut scroll_rows = BTreeSet::new();
+        let mut scroll_track_min = usize::MAX;
+        let mut scroll_track_max = 0usize;
+        let mut bucket_counts = BTreeMap::<i32, u32>::new();
+        let mut scroll_min_y = f32::MAX;
+        let mut scroll_max_y = f32::MIN;
+        for item in &layout.items {
+            stats.placed_items += 1;
+            match item.mode {
+                DanmakuMode::Scroll | DanmakuMode::ScrollReverse => {
+                    stats.scroll_items += 1;
+                    let row_key = item.y.round() as i32;
+                    scroll_rows.insert(row_key);
+                    *bucket_counts.entry(row_key).or_default() += 1;
+                    scroll_track_min = scroll_track_min.min(item.track_index);
+                    scroll_track_max = scroll_track_max.max(item.track_index);
+                    scroll_min_y = scroll_min_y.min(item.y);
+                    scroll_max_y = scroll_max_y.max(item.y + item.height);
+                }
+                DanmakuMode::Top => stats.top_items += 1,
+                DanmakuMode::Bottom => stats.bottom_items += 1,
+                DanmakuMode::Special => {}
+            }
+        }
+        stats.scroll_rows = scroll_rows.len();
+        if stats.scroll_items > 0 {
+            stats.scroll_track_min = scroll_track_min;
+            stats.scroll_track_max = scroll_track_max;
+            stats.scroll_min_y = scroll_min_y;
+            stats.scroll_max_y = scroll_max_y;
+        }
+        stats.scroll_bucket_count = fill_debug_buckets(&bucket_counts, &mut stats.scroll_buckets);
+        stats
+    }
+}
+
+impl DanmakuPreparedStats {
+    fn from_items(
+        source_items: usize,
+        supported_items: usize,
+        prepared: &[PreparedDanmakuItem],
+        viewport: DanmakuViewport,
+        config: &DanmakuLayoutConfig,
+        dfm_track_count: usize,
+    ) -> Self {
+        let mut stats = Self {
+            source_items,
+            supported_items,
+            prepared_items: prepared.len(),
+            filtered_items: supported_items.saturating_sub(prepared.len()),
+            dfm_track_count,
+            display_area_height: viewport.height as f32 * config.display_area.clamp(0.1, 1.0),
+            scroll_area_height: viewport.height as f32 * config.display_area.clamp(0.1, 1.0),
+            ..Self::default()
+        };
+        let mut scroll_rows = BTreeSet::new();
+        let mut bucket_counts = BTreeMap::<i32, u32>::new();
+        let mut scroll_min_y = f32::MAX;
+        let mut scroll_max_y = f32::MIN;
+        let mut first_scroll_height = 0.0f32;
+        for item in prepared {
+            match item.mode {
+                DanmakuMode::Scroll | DanmakuMode::ScrollReverse => {
+                    stats.prepared_scroll_items += 1;
+                    let row_key = item.y.round() as i32;
+                    scroll_rows.insert(row_key);
+                    *bucket_counts.entry(row_key).or_default() += 1;
+                    scroll_min_y = scroll_min_y.min(item.y);
+                    scroll_max_y = scroll_max_y.max(item.y + item.height);
+                    if first_scroll_height <= 0.0 {
+                        first_scroll_height = item.height;
+                    }
+                }
+                DanmakuMode::Top => stats.prepared_top_items += 1,
+                DanmakuMode::Bottom => stats.prepared_bottom_items += 1,
+                DanmakuMode::Special => {}
+            }
+        }
+        stats.prepared_scroll_rows = scroll_rows.len();
+        if stats.prepared_scroll_items > 0 {
+            stats.prepared_scroll_min_y = scroll_min_y;
+            stats.prepared_scroll_max_y = scroll_max_y;
+        }
+        let track_height =
+            (first_scroll_height + first_scroll_height * config.track_gap_ratio).max(1.0);
+        stats.track_height = track_height;
+        stats.expected_scroll_tracks =
+            (stats.scroll_area_height / track_height).floor().max(1.0) as usize;
+        stats.scroll_bucket_count = fill_debug_buckets(&bucket_counts, &mut stats.scroll_buckets);
+        stats
+    }
+}
+
+fn fill_debug_buckets(
+    source: &BTreeMap<i32, u32>,
+    target: &mut [DanmakuDebugBucket; DANMAKU_DEBUG_BUCKETS],
+) -> usize {
+    for bucket in target.iter_mut() {
+        *bucket = DanmakuDebugBucket::default();
+    }
+    for (slot, (&key, &count)) in target.iter_mut().zip(source.iter()) {
+        *slot = DanmakuDebugBucket { key, count };
+    }
+    source.len()
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -869,6 +1035,7 @@ struct PreparedTextLayout {
 #[derive(Debug, Clone, PartialEq)]
 struct PreparedGlyphPlacement {
     glyph: Arc<RasterizedGlyph>,
+    packed: PackedGlyph,
     pen_x: f32,
 }
 
@@ -1194,14 +1361,30 @@ impl DanmakuTextRasterizer {
                 outline_width,
             );
             let glyph = self.cached_glyph_by_key(glyph_key);
+            let packed = if glyph.has_bitmap() {
+                self.pack_glyph(&glyph)
+            } else {
+                PackedGlyph::default()
+            };
             let advance = glyph.advance;
-            glyphs.push(PreparedGlyphPlacement { glyph, pen_x });
+            glyphs.push(PreparedGlyphPlacement {
+                glyph,
+                packed,
+                pen_x,
+            });
             pen_x += advance;
             previous = face
                 .as_ref()
                 .and_then(|face| glyph_id.map(|glyph_id| (face.id, glyph_id)));
         }
         PreparedTextLayout { metrics, glyphs }
+    }
+
+    fn pack_glyph(&self, glyph: &RasterizedGlyph) -> PackedGlyph {
+        self.glyph_atlas
+            .lock()
+            .expect("danmaku glyph atlas lock")
+            .pack(glyph)
     }
 
     fn resolve_font(&self, ch: char) -> Option<DanmakuFontFace> {
@@ -1217,46 +1400,40 @@ impl DanmakuTextRasterizer {
     }
 
     pub fn render_plan(&self, layout: &DanmakuFrameLayout) -> DanmakuRenderPlan {
+        let frame_stats = DanmakuFrameStats::from_layout(layout);
         if layout.items.is_empty() {
             return DanmakuRenderPlan::empty(layout.media_time, layout.generation, layout.viewport);
         }
-        let mut atlas = self.glyph_atlas.lock().expect("danmaku glyph atlas lock");
-        let mut pending = Vec::new();
+        let Some(atlas_snapshot) = self
+            .glyph_atlas
+            .lock()
+            .expect("danmaku glyph atlas lock")
+            .snapshot()
+        else {
+            return DanmakuRenderPlan::empty(layout.media_time, layout.generation, layout.viewport);
+        };
+        let atlas_w = atlas_snapshot.width.max(1) as f32;
+        let atlas_h = atlas_snapshot.height.max(1) as f32;
+        let capacity = layout
+            .items
+            .iter()
+            .map(|item| item.text_layout.glyphs.len())
+            .sum();
+        let mut items = Vec::with_capacity(capacity);
         for item in &layout.items {
             let color = item.color.rgba(item.opacity);
             if color[3] <= 0.0 {
                 continue;
             }
-            self.append_item_glyphs(item, color, &mut atlas, &mut pending);
+            self.append_item_glyphs(item, color, atlas_w, atlas_h, &mut items);
         }
-        let Some(atlas_snapshot) = atlas.snapshot() else {
-            return DanmakuRenderPlan::empty(layout.media_time, layout.generation, layout.viewport);
-        };
-        let atlas_w = atlas_snapshot.width.max(1) as f32;
-        let atlas_h = atlas_snapshot.height.max(1) as f32;
-        let items = pending
-            .into_iter()
-            .map(|item| DanmakuGlyphInstance {
-                item_id: item.item_id,
-                rect: item.rect,
-                tex_rect: [
-                    item.tex_rect[0] as f32 / atlas_w,
-                    item.tex_rect[1] as f32 / atlas_h,
-                    item.tex_rect[2] as f32 / atlas_w,
-                    item.tex_rect[3] as f32 / atlas_h,
-                ],
-                color_rgba: item.color_rgba,
-                outline_rgba: item.outline_rgba,
-                shadow_rgba: item.shadow_rgba,
-                shadow_offset: item.shadow_offset,
-            })
-            .collect();
         DanmakuRenderPlan {
             media_time: layout.media_time,
             generation: layout.generation,
             viewport: layout.viewport,
             atlas: Some(atlas_snapshot),
             items,
+            frame_stats,
         }
     }
 
@@ -1264,15 +1441,16 @@ impl DanmakuTextRasterizer {
         &self,
         item: &DanmakuPlacedItem,
         color: [f32; 4],
-        atlas: &mut PersistentGlyphAtlas,
-        pending: &mut Vec<PendingGlyphInstance>,
+        atlas_w: f32,
+        atlas_h: f32,
+        items: &mut Vec<DanmakuGlyphInstance>,
     ) {
         let baseline = item.y + item.text_layout.metrics.ascent;
         for placement in &item.text_layout.glyphs {
             let glyph = &placement.glyph;
             if glyph.has_bitmap() {
-                let packed = atlas.pack(&glyph);
-                pending.push(PendingGlyphInstance {
+                let packed = placement.packed;
+                items.push(DanmakuGlyphInstance {
                     item_id: item.item_id,
                     rect: [
                         item.x + placement.pen_x + glyph.offset_x,
@@ -1280,7 +1458,12 @@ impl DanmakuTextRasterizer {
                         glyph.width as f32,
                         glyph.height as f32,
                     ],
-                    tex_rect: [packed.x, packed.y, packed.width, packed.height],
+                    tex_rect: [
+                        packed.x as f32 / atlas_w,
+                        packed.y as f32 / atlas_h,
+                        packed.width as f32 / atlas_w,
+                        packed.height as f32 / atlas_h,
+                    ],
                     color_rgba: color,
                     outline_rgba: [0.0, 0.0, 0.0, color[3].min(0.75)],
                     shadow_rgba: [0.0, 0.0, 0.0, (color[3] * item.shadow_alpha).min(1.0)],
@@ -1343,17 +1526,6 @@ impl DanmakuTextRasterizer {
         }
         rasterize_fallback_glyph(&self.shaper, key)
     }
-}
-
-#[derive(Debug, Clone)]
-struct PendingGlyphInstance {
-    item_id: u64,
-    rect: [f32; 4],
-    tex_rect: [u32; 4],
-    color_rgba: [f32; 4],
-    outline_rgba: [f32; 4],
-    shadow_rgba: [f32; 4],
-    shadow_offset: [f32; 2],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1425,7 +1597,7 @@ impl RasterizedGlyph {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct PackedGlyph {
     x: u32,
     y: u32,
@@ -1657,6 +1829,7 @@ fn prepare_layout(
             viewport,
             config: config.clone(),
             dfm_layout,
+            stats: DanmakuPreparedStats::default(),
             scroll_duration: DEFAULT_SCROLL_DURATION,
             static_duration: DEFAULT_STATIC_DURATION,
             item_times: Vec::new(),
@@ -1665,6 +1838,7 @@ fn prepare_layout(
     }
     let scroll_duration = compute_scroll_duration(config);
     let base_font_size = effective_config_font_size(config.font_size, viewport.scale_factor);
+    let source_count = timeline.items().len();
     let mut source_items = Vec::new();
     for source in timeline.items() {
         if source.mode == DanmakuMode::Special {
@@ -1686,6 +1860,7 @@ fn prepare_layout(
             paint_height: measure.height.max(font_size * 1.2) as f64,
         });
     }
+    let supported_count = source_items.len();
 
     let dfm_layout = dfm::prepare_layout(dfm::PrepareRequest {
         items: source_items,
@@ -1695,6 +1870,7 @@ fn prepare_layout(
         display_area: config.display_area as f64,
         scroll_duration_seconds: scroll_duration.as_secs_f64(),
         allow_stacking: config.allow_stacking,
+        allow_scroll_overwrite: config.allow_scroll_overwrite,
         merge_danmaku: config.merge_duplicates,
         max_quantity: config.max_quantity,
         max_lines_per_type: config.max_lines_per_mode,
@@ -1753,10 +1929,19 @@ fn prepare_layout(
         .iter()
         .map(|item| item.time.as_secs_f64())
         .collect();
+    let stats = DanmakuPreparedStats::from_items(
+        source_count,
+        supported_count,
+        &prepared,
+        viewport,
+        config,
+        dfm_layout.track_count.max(0) as usize,
+    );
     DfmPreparedLayout {
         viewport,
         config: config.clone(),
         dfm_layout,
+        stats,
         scroll_duration,
         static_duration: DEFAULT_STATIC_DURATION,
         item_times,
@@ -2349,7 +2534,7 @@ mod tests {
     }
 
     #[test]
-    fn default_scroll_layout_matches_nipaplay_scroll_display_cap() {
+    fn default_scroll_layout_uses_full_display_area_when_configured() {
         let timeline = DanmakuTimeline::new(
             (0..18)
                 .map(|index| item(1.0, &format!("line {index}"), DanmakuMode::Scroll))
@@ -2371,8 +2556,12 @@ mod tests {
             .fold(0.0, f32::max);
 
         assert!(
-            max_y < 270.0,
-            "NipaPlay DFM+ caps scroll rows away from the lower viewport, got max y {max_y}"
+            max_y > 270.0,
+            "display_area=1.0 should allow scroll rows into the lower viewport, got max y {max_y}"
+        );
+        assert!(
+            max_y < 360.0,
+            "scroll rows should still stay inside the viewport, got max y {max_y}"
         );
     }
 

--- a/crates/kuroko/src/danmaku/dfm.rs
+++ b/crates/kuroko/src/danmaku/dfm.rs
@@ -39,6 +39,7 @@ pub struct PrepareRequest {
     pub display_area: f64,
     pub scroll_duration_seconds: f64,
     pub allow_stacking: bool,
+    pub allow_scroll_overwrite: bool,
     pub merge_danmaku: bool,
     pub max_quantity: Option<u32>,
     pub max_lines_per_type: Option<u32>,
@@ -93,6 +94,7 @@ pub struct FrameLayout {
 #[derive(Debug, Clone, PartialEq)]
 pub struct FrameItem {
     pub item_index: usize,
+    pub track_index: i32,
     pub x: f64,
     pub y: f64,
     pub offstage_x: f64,
@@ -103,7 +105,6 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
     let height = request.height.max(1.0) as f32;
     let font_size = request.font_size.max(1.0) as f32;
     let display_area = request.display_area.clamp(0.1, 1.0) as f32;
-    let _allow_stacking = request.allow_stacking;
     let scroll_dur_secs = request.scroll_duration_seconds.max(1.0);
     let scroll_dur_ms = (scroll_dur_secs * 1000.0) as i64;
     let global_flags = GlobalFlags::default();
@@ -221,15 +222,19 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
     for (type_idx, _) in type_order.iter().enumerate() {
         for &i in &type_indices[type_idx] {
             let is_me = items[i].1;
-            let (placed, displaced_index) = retainer.fix(
+            let (placed, displaced_index) = retainer.fix_with_options(
                 &mut items[i].4,
                 width,
                 height,
                 &global_flags,
                 display_area,
                 is_me,
+                request.allow_stacking,
+                request.allow_scroll_overwrite,
             );
             if !placed {
+                items[i].4.is_filtered = true;
+                items[i].4.filter_param = 99;
                 continue;
             }
             if exceeds_max_line(
@@ -276,7 +281,7 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
             font_size_multiplier: 1.0,
             count_text: None,
             duplicate_count: *duplicate_count,
-            track_index: 0,
+            track_index: track_index_from_y(item.y, item.paint_height, track_gap_ratio),
             y_position: item.y as f64,
             width: item.paint_width as f64,
             height: item.paint_height as f64,
@@ -303,6 +308,14 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
         item_times,
         track_count: ((height * display_area) / (font_size * 1.2 * 1.25)).max(1.0) as i32,
     })
+}
+
+fn track_index_from_y(y: f32, height: f32, track_gap_ratio: f32) -> i32 {
+    if !y.is_finite() || y < 0.0 {
+        return 0;
+    }
+    let track_height = (height + height * track_gap_ratio).max(1.0);
+    ((y - 2.0).max(0.0) / track_height).round().max(0.0) as i32
 }
 
 pub fn layout_frame(layout: &PreparedLayout, current_time: f64) -> FrameLayout {
@@ -342,6 +355,7 @@ pub fn layout_frame(layout: &PreparedLayout, current_time: f64) -> FrameLayout {
         }
         frame_items.push(FrameItem {
             item_index: i,
+            track_index: item.track_index,
             x,
             y: item.y_position,
             offstage_x,

--- a/crates/kuroko/src/danmaku/dfm_core/retainer.rs
+++ b/crates/kuroko/src/danmaku/dfm_core/retainer.rs
@@ -123,25 +123,34 @@ impl DanmakuRetainer {
         display_area: f32,
         is_me: bool,
     ) -> (bool, DisplacedIndices) {
-        // Scroll danmaku is capped at 75% of the display area to prevent
-        // blocking subtitles at the bottom of the screen.
-        // Fixed danmaku can use the full display area.
+        self.fix_with_options(
+            item,
+            view_width,
+            view_height,
+            flags,
+            display_area,
+            is_me,
+            false,
+            true,
+        )
+    }
+
+    pub fn fix_with_options(
+        &mut self,
+        item: &mut DanmakuItem,
+        view_width: f32,
+        view_height: f32,
+        flags: &GlobalFlags,
+        display_area: f32,
+        is_me: bool,
+        allow_stacking: bool,
+        allow_scroll_overwrite: bool,
+    ) -> (bool, DisplacedIndices) {
         // Each type has independent track systems (r2l_tracks, top_tracks, etc.).
-        let capped_display = if item.danmaku_type.is_scroll() {
-            display_area.min(0.75)
-        } else {
-            display_area
-        };
-        let effective_height = view_height * capped_display;
+        // Respect display_area exactly; display_area=1.0 means full-screen danmaku.
+        let effective_height = view_height * display_area;
         let track_height = item.paint_height + item.paint_height * self.track_gap_ratio;
-        let mut track_count = (effective_height / track_height).floor().max(1.0) as usize;
-        // Reserve one track at the bottom for screen-edge padding when using full display area.
-        // Check against the original display_area so scroll danmaku also benefits when
-        // the user sets display_area to 1.0 (capped_display would be 0.75 which would
-        // skip this check).
-        if (display_area - 1.0).abs() < 0.001 && track_count > 1 {
-            track_count -= 1;
-        }
+        let track_count = (effective_height / track_height).floor().max(1.0) as usize;
         let danmaku_index = item.index as usize;
 
         let entry = TrackEntry::from_item(item, danmaku_index);
@@ -155,6 +164,8 @@ impl DanmakuRetainer {
                     track_count,
                     view_width,
                     is_me,
+                    allow_stacking,
+                    allow_scroll_overwrite,
                 ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
@@ -173,6 +184,8 @@ impl DanmakuRetainer {
                     track_count,
                     view_width,
                     is_me,
+                    allow_stacking,
+                    allow_scroll_overwrite,
                 ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
@@ -233,8 +246,16 @@ fn select_scroll_track(
     track_count: usize,
     view_width: f32,
     is_me: bool,
+    allow_stacking: bool,
+    allow_scroll_overwrite: bool,
 ) -> Option<(usize, DisplacedIndices)> {
     track_data.compact(new_entry.time_ms, new_entry.duration_ms);
+
+    if allow_stacking && track_count > 0 {
+        let row = stack_track_for(new_entry, track_count);
+        track_data.tracks[row].push(new_entry.clone());
+        return Some((row, SmallVec::new()));
+    }
 
     let overwrite_count = ((track_count as f32 * 0.6).ceil() as usize)
         .max(1)
@@ -280,6 +301,10 @@ fn select_scroll_track(
         return Some((0, displaced));
     }
 
+    if !allow_scroll_overwrite {
+        return None;
+    }
+
     if min_right_edge < f32::MAX {
         let displaced: DisplacedIndices = track_data.tracks[best_track]
             .iter()
@@ -291,6 +316,13 @@ fn select_scroll_track(
     }
 
     None
+}
+
+fn stack_track_for(entry: &TrackEntry, track_count: usize) -> usize {
+    let mut value = entry.danmaku_index.wrapping_mul(1_103_515_245usize);
+    value ^= (entry.time_ms.max(0) as usize).rotate_left(11);
+    value ^= (entry.paint_width.to_bits() as usize).rotate_left(5);
+    value % track_count.max(1)
 }
 
 fn entry_right_edge_at(entry: &TrackEntry, time_ms: i64, view_width: f32) -> f32 {

--- a/crates/kuroko/src/playback.rs
+++ b/crates/kuroko/src/playback.rs
@@ -53,14 +53,14 @@ impl VideoDecodePreference {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 impl Default for VideoDecodePreference {
     fn default() -> Self {
         Self::VideoToolbox
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 impl Default for VideoDecodePreference {
     fn default() -> Self {
         Self::Software

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -2,8 +2,11 @@ use std::{env, fs::OpenOptions, io::Write, path::PathBuf, time::Duration};
 
 use crossbeam_channel::Receiver;
 
+#[cfg(target_os = "macos")]
 use crate::apple::coreaudio::{CoreAudioOutput, CoreAudioOutputConfig};
-use crate::audio::AudioClockSnapshot;
+#[cfg(not(target_os = "macos"))]
+use crate::audio::BufferedAudioOutput;
+use crate::audio::{AudioClockSnapshot, AudioOutputBackend, AudioRingBufferConfig};
 use crate::core::{
     MediaRequest, PlatformSurface, Player, PlayerAudioFrame, PlayerConfig, PlayerSubtitleFrame,
     PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererBackendPreference, TrackInfo,
@@ -33,18 +36,44 @@ const AUDIO_START_BUFFER: Duration = Duration::from_millis(50);
 #[derive(Debug, Clone)]
 pub struct PresenterConfig {
     pub player: PlayerConfig,
-    pub audio: CoreAudioOutputConfig,
+    pub audio: PresenterAudioConfig,
     pub renderer: MetalRendererConfig,
     pub overlay: OverlayTimeline,
     pub danmaku: Option<DanmakuTimeline>,
     pub danmaku_config: DanmakuLayoutConfig,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PresenterAudioConfig {
+    pub ring_buffer: AudioRingBufferConfig,
+}
+
+impl Default for PresenterAudioConfig {
+    fn default() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            let config = CoreAudioOutputConfig::default();
+            Self {
+                ring_buffer: config.ring_buffer,
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self {
+                ring_buffer: AudioRingBufferConfig {
+                    capacity_frames: 96_000,
+                    drop_oldest_on_overflow: true,
+                },
+            }
+        }
+    }
+}
+
 impl Default for PresenterConfig {
     fn default() -> Self {
         Self {
             player: PlayerConfig::default(),
-            audio: CoreAudioOutputConfig::default(),
+            audio: PresenterAudioConfig::default(),
             renderer: MetalRendererConfig::default(),
             overlay: OverlayTimeline::default(),
             danmaku: None,
@@ -74,7 +103,7 @@ pub struct PresenterRuntime {
     video_frames: Receiver<PlayerVideoFrame>,
     audio_frames: Receiver<PlayerAudioFrame>,
     subtitle_frames: Receiver<PlayerSubtitleFrame>,
-    audio_output: CoreAudioOutput,
+    audio_output: Box<dyn AudioOutputBackend>,
     audio_configured: bool,
     audio_started: bool,
     last_audio_clock_sync: Option<AudioClockSyncState>,
@@ -173,7 +202,7 @@ impl PresenterRuntime {
             video_frames,
             audio_frames,
             subtitle_frames,
-            audio_output: CoreAudioOutput::new(config.audio),
+            audio_output: build_audio_output(config.audio),
             audio_configured: false,
             audio_started: false,
             last_audio_clock_sync: None,
@@ -241,7 +270,7 @@ impl PresenterRuntime {
         let result = self.player.pause();
         if let Err(error) = self.audio_output.pause() {
             self.stats.audio_failures += 1;
-            eprintln!("Kuroko presenter CoreAudio pause failed: {error}");
+            eprintln!("Kuroko presenter audio pause failed: {error}");
         }
         self.audio_started = false;
         self.last_audio_clock_sync = None;
@@ -777,7 +806,7 @@ impl PresenterRuntime {
     }
 
     fn sync_player_to_audio_output(&mut self) {
-        let Ok(snapshot) = self.audio_output.clock_snapshot() else {
+        let Some(snapshot) = self.audio_output.clock_snapshot() else {
             return;
         };
         if !self.should_sync_audio_clock(snapshot) {
@@ -819,7 +848,7 @@ impl PresenterRuntime {
         if !self.audio_configured {
             if let Err(error) = self.audio_output.configure(frame.frame.format) {
                 self.stats.audio_failures += 1;
-                eprintln!("Kuroko presenter CoreAudio configure failed: {error}");
+                eprintln!("Kuroko presenter audio configure failed: {error}");
                 return;
             }
             self.audio_configured = true;
@@ -829,7 +858,7 @@ impl PresenterRuntime {
             Ok(_) => self.stats.pushed_audio_frames += 1,
             Err(error) => {
                 self.stats.audio_failures += 1;
-                eprintln!("Kuroko presenter CoreAudio push failed: {error}");
+                eprintln!("Kuroko presenter audio push failed: {error}");
                 return;
             }
         }
@@ -837,7 +866,7 @@ impl PresenterRuntime {
         if !self.audio_started && self.audio_output_ready_to_start() {
             if let Err(error) = self.audio_output.start() {
                 self.stats.audio_failures += 1;
-                eprintln!("Kuroko presenter CoreAudio start failed: {error}");
+                eprintln!("Kuroko presenter audio start failed: {error}");
                 return;
             }
             self.audio_started = true;
@@ -848,7 +877,6 @@ impl PresenterRuntime {
     fn audio_output_ready_to_start(&self) -> bool {
         self.audio_output
             .clock_snapshot()
-            .ok()
             .and_then(|snapshot| snapshot.queued_duration)
             .is_some_and(|queued| queued >= AUDIO_START_BUFFER)
     }
@@ -856,7 +884,7 @@ impl PresenterRuntime {
     fn reset_audio_output(&mut self) {
         if let Err(error) = self.audio_output.stop() {
             self.stats.audio_failures += 1;
-            eprintln!("Kuroko presenter CoreAudio reset failed: {error}");
+            eprintln!("Kuroko presenter audio reset failed: {error}");
         }
         self.audio_configured = false;
         self.audio_started = false;
@@ -954,6 +982,19 @@ fn build_renderer(
         RendererBackendPreference::FlutterTexture => Err(PlayerError::Renderer(
             "Flutter texture backend is not supported by the presenter runtime".to_string(),
         )),
+    }
+}
+
+fn build_audio_output(config: PresenterAudioConfig) -> Box<dyn AudioOutputBackend> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(CoreAudioOutput::new(CoreAudioOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Box::new(BufferedAudioOutput::new(config.ring_buffer))
     }
 }
 

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -424,10 +424,9 @@ impl PresenterRuntime {
     }
 
     pub fn set_danmaku_config(&mut self, config: DanmakuLayoutConfig) {
-        if self.danmaku.config() == &config {
+        if !self.danmaku.set_config(config) {
             return;
         }
-        self.danmaku.set_config(config);
         self.current_danmaku = None;
         self.current_danmaku_viewport = None;
         self.bump_danmaku_generation();
@@ -1348,6 +1347,26 @@ mod tests {
 
         assert_eq!(danmaku_generation, 5);
         assert_eq!(generation, 8);
+    }
+
+    #[test]
+    fn repeated_danmaku_config_does_not_bump_generation() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+        let original_generation = presenter.current_generation;
+
+        presenter.set_danmaku_config(DanmakuLayoutConfig::default());
+
+        assert_eq!(presenter.current_generation, original_generation);
+
+        let mut config = DanmakuLayoutConfig::default();
+        config.font_size += 1.0;
+        presenter.set_danmaku_config(config.clone());
+        let changed_generation = presenter.current_generation;
+
+        assert!(changed_generation > original_generation);
+        presenter.set_danmaku_config(config);
+
+        assert_eq!(presenter.current_generation, changed_generation);
     }
 
     #[test]

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -301,6 +301,14 @@ impl PresenterRuntime {
         self.player.set_playback_rate(rate)
     }
 
+    pub fn set_volume(&mut self, volume: f64) {
+        self.audio_output.set_volume(volume as f32);
+    }
+
+    pub fn volume(&self) -> f64 {
+        self.audio_output.volume() as f64
+    }
+
     pub fn set_danmaku_timeline(&mut self, timeline: DanmakuTimeline) {
         self.danmaku_session.replace_default_track(
             timeline,
@@ -387,6 +395,9 @@ impl PresenterRuntime {
     }
 
     pub fn set_danmaku_config(&mut self, config: DanmakuLayoutConfig) {
+        if self.danmaku.config() == &config {
+            return;
+        }
         self.danmaku.set_config(config);
         self.current_danmaku = None;
         self.current_danmaku_viewport = None;
@@ -1326,6 +1337,19 @@ mod tests {
             written_frames: 24_000,
             underflow_frames: 0,
         }));
+    }
+
+    #[test]
+    fn presenter_volume_is_clamped() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+
+        assert_eq!(presenter.volume(), 1.0);
+        presenter.set_volume(0.4);
+        assert!((presenter.volume() - 0.4).abs() < 0.000_001);
+        presenter.set_volume(-1.0);
+        assert_eq!(presenter.volume(), 0.0);
+        presenter.set_volume(f64::NAN);
+        assert_eq!(presenter.volume(), 1.0);
     }
 
     #[test]

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -1,4 +1,10 @@
-use std::{env, fs::OpenOptions, io::Write, path::PathBuf, time::Duration};
+use std::{
+    env,
+    fs::OpenOptions,
+    io::Write,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use crossbeam_channel::Receiver;
 
@@ -9,12 +15,13 @@ use crate::audio::BufferedAudioOutput;
 use crate::audio::{AudioClockSnapshot, AudioOutputBackend, AudioRingBufferConfig};
 use crate::core::{
     MediaRequest, PlatformSurface, Player, PlayerAudioFrame, PlayerConfig, PlayerSubtitleFrame,
-    PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererBackendPreference, TrackInfo,
-    TrackSelection,
+    PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererBackendPreference,
+    RendererRuntimeStats, TrackInfo, TrackSelection,
 };
 use crate::danmaku::{
-    DanmakuLayoutConfig, DanmakuRenderPlan, DanmakuSession, DanmakuTimeline, DanmakuTrackInfo,
-    DanmakuTrackSource, DanmakuViewport, DfmLayoutEngine,
+    DANMAKU_DEBUG_BUCKETS, DanmakuDebugBucket, DanmakuLayoutConfig, DanmakuPreparedStats,
+    DanmakuRenderPlan, DanmakuSession, DanmakuTimeline, DanmakuTrackInfo, DanmakuTrackSource,
+    DanmakuViewport, DfmLayoutEngine,
 };
 use crate::overlay::{OverlayFrame, OverlayTimeline, OverlayViewport};
 use crate::renderer::metal::{MetalRenderer, MetalRendererConfig};
@@ -97,6 +104,42 @@ pub struct PresenterStats {
     pub audio_failures: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct PresenterRuntimeSnapshot {
+    pub stats: PresenterStats,
+    pub renderer: RendererRuntimeStats,
+    pub media_time: Duration,
+    pub generation: u64,
+    pub playing: bool,
+    pub current_danmaku_items: usize,
+    pub current_danmaku_atlas_version: u64,
+    pub current_danmaku_atlas_bytes: usize,
+    pub current_danmaku_viewport_width: u32,
+    pub current_danmaku_viewport_height: u32,
+    pub current_danmaku_placed_items: usize,
+    pub current_danmaku_scroll_items: usize,
+    pub current_danmaku_top_items: usize,
+    pub current_danmaku_bottom_items: usize,
+    pub current_danmaku_scroll_rows: usize,
+    pub current_danmaku_scroll_track_min: usize,
+    pub current_danmaku_scroll_track_max: usize,
+    pub current_danmaku_scroll_min_y: f32,
+    pub current_danmaku_scroll_max_y: f32,
+    pub current_danmaku_scroll_bucket_count: usize,
+    pub current_danmaku_scroll_buckets: [DanmakuDebugBucket; DANMAKU_DEBUG_BUCKETS],
+    pub current_danmaku_prepared: DanmakuPreparedStats,
+    pub last_tick_duration: Duration,
+    pub last_pump_duration: Duration,
+    pub last_audio_pump_duration: Duration,
+    pub last_subtitle_pump_duration: Duration,
+    pub last_video_pump_duration: Duration,
+    pub last_clock_sync_duration: Duration,
+    pub last_danmaku_plan_duration: Duration,
+    pub last_render_duration: Duration,
+    pub last_render_current_duration: Duration,
+    pub last_render_test_duration: Duration,
+}
+
 pub struct PresenterRuntime {
     player: Player,
     renderer: Box<dyn RendererBackend>,
@@ -120,6 +163,16 @@ pub struct PresenterRuntime {
     danmaku_generation: u64,
     danmaku_trace: DanmakuTimeTrace,
     stats: PresenterStats,
+    last_tick_duration: Duration,
+    last_pump_duration: Duration,
+    last_audio_pump_duration: Duration,
+    last_subtitle_pump_duration: Duration,
+    last_video_pump_duration: Duration,
+    last_clock_sync_duration: Duration,
+    last_danmaku_plan_duration: Duration,
+    last_render_duration: Duration,
+    last_render_current_duration: Duration,
+    last_render_test_duration: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,6 +272,16 @@ impl PresenterRuntime {
             danmaku_generation: 1,
             danmaku_trace: DanmakuTimeTrace::from_env(),
             stats: PresenterStats::default(),
+            last_tick_duration: Duration::ZERO,
+            last_pump_duration: Duration::ZERO,
+            last_audio_pump_duration: Duration::ZERO,
+            last_subtitle_pump_duration: Duration::ZERO,
+            last_video_pump_duration: Duration::ZERO,
+            last_clock_sync_duration: Duration::ZERO,
+            last_danmaku_plan_duration: Duration::ZERO,
+            last_render_duration: Duration::ZERO,
+            last_render_current_duration: Duration::ZERO,
+            last_render_test_duration: Duration::ZERO,
         })
     }
 
@@ -464,11 +527,29 @@ impl PresenterRuntime {
     }
 
     pub fn render_tick(&mut self, time_seconds: f64) -> Result<PresenterStats> {
+        let tick_started = Instant::now();
+        let pump_started = Instant::now();
+
+        let audio_started = Instant::now();
         self.pump_audio();
+        self.last_audio_pump_duration = audio_started.elapsed();
+
+        let subtitle_started = Instant::now();
         self.pump_subtitles();
+        self.last_subtitle_pump_duration = subtitle_started.elapsed();
+
+        let video_started = Instant::now();
         self.pump_video();
+        self.last_video_pump_duration = video_started.elapsed();
+
+        let sync_started = Instant::now();
         self.sync_media_time_from_player();
+        self.last_clock_sync_duration = sync_started.elapsed();
+
+        let plan_started = Instant::now();
         self.refresh_stale_danmaku_plan();
+        self.last_danmaku_plan_duration = plan_started.elapsed();
+        self.last_pump_duration = pump_started.elapsed();
         let plan_time = self.current_danmaku.as_ref().map(|plan| plan.media_time);
         let plan_generation = self.current_danmaku.as_ref().map(|plan| plan.generation);
         let plan_items = self
@@ -495,10 +576,18 @@ impl PresenterRuntime {
                 self.current_output_viewport
                     .map_or(0, |viewport| viewport.height),
             );
-        match self.renderer.render_current_frame(context) {
+        let render_started = Instant::now();
+        let render_result = self.renderer.render_current_frame(context);
+        self.last_render_current_duration = render_started.elapsed();
+        self.last_render_duration = self.last_render_current_duration;
+        self.last_render_test_duration = Duration::ZERO;
+        match render_result {
             Ok(true) => self.stats.rendered_video_frames += 1,
             Ok(false) => {
+                let render_started = Instant::now();
                 self.renderer.render_test_frame(time_seconds)?;
+                self.last_render_test_duration = render_started.elapsed();
+                self.last_render_duration = self.last_render_test_duration;
                 self.stats.rendered_test_frames += 1;
             }
             Err(error) => {
@@ -507,11 +596,67 @@ impl PresenterRuntime {
             }
         }
 
+        self.last_tick_duration = tick_started.elapsed();
         Ok(self.stats)
     }
 
     pub fn stats(&self) -> PresenterStats {
         self.stats
+    }
+
+    pub fn runtime_snapshot(&self) -> PresenterRuntimeSnapshot {
+        let renderer = self.renderer.runtime_stats();
+        let (current_danmaku_items, current_danmaku_atlas_version, current_danmaku_atlas_bytes) =
+            self.current_danmaku.as_ref().map_or((0, 0, 0), |plan| {
+                let atlas = plan.atlas.as_ref();
+                (
+                    plan.items.len(),
+                    atlas.map_or(0, |atlas| atlas.version),
+                    atlas.map_or(0, |atlas| atlas.required_len().saturating_mul(2)),
+                )
+            });
+        let frame_stats = self
+            .current_danmaku
+            .as_ref()
+            .map_or(Default::default(), |plan| plan.frame_stats);
+        PresenterRuntimeSnapshot {
+            stats: self.stats,
+            renderer,
+            media_time: self.current_media_time,
+            generation: self.current_generation,
+            playing: self.is_playing(),
+            current_danmaku_items,
+            current_danmaku_atlas_version,
+            current_danmaku_atlas_bytes,
+            current_danmaku_viewport_width: self
+                .current_danmaku_viewport
+                .map_or(0, |viewport| viewport.width),
+            current_danmaku_viewport_height: self
+                .current_danmaku_viewport
+                .map_or(0, |viewport| viewport.height),
+            current_danmaku_placed_items: frame_stats.placed_items,
+            current_danmaku_scroll_items: frame_stats.scroll_items,
+            current_danmaku_top_items: frame_stats.top_items,
+            current_danmaku_bottom_items: frame_stats.bottom_items,
+            current_danmaku_scroll_rows: frame_stats.scroll_rows,
+            current_danmaku_scroll_track_min: frame_stats.scroll_track_min,
+            current_danmaku_scroll_track_max: frame_stats.scroll_track_max,
+            current_danmaku_scroll_min_y: frame_stats.scroll_min_y,
+            current_danmaku_scroll_max_y: frame_stats.scroll_max_y,
+            current_danmaku_scroll_bucket_count: frame_stats.scroll_bucket_count,
+            current_danmaku_scroll_buckets: frame_stats.scroll_buckets,
+            current_danmaku_prepared: frame_stats.prepared,
+            last_tick_duration: self.last_tick_duration,
+            last_pump_duration: self.last_pump_duration,
+            last_audio_pump_duration: self.last_audio_pump_duration,
+            last_subtitle_pump_duration: self.last_subtitle_pump_duration,
+            last_video_pump_duration: self.last_video_pump_duration,
+            last_clock_sync_duration: self.last_clock_sync_duration,
+            last_danmaku_plan_duration: self.last_danmaku_plan_duration,
+            last_render_duration: self.last_render_duration,
+            last_render_current_duration: self.last_render_current_duration,
+            last_render_test_duration: self.last_render_test_duration,
+        }
     }
 
     fn pump_video(&mut self) {

--- a/crates/kuroko/src/renderer/metal/apple.rs
+++ b/crates/kuroko/src/renderer/metal/apple.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_void;
 use std::mem;
 use std::ptr::NonNull;
+use std::time::{Duration, Instant};
 
 use crate::core::{PlayerError, Result};
 use objc2::rc::Retained;
@@ -30,7 +31,7 @@ use objc2_metal::{
     MTLTextureUsage,
 };
 use objc2_metal::{
-    MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue, MTLDevice, MTLDrawable,
+    MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue, MTLDevice, MTLDrawable,
     MTLRenderPassDescriptor, MTLTexture,
 };
 use objc2_metal::{
@@ -40,7 +41,7 @@ use objc2_metal::{
 use objc2_metal::{MTLSamplerDescriptor, MTLSamplerMinMagFilter, MTLSamplerState};
 use objc2_quartz_core::{CAMetalDrawable, CAMetalLayer};
 
-use crate::danmaku::{DanmakuGlyphAtlas, DanmakuGlyphInstance, DanmakuRenderPlan};
+use crate::danmaku::{DanmakuGlyphAtlas, DanmakuRenderPlan};
 use crate::renderer::metal::{
     ClearColor, DanmakuRenderFrame, ImportedVideoFormat, ImportedVideoFrameInfo,
     ImportedVideoPlaneInfo, MetalDrawablePixelFormat, MetalOutputMode, MetalRendererConfig,
@@ -104,9 +105,12 @@ pub struct MetalRendererImpl {
     texture_cache: Option<CFRetained<CVMetalTextureCache>>,
     video_pipeline: Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>,
     overlay_pipeline: Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>,
+    danmaku_batch_pipeline: Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>,
     video_sampler: Option<Retained<ProtocolObject<dyn MTLSamplerState>>>,
     overlay_alpha_atlas_cache: Option<OverlayAlphaAtlasCache>,
     danmaku_alpha_atlas_cache: Option<DanmakuAlphaAtlasCache>,
+    danmaku_vertex_buffer: Option<Retained<ProtocolObject<dyn MTLBuffer>>>,
+    danmaku_vertex_buffer_len: usize,
     stats: MetalRendererStats,
 }
 
@@ -127,9 +131,12 @@ impl MetalRendererImpl {
             texture_cache: None,
             video_pipeline: None,
             overlay_pipeline: None,
+            danmaku_batch_pipeline: None,
             video_sampler: None,
             overlay_alpha_atlas_cache: None,
             danmaku_alpha_atlas_cache: None,
+            danmaku_vertex_buffer: None,
+            danmaku_vertex_buffer_len: 0,
             stats: MetalRendererStats::default(),
         })
     }
@@ -189,7 +196,10 @@ impl MetalRendererImpl {
         }
         self.video_pipeline = None;
         self.overlay_pipeline = None;
+        self.danmaku_batch_pipeline = None;
         self.overlay_alpha_atlas_cache = None;
+        self.danmaku_vertex_buffer = None;
+        self.danmaku_vertex_buffer_len = 0;
     }
 
     pub fn record_prepared_overlay_frame(&mut self, info: PreparedOverlayFrameInfo) {
@@ -339,6 +349,12 @@ impl MetalRendererImpl {
         let danmaku_item_count = danmaku
             .as_ref()
             .map_or(0usize, |danmaku| danmaku.plan.items.len());
+        self.stats.last_danmaku_atlas_duration = Duration::ZERO;
+        self.stats.last_danmaku_vertex_build_duration = Duration::ZERO;
+        self.stats.last_danmaku_vertex_copy_duration = Duration::ZERO;
+        self.stats.last_danmaku_encode_duration = Duration::ZERO;
+        self.stats.last_danmaku_vertex_bytes = 0;
+        self.stats.last_danmaku_vertex_count = 0;
         let Some(layer) = &self.layer else {
             return Err(PlayerError::Renderer(
                 "no CAMetalLayer attached".to_string(),
@@ -585,20 +601,20 @@ impl MetalRendererImpl {
                 atlas.stride
             )));
         }
-        let pipeline = self.overlay_pipeline_state()?;
+        let pipeline = self.danmaku_batch_pipeline_state()?;
         let sampler = self.video_sampler_state()?;
+        let atlas_started = Instant::now();
         let (fill_texture, outline_texture) = self.prepare_danmaku_alpha_atlas(atlas)?;
-        for item in &plan.items {
-            self.draw_danmaku_glyph(
-                encoder,
-                &pipeline,
-                &sampler,
-                item,
-                &fill_texture,
-                &outline_texture,
-                layout,
-            );
-        }
+        self.stats.last_danmaku_atlas_duration = atlas_started.elapsed();
+        self.draw_danmaku_batch(
+            encoder,
+            &pipeline,
+            &sampler,
+            plan,
+            &fill_texture,
+            &outline_texture,
+            layout,
+        )?;
         Ok(())
     }
 
@@ -637,44 +653,100 @@ impl MetalRendererImpl {
         Ok((fill_texture, outline_texture))
     }
 
-    fn draw_danmaku_glyph(
-        &self,
+    fn draw_danmaku_batch(
+        &mut self,
         encoder: &ProtocolObject<dyn MTLRenderCommandEncoder>,
         pipeline: &ProtocolObject<dyn MTLRenderPipelineState>,
         sampler: &ProtocolObject<dyn MTLSamplerState>,
-        item: &DanmakuGlyphInstance,
+        plan: &DanmakuRenderPlan,
         fill_texture: &ProtocolObject<dyn MTLTexture>,
         outline_texture: &ProtocolObject<dyn MTLTexture>,
         layout: VideoPresentationLayout,
-    ) {
-        if item.shadow_rgba[3] > 0.0 {
-            let mut rect = item.rect;
-            rect[0] += item.shadow_offset[0];
-            rect[1] += item.shadow_offset[1];
-            let uniforms = OverlayUniforms::from_output_alpha_atlas_rect(
-                item.shadow_rgba,
-                rect,
-                item.tex_rect,
-                layout,
+    ) -> Result<()> {
+        let build_started = Instant::now();
+        let uniforms = DanmakuBatchUniforms {
+            viewport: layout.overlay_viewport(),
+            _reserved0: [0.0, 0.0],
+        };
+        unsafe {
+            encoder.setRenderPipelineState(pipeline);
+            encoder.setFragmentSamplerState_atIndex(Some(sampler), 0);
+            encoder.setVertexBytes_length_atIndex(
+                NonNull::new(
+                    (&uniforms as *const DanmakuBatchUniforms)
+                        .cast::<c_void>()
+                        .cast_mut(),
+                )
+                .expect("danmaku batch uniforms pointer is non-null"),
+                mem::size_of::<DanmakuBatchUniforms>(),
+                1,
             );
-            draw_alpha_mask(encoder, pipeline, sampler, outline_texture, &uniforms);
         }
-        if item.outline_rgba[3] > 0.0 {
-            let uniforms = OverlayUniforms::from_output_alpha_atlas_rect(
-                item.outline_rgba,
-                item.rect,
-                item.tex_rect,
-                layout,
-            );
-            draw_alpha_mask(encoder, pipeline, sampler, outline_texture, &uniforms);
+        let shadow_count = plan
+            .items
+            .iter()
+            .filter(|item| item.shadow_rgba[3] > 0.0)
+            .count();
+        let outline_count = plan
+            .items
+            .iter()
+            .filter(|item| item.outline_rgba[3] > 0.0)
+            .count();
+        let outline_texture_count = shadow_count
+            .checked_add(outline_count)
+            .ok_or_else(|| PlayerError::Renderer("danmaku instance count overflow".to_string()))?;
+        let fill_count = plan.items.len();
+        let total_instances = outline_texture_count
+            .checked_add(fill_count)
+            .ok_or_else(|| PlayerError::Renderer("danmaku instance count overflow".to_string()))?;
+        let total_bytes = instance_bytes_len(total_instances)?;
+        self.stats.last_danmaku_vertex_bytes = total_bytes;
+        self.stats.last_danmaku_vertex_count = total_instances;
+        self.ensure_danmaku_vertex_buffer(total_bytes)?;
+        let buffer = self
+            .danmaku_vertex_buffer
+            .as_ref()
+            .expect("danmaku vertex buffer exists")
+            .clone();
+        write_danmaku_instances_direct(
+            &buffer,
+            plan,
+            shadow_count,
+            outline_texture_count,
+            total_instances,
+        )?;
+        self.stats.last_danmaku_vertex_build_duration = build_started.elapsed();
+        self.stats.last_danmaku_vertex_copy_duration = Duration::ZERO;
+
+        let encode_started = Instant::now();
+        draw_danmaku_instance_batch(encoder, outline_texture, &buffer, 0, outline_texture_count)?;
+        let fill_offset = instance_bytes_len(outline_texture_count)?;
+        draw_danmaku_instance_batch(
+            encoder,
+            fill_texture,
+            &buffer,
+            fill_offset,
+            fill_count,
+        )?;
+        self.stats.last_danmaku_encode_duration = encode_started.elapsed();
+        Ok(())
+    }
+
+    fn ensure_danmaku_vertex_buffer(&mut self, required_len: usize) -> Result<()> {
+        if required_len == 0 {
+            return Ok(());
         }
-        let uniforms = OverlayUniforms::from_output_alpha_atlas_rect(
-            item.color_rgba,
-            item.rect,
-            item.tex_rect,
-            layout,
-        );
-        draw_alpha_mask(encoder, pipeline, sampler, fill_texture, &uniforms);
+        if self.danmaku_vertex_buffer_len >= required_len && self.danmaku_vertex_buffer.is_some() {
+            return Ok(());
+        }
+        let len = required_len.next_power_of_two().max(4096);
+        let buffer = self
+            .device
+            .newBufferWithLength_options(len, MTLResourceOptions::StorageModeShared)
+            .ok_or_else(|| PlayerError::Renderer("newBufferWithLength returned nil".to_string()))?;
+        self.danmaku_vertex_buffer = Some(buffer);
+        self.danmaku_vertex_buffer_len = len;
+        Ok(())
     }
 
     fn prepare_overlay_alpha_atlas(
@@ -1042,6 +1114,65 @@ impl MetalRendererImpl {
             .expect("overlay pipeline exists")
             .clone())
     }
+
+    fn danmaku_batch_pipeline_state(
+        &mut self,
+    ) -> Result<Retained<ProtocolObject<dyn MTLRenderPipelineState>>> {
+        if self.danmaku_batch_pipeline.is_none() {
+            let library = self
+                .device
+                .newLibraryWithSource_options_error(&NSString::from_str(VIDEO_SHADER_SOURCE), None)
+                .map_err(|error| {
+                    PlayerError::Renderer(format!(
+                        "Metal danmaku batch shader compile failed: {}",
+                        error.localizedDescription()
+                    ))
+                })?;
+            let vertex = library
+                .newFunctionWithName(&NSString::from_str("kuroko_danmaku_batch_vertex"))
+                .ok_or_else(|| {
+                    PlayerError::Renderer(
+                        "Metal shader missing kuroko_danmaku_batch_vertex".to_string(),
+                    )
+                })?;
+            let fragment = library
+                .newFunctionWithName(&NSString::from_str("kuroko_danmaku_batch_fragment"))
+                .ok_or_else(|| {
+                    PlayerError::Renderer(
+                        "Metal shader missing kuroko_danmaku_batch_fragment".to_string(),
+                    )
+                })?;
+            let descriptor = MTLRenderPipelineDescriptor::new();
+            descriptor.setLabel(Some(&NSString::from_str("Kuroko Danmaku Batch Pipeline")));
+            descriptor.setVertexFunction(Some(&*vertex));
+            descriptor.setFragmentFunction(Some(&*fragment));
+            let attachments = descriptor.colorAttachments();
+            let attachment = unsafe { attachments.objectAtIndexedSubscript(0) };
+            attachment.setPixelFormat(metal_pixel_format(self.drawable_pixel_format));
+            attachment.setBlendingEnabled(true);
+            attachment.setSourceRGBBlendFactor(MTLBlendFactor::SourceAlpha);
+            attachment.setDestinationRGBBlendFactor(MTLBlendFactor::OneMinusSourceAlpha);
+            attachment.setRgbBlendOperation(MTLBlendOperation::Add);
+            attachment.setSourceAlphaBlendFactor(MTLBlendFactor::One);
+            attachment.setDestinationAlphaBlendFactor(MTLBlendFactor::OneMinusSourceAlpha);
+            attachment.setAlphaBlendOperation(MTLBlendOperation::Add);
+            let pipeline = self
+                .device
+                .newRenderPipelineStateWithDescriptor_error(&descriptor)
+                .map_err(|error| {
+                    PlayerError::Renderer(format!(
+                        "Metal danmaku batch pipeline create failed: {}",
+                        error.localizedDescription()
+                    ))
+                })?;
+            self.danmaku_batch_pipeline = Some(pipeline);
+        }
+        Ok(self
+            .danmaku_batch_pipeline
+            .as_ref()
+            .expect("danmaku batch pipeline exists")
+            .clone())
+    }
 }
 
 fn set_layer_edr_enabled(layer: &CAMetalLayer, enabled: bool) {
@@ -1162,6 +1293,31 @@ struct OverlayUniforms {
     color: [f32; 4],
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct DanmakuBatchUniforms {
+    viewport: [f32; 2],
+    _reserved0: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct DanmakuBatchInstance {
+    rect: [f32; 4],
+    tex_rect: [f32; 4],
+    color: [f32; 4],
+}
+
+impl DanmakuBatchInstance {
+    fn new(rect: [f32; 4], tex_rect: [f32; 4], color: [f32; 4]) -> Self {
+        Self {
+            rect,
+            tex_rect,
+            color,
+        }
+    }
+}
+
 impl OverlayUniforms {
     fn from_plane(
         x: i32,
@@ -1215,21 +1371,6 @@ impl OverlayUniforms {
         }
     }
 
-    fn from_output_alpha_atlas_rect(
-        color: [f32; 4],
-        rect: [f32; 4],
-        tex_rect: [f32; 4],
-        layout: VideoPresentationLayout,
-    ) -> Self {
-        Self {
-            rect,
-            tex_rect,
-            viewport: layout.overlay_viewport(),
-            overlay_mode: 1,
-            _reserved0: 0,
-            color,
-        }
-    }
 }
 
 fn overlay_uniform_pointer(uniforms: &OverlayUniforms) -> NonNull<c_void> {
@@ -1241,29 +1382,86 @@ fn overlay_uniform_pointer(uniforms: &OverlayUniforms) -> NonNull<c_void> {
     .expect("overlay uniform pointer is non-null")
 }
 
-fn draw_alpha_mask(
-    encoder: &ProtocolObject<dyn MTLRenderCommandEncoder>,
-    pipeline: &ProtocolObject<dyn MTLRenderPipelineState>,
-    sampler: &ProtocolObject<dyn MTLSamplerState>,
-    texture: &ProtocolObject<dyn MTLTexture>,
-    uniforms: &OverlayUniforms,
-) {
-    unsafe {
-        encoder.setRenderPipelineState(pipeline);
-        encoder.setFragmentTexture_atIndex(Some(texture), 0);
-        encoder.setFragmentSamplerState_atIndex(Some(sampler), 0);
-        encoder.setVertexBytes_length_atIndex(
-            overlay_uniform_pointer(uniforms),
-            mem::size_of::<OverlayUniforms>(),
-            0,
-        );
-        encoder.setFragmentBytes_length_atIndex(
-            overlay_uniform_pointer(uniforms),
-            mem::size_of::<OverlayUniforms>(),
-            0,
-        );
-        encoder.drawPrimitives_vertexStart_vertexCount(MTLPrimitiveType::TriangleStrip, 0, 4);
+fn instance_bytes_len(instance_count: usize) -> Result<usize> {
+    instance_count
+        .checked_mul(mem::size_of::<DanmakuBatchInstance>())
+        .ok_or_else(|| PlayerError::Renderer("danmaku batch instance buffer overflow".to_string()))
+}
+
+fn write_danmaku_instances_direct(
+    buffer: &ProtocolObject<dyn MTLBuffer>,
+    plan: &DanmakuRenderPlan,
+    shadow_count: usize,
+    outline_texture_count: usize,
+    total_instances: usize,
+) -> Result<()> {
+    if total_instances == 0 {
+        return Ok(());
     }
+    let byte_len = instance_bytes_len(total_instances)?;
+    let end = byte_len;
+    if end > buffer.length() {
+        return Err(PlayerError::Renderer(
+            "danmaku instance buffer too small".to_string(),
+        ));
+    }
+    unsafe {
+        let dst = buffer.contents().as_ptr() as *mut DanmakuBatchInstance;
+        let mut shadow_index = 0usize;
+        let mut outline_index = shadow_count;
+        let mut fill_index = outline_texture_count;
+        for item in &plan.items {
+            if item.shadow_rgba[3] > 0.0 {
+                let mut rect = item.rect;
+                rect[0] += item.shadow_offset[0];
+                rect[1] += item.shadow_offset[1];
+                dst.add(shadow_index)
+                    .write(DanmakuBatchInstance::new(rect, item.tex_rect, item.shadow_rgba));
+                shadow_index += 1;
+            }
+            if item.outline_rgba[3] > 0.0 {
+                dst.add(outline_index).write(DanmakuBatchInstance::new(
+                    item.rect,
+                    item.tex_rect,
+                    item.outline_rgba,
+                ));
+                outline_index += 1;
+            }
+            dst.add(fill_index).write(DanmakuBatchInstance::new(
+                item.rect,
+                item.tex_rect,
+                item.color_rgba,
+            ));
+            fill_index += 1;
+        }
+        debug_assert_eq!(shadow_index, shadow_count);
+        debug_assert_eq!(outline_index, outline_texture_count);
+        debug_assert_eq!(fill_index, total_instances);
+    }
+    Ok(())
+}
+
+fn draw_danmaku_instance_batch(
+    encoder: &ProtocolObject<dyn MTLRenderCommandEncoder>,
+    texture: &ProtocolObject<dyn MTLTexture>,
+    buffer: &ProtocolObject<dyn MTLBuffer>,
+    offset: usize,
+    instance_count: usize,
+) -> Result<()> {
+    if instance_count == 0 {
+        return Ok(());
+    }
+    unsafe {
+        encoder.setFragmentTexture_atIndex(Some(texture), 0);
+        encoder.setVertexBuffer_offset_atIndex(Some(buffer), offset, 0);
+        encoder.drawPrimitives_vertexStart_vertexCount_instanceCount(
+            MTLPrimitiveType::Triangle,
+            0,
+            6,
+            instance_count,
+        );
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1708,6 +1906,59 @@ fragment float4 kuroko_overlay_fragment(
         return float4(uniforms.color.rgb, uniforms.color.a * sampled.r);
     }
     return sampled;
+}
+
+struct DanmakuBatchUniforms {
+    float2 viewport;
+    float2 reserved0;
+};
+
+struct DanmakuBatchInstance {
+    float4 rect;
+    float4 tex_rect;
+    float4 color;
+};
+
+struct DanmakuBatchOut {
+    float4 position [[position]];
+    float2 tex_coord;
+    float4 color;
+};
+
+vertex DanmakuBatchOut kuroko_danmaku_batch_vertex(
+    uint vertex_id [[vertex_id]],
+    uint instance_id [[instance_id]],
+    constant DanmakuBatchInstance* instances [[buffer(0)]],
+    constant DanmakuBatchUniforms& uniforms [[buffer(1)]]) {
+    constexpr float2 corners[6] = {
+        float2(0.0, 0.0),
+        float2(1.0, 0.0),
+        float2(0.0, 1.0),
+        float2(1.0, 0.0),
+        float2(1.0, 1.0),
+        float2(0.0, 1.0),
+    };
+    DanmakuBatchInstance glyph = instances[instance_id];
+    float2 corner = corners[vertex_id];
+    float2 position = glyph.rect.xy + corner * glyph.rect.zw;
+    float2 tex_coord = glyph.tex_rect.xy + corner * glyph.tex_rect.zw;
+    float2 ndc = float2(
+        position.x / max(uniforms.viewport.x, 1.0) * 2.0 - 1.0,
+        1.0 - position.y / max(uniforms.viewport.y, 1.0) * 2.0
+    );
+    DanmakuBatchOut out;
+    out.position = float4(ndc, 0.0, 1.0);
+    out.tex_coord = tex_coord;
+    out.color = glyph.color;
+    return out;
+}
+
+fragment float4 kuroko_danmaku_batch_fragment(
+    DanmakuBatchOut in [[stage_in]],
+    texture2d<float, access::sample> atlas_texture [[texture(0)]],
+    sampler atlas_sampler [[sampler(0)]]) {
+    float mask = atlas_texture.sample(atlas_sampler, in.tex_coord).r;
+    return float4(in.color.rgb, in.color.a * mask);
 }
 "#;
 

--- a/crates/kuroko/src/renderer/metal/apple.rs
+++ b/crates/kuroko/src/renderer/metal/apple.rs
@@ -4,7 +4,7 @@ use std::ptr::NonNull;
 
 use crate::core::{PlayerError, Result};
 use objc2::rc::Retained;
-use objc2::runtime::ProtocolObject;
+use objc2::runtime::{NSObjectProtocol, ProtocolObject};
 use objc2_core_foundation::CFRetained;
 use objc2_core_foundation::CGSize;
 use objc2_core_graphics::{CGColorSpace, kCGColorSpaceExtendedLinearSRGB, kCGColorSpaceSRGB};
@@ -178,7 +178,7 @@ impl MetalRendererImpl {
     fn configure_layer_output(&mut self, layer: &CAMetalLayer) {
         self.drawable_pixel_format = self.output_mode.pixel_format();
         layer.setPixelFormat(metal_pixel_format(self.drawable_pixel_format));
-        layer.setWantsExtendedDynamicRangeContent(self.output_mode.is_edr());
+        set_layer_edr_enabled(layer, self.output_mode.is_edr());
         let color_space_name = if self.output_mode.is_edr() {
             Some(unsafe { kCGColorSpaceExtendedLinearSRGB })
         } else {
@@ -1041,6 +1041,12 @@ impl MetalRendererImpl {
             .as_ref()
             .expect("overlay pipeline exists")
             .clone())
+    }
+}
+
+fn set_layer_edr_enabled(layer: &CAMetalLayer, enabled: bool) {
+    if layer.respondsToSelector(objc2::sel!(setWantsExtendedDynamicRangeContent:)) {
+        layer.setWantsExtendedDynamicRangeContent(enabled);
     }
 }
 

--- a/crates/kuroko/src/renderer/metal/mod.rs
+++ b/crates/kuroko/src/renderer/metal/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::core::{
     ColorPrimaries, PlatformSurface, PlayerError, PlayerVideoFrame, RenderFrameContext,
-    RendererBackend, Result, TransferFunction,
+    RendererBackend, RendererRuntimeStats, Result, TransferFunction,
 };
 use crate::danmaku::DanmakuRenderPlan;
 use crate::ffmpeg::Frame;
@@ -115,6 +115,12 @@ pub struct MetalRendererStats {
     pub danmaku_items: u64,
     pub overlay_alpha_atlas_uploads: u64,
     pub overlay_alpha_atlas_reuses: u64,
+    pub last_danmaku_atlas_duration: Duration,
+    pub last_danmaku_vertex_build_duration: Duration,
+    pub last_danmaku_vertex_copy_duration: Duration,
+    pub last_danmaku_encode_duration: Duration,
+    pub last_danmaku_vertex_bytes: usize,
+    pub last_danmaku_vertex_count: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -600,6 +606,29 @@ impl RendererBackend for MetalRenderer {
         );
         self.current_frame = Some(frame);
         result.map(|()| true)
+    }
+
+    fn runtime_stats(&self) -> RendererRuntimeStats {
+        let stats = self.stats();
+        RendererRuntimeStats {
+            surface_width: stats.drawable_width,
+            surface_height: stats.drawable_height,
+            rendered_frames: stats.rendered_frames,
+            offscreen_frames: 0,
+            prepared_overlay_frames: stats.prepared_overlay_frames,
+            prepared_overlay_subtitle_planes: stats.prepared_overlay_subtitle_planes,
+            danmaku_passes: stats.danmaku_passes,
+            danmaku_draw_items: stats.danmaku_items,
+            overlay_alpha_atlas_uploads: stats.overlay_alpha_atlas_uploads,
+            overlay_alpha_atlas_reuses: stats.overlay_alpha_atlas_reuses,
+            last_danmaku_atlas_duration: stats.last_danmaku_atlas_duration,
+            last_danmaku_vertex_build_duration: stats.last_danmaku_vertex_build_duration,
+            last_danmaku_vertex_copy_duration: stats.last_danmaku_vertex_copy_duration,
+            last_danmaku_encode_duration: stats.last_danmaku_encode_duration,
+            last_danmaku_vertex_bytes: stats.last_danmaku_vertex_bytes,
+            last_danmaku_vertex_count: stats.last_danmaku_vertex_count,
+            attached: stats.drawable_width > 0 && stats.drawable_height > 0,
+        }
     }
 }
 

--- a/crates/kuroko/src/renderer/metal/mod.rs
+++ b/crates/kuroko/src/renderer/metal/mod.rs
@@ -12,8 +12,8 @@ use crate::renderer::pipeline::{
     ColorRange, HdrMetadata, MatrixCoefficients, SourceColorState, VideoRenderPipeline,
 };
 
-#[cfg(target_os = "macos")]
-mod macos;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod apple;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ClearColor {
@@ -35,9 +35,9 @@ impl ClearColor {
 }
 
 pub struct MetalRenderer {
-    #[cfg(target_os = "macos")]
-    inner: macos::MetalRendererImpl,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    inner: apple::MetalRendererImpl,
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     _unsupported: (),
     current_frame: Option<ImportedVideoFrame>,
     current_media_time: Duration,
@@ -155,9 +155,9 @@ pub struct ImportedVideoFrameInfo {
 pub struct ImportedVideoFrame {
     info: ImportedVideoFrameInfo,
     source_color: SourceColorState,
-    #[cfg(target_os = "macos")]
-    inner: Option<macos::ImportedVideoFrameTextures>,
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    inner: Option<apple::ImportedVideoFrameTextures>,
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     _unsupported: (),
 }
 
@@ -167,11 +167,11 @@ impl ImportedVideoFrame {
     }
 
     pub fn plane_count(&self) -> usize {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.as_ref().map_or(0, |inner| inner.plane_count())
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             0
         }
@@ -292,19 +292,19 @@ impl MetalRenderer {
     }
 
     pub fn with_config(config: MetalRendererConfig) -> Result<Self> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             Ok(Self {
-                inner: macos::MetalRendererImpl::new(config)?,
+                inner: apple::MetalRendererImpl::new(config)?,
                 current_frame: None,
                 current_media_time: Duration::ZERO,
                 current_generation: 1,
             })
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -316,15 +316,15 @@ impl MetalRenderer {
         height: u32,
         scale: f64,
     ) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             unsafe { self.inner.attach_raw_layer(layer, width, height, scale) }
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = (layer, width, height, scale);
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -333,7 +333,7 @@ impl MetalRenderer {
         &mut self,
         source: VideoFrameTextureSource,
     ) -> Result<ImportedVideoFrame> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             let imported = unsafe { self.inner.import_video_frame_textures(source) }?;
             let source_color =
@@ -345,25 +345,25 @@ impl MetalRenderer {
                 inner: Some(imported.textures),
             })
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = source;
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
 
     pub fn render_video_frame(&mut self, frame: VideoRenderFrame<'_>) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.render_video_frame(frame)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = frame;
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -373,15 +373,15 @@ impl MetalRenderer {
         frame: VideoRenderFrame<'_>,
         overlay: OverlayRenderFrame<'_>,
     ) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.render_video_frame_with_overlay(frame, overlay)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = (frame, overlay);
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -392,30 +392,30 @@ impl MetalRenderer {
         overlay: Option<OverlayRenderFrame<'_>>,
         danmaku: Option<DanmakuRenderFrame<'_>>,
     ) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner
                 .render_video_frame_with_context(frame, overlay, danmaku)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = (frame, overlay, danmaku);
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
 
     pub fn render_overlay_frame(&mut self, overlay: OverlayRenderFrame<'_>) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.render_overlay_frame(overlay)
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = overlay;
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -425,7 +425,7 @@ impl MetalRenderer {
         frame: OverlayRenderFrame<'_>,
     ) -> Result<PreparedOverlayFrameInfo> {
         let info = inspect_overlay_frame(frame.frame)?;
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.record_prepared_overlay_frame(info);
         }
@@ -456,11 +456,11 @@ impl MetalRenderer {
     }
 
     pub fn stats(&self) -> MetalRendererStats {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.stats()
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             MetalRendererStats::default()
         }
@@ -542,7 +542,7 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn detach_surface(&mut self) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.detach_surface();
         }
@@ -550,11 +550,11 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn resize_surface(&mut self, width: u32, height: u32, scale: f64) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.resize_surface(width, height, scale);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = (width, height, scale);
         }
@@ -562,15 +562,15 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn render_test_frame(&mut self, time_seconds: f64) -> Result<()> {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             self.inner.render_clear(ClearColor::animated(time_seconds))
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             let _ = time_seconds;
             Err(PlayerError::Renderer(
-                "Metal renderer is only available on macOS for v0".to_string(),
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
             ))
         }
     }
@@ -628,9 +628,9 @@ mod tests {
                 planes: Vec::new(),
             },
             source_color,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             inner: None,
-            #[cfg(not(target_os = "macos"))]
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
             _unsupported: (),
         }
     }

--- a/crates/kuroko/src/renderer/wgpu.rs
+++ b/crates/kuroko/src/renderer/wgpu.rs
@@ -3,7 +3,8 @@ use wgpu::util::DeviceExt;
 
 use crate::core::{
     ColorPrimaries, PlatformSurface, PlayerError, PlayerVideoFrame, RenderFrameContext,
-    RendererBackend, Result, TransferFunction, WgpuSurfaceHandle, WgpuSurfaceKind,
+    RendererBackend, RendererRuntimeStats, Result, TransferFunction, WgpuSurfaceHandle,
+    WgpuSurfaceKind,
 };
 use crate::danmaku::{DanmakuGlyphAtlas, DanmakuGlyphInstance, DanmakuRenderPlan};
 use crate::ffmpeg::{PlanarFrame, PlanarPixelFormat};
@@ -1593,6 +1594,29 @@ impl RendererBackend for WgpuRenderer {
             self.stats.danmaku_items += danmaku_draws as u64;
         }
         Ok(true)
+    }
+
+    fn runtime_stats(&self) -> RendererRuntimeStats {
+        let stats = self.stats();
+        RendererRuntimeStats {
+            surface_width: stats.surface_width,
+            surface_height: stats.surface_height,
+            rendered_frames: stats.rendered_frames,
+            offscreen_frames: stats.offscreen_frames,
+            prepared_overlay_frames: 0,
+            prepared_overlay_subtitle_planes: 0,
+            danmaku_passes: stats.danmaku_passes,
+            danmaku_draw_items: stats.danmaku_items,
+            overlay_alpha_atlas_uploads: 0,
+            overlay_alpha_atlas_reuses: 0,
+            last_danmaku_atlas_duration: Default::default(),
+            last_danmaku_vertex_build_duration: Default::default(),
+            last_danmaku_vertex_copy_duration: Default::default(),
+            last_danmaku_encode_duration: Default::default(),
+            last_danmaku_vertex_bytes: 0,
+            last_danmaku_vertex_count: 0,
+            attached: stats.attached,
+        }
     }
 }
 

--- a/crates/kuroko/src/renderer/wgpu.rs
+++ b/crates/kuroko/src/renderer/wgpu.rs
@@ -89,7 +89,7 @@ impl WgpuOffscreenReadback {
 }
 
 /// Fragment-shader uniforms for the video pipeline. The field order and byte layout
-/// mirror the Metal `VideoUniforms` in `renderer/metal/macos.rs` exactly, so both
+/// mirror the Metal `VideoUniforms` in `renderer/metal/apple.rs` exactly, so both
 /// backends consume the same data and produce the same pixels.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]

--- a/crates/kuroko/src/renderer/wgpu_overlay.wgsl
+++ b/crates/kuroko/src/renderer/wgpu_overlay.wgsl
@@ -1,4 +1,4 @@
-// WGSL port of the Metal overlay shader in `renderer/metal/macos.rs`. Draws a
+// WGSL port of the Metal overlay shader in `renderer/metal/apple.rs`. Draws a
 // textured quad placed by pixel rect within the viewport, alpha-blended over the
 // video plane. Mode 0 samples straight RGBA; mode 1 is an alpha mask tinted by
 // `color` (libass coverage bitmaps).

--- a/crates/kuroko/src/renderer/wgpu_video.wgsl
+++ b/crates/kuroko/src/renderer/wgpu_video.wgsl
@@ -1,4 +1,4 @@
-// WGSL port of the Metal `VIDEO_SHADER_SOURCE` in `renderer/metal/macos.rs`.
+// WGSL port of the Metal `VIDEO_SHADER_SOURCE` in `renderer/metal/apple.rs`.
 // Kept line-for-line equivalent so the wgpu backend produces the same pixels as
 // the native Metal renderer for a given frame and color pipeline.
 

--- a/crates/kuroko_capi/include/kuroko.h
+++ b/crates/kuroko_capi/include/kuroko.h
@@ -242,6 +242,7 @@ KurokoStatus kuroko_presenter_stop(KurokoPresenterHandle *handle);
 KurokoStatus kuroko_presenter_close(KurokoPresenterHandle *handle);
 KurokoStatus kuroko_presenter_seek(KurokoPresenterHandle *handle, uint64_t position_micros);
 KurokoStatus kuroko_presenter_set_playback_rate(KurokoPresenterHandle *handle, double rate);
+KurokoStatus kuroko_presenter_set_volume(KurokoPresenterHandle *handle, double volume);
 KurokoStatus kuroko_presenter_add_external_subtitle(
     KurokoPresenterHandle *handle,
     const char *uri,
@@ -302,6 +303,9 @@ KurokoStatus kuroko_presenter_set_danmaku_config(
 KurokoStatus kuroko_presenter_set_danmaku_config_ptr(
     KurokoPresenterHandle *handle,
     const KurokoDanmakuConfig *config);
+KurokoStatus kuroko_presenter_get_danmaku_config(
+    KurokoPresenterHandle *handle,
+    KurokoDanmakuConfig *out_config);
 KurokoStatus kuroko_presenter_set_danmaku_font(
     KurokoPresenterHandle *handle,
     const char *family,

--- a/crates/kuroko_capi/src/lib.rs
+++ b/crates/kuroko_capi/src/lib.rs
@@ -6,9 +6,9 @@ use crossbeam_channel::Receiver;
 use kuroko::danmaku::{
     DanmakuLayoutConfig, DanmakuShadowStyle, DanmakuTimeline, DanmakuTrackInfo, DanmakuTrackSource,
 };
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use kuroko::presenter::{PresenterConfig, PresenterRuntime, PresenterStats};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 use kuroko::renderer::metal::{MetalOutputMode, MetalRendererConfig};
 use kuroko::{
     FlutterTextureHandle, FlutterTextureKind, MediaRequest, MetalSurfaceHandle, PlatformSurface,
@@ -290,7 +290,7 @@ pub struct KurokoHandle {
     events: Receiver<PlayerEvent>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub struct KurokoPresenterHandle {
     presenter: PresenterRuntime,
     events: Receiver<PlayerEvent>,
@@ -596,19 +596,19 @@ pub unsafe extern "C" fn kuroko_poll_event(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create() -> *mut KurokoPresenterHandle {
     create_presenter_handle(PresenterConfig::default())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create() -> *mut std::ffi::c_void {
     std::ptr::null_mut()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create_with_config(
     config: KurokoPresenterConfig,
@@ -616,7 +616,7 @@ pub extern "C" fn kuroko_presenter_create_with_config(
     create_presenter_handle(presenter_config_from_c(config))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create_with_output_mode(
     output_mode: i32,
@@ -628,7 +628,7 @@ pub extern "C" fn kuroko_presenter_create_with_output_mode(
     }))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create_with_config(
     _config: KurokoPresenterConfig,
@@ -636,7 +636,7 @@ pub extern "C" fn kuroko_presenter_create_with_config(
     std::ptr::null_mut()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kuroko_presenter_create_with_output_mode(
     _output_mode: i32,
@@ -645,7 +645,7 @@ pub extern "C" fn kuroko_presenter_create_with_output_mode(
     std::ptr::null_mut()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn create_presenter_handle(config: PresenterConfig) -> *mut KurokoPresenterHandle {
     match PresenterRuntime::new(config) {
         Ok(presenter) => {
@@ -656,7 +656,7 @@ fn create_presenter_handle(config: PresenterConfig) -> *mut KurokoPresenterHandl
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn presenter_config_from_c(config: KurokoPresenterConfig) -> PresenterConfig {
     let output_mode = match KurokoPresenterOutputMode::from_raw(config.output_mode) {
         KurokoPresenterOutputMode::AppleEdr => {
@@ -745,12 +745,12 @@ fn danmaku_block_words_from_json(json: &str) -> Result<Vec<String>, KurokoStatus
     }
 }
 
-#[cfg(all(target_os = "macos", test))]
+#[cfg(all(any(target_os = "macos", target_os = "ios"), test))]
 fn metal_output_mode_from_c(config: KurokoPresenterConfig) -> MetalOutputMode {
     presenter_config_from_c(config).renderer.output_mode
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_destroy(handle: *mut KurokoPresenterHandle) {
     if !handle.is_null() {
@@ -758,11 +758,11 @@ pub unsafe extern "C" fn kuroko_presenter_destroy(handle: *mut KurokoPresenterHa
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_destroy(_handle: *mut std::ffi::c_void) {}
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_open(
     handle: *mut KurokoPresenterHandle,
@@ -777,7 +777,7 @@ pub unsafe extern "C" fn kuroko_presenter_open(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_play(handle: *mut KurokoPresenterHandle) -> KurokoStatus {
     with_presenter_mut(handle, |handle| {
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn kuroko_presenter_play(handle: *mut KurokoPresenterHandl
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_pause(
     handle: *mut KurokoPresenterHandle,
@@ -795,7 +795,7 @@ pub unsafe extern "C" fn kuroko_presenter_pause(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_stop(handle: *mut KurokoPresenterHandle) -> KurokoStatus {
     with_presenter_mut(handle, |handle| {
@@ -803,7 +803,7 @@ pub unsafe extern "C" fn kuroko_presenter_stop(handle: *mut KurokoPresenterHandl
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_close(
     handle: *mut KurokoPresenterHandle,
@@ -813,7 +813,7 @@ pub unsafe extern "C" fn kuroko_presenter_close(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_seek(
     handle: *mut KurokoPresenterHandle,
@@ -828,7 +828,7 @@ pub unsafe extern "C" fn kuroko_presenter_seek(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     handle: *mut KurokoPresenterHandle,
@@ -839,7 +839,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_volume(
     handle: *mut KurokoPresenterHandle,
@@ -876,7 +876,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_external_subtitle(
     })
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_external_subtitle(
     _handle: *mut std::ffi::c_void,
@@ -886,7 +886,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_external_subtitle(
     KurokoStatus::PlayerError
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_remove_subtitle_track(
     handle: *mut KurokoPresenterHandle,
@@ -897,7 +897,7 @@ pub unsafe extern "C" fn kuroko_presenter_remove_subtitle_track(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_select_audio_track(
     handle: *mut KurokoPresenterHandle,
@@ -912,7 +912,7 @@ pub unsafe extern "C" fn kuroko_presenter_select_audio_track(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_select_subtitle_track(
     handle: *mut KurokoPresenterHandle,
@@ -927,7 +927,7 @@ pub unsafe extern "C" fn kuroko_presenter_select_subtitle_track(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_load_danmaku_file(
     handle: *mut KurokoPresenterHandle,
@@ -948,7 +948,7 @@ pub unsafe extern "C" fn kuroko_presenter_load_danmaku_file(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_load_danmaku_json(
     handle: *mut KurokoPresenterHandle,
@@ -969,7 +969,7 @@ pub unsafe extern "C" fn kuroko_presenter_load_danmaku_json(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_file(
     handle: *mut KurokoPresenterHandle,
@@ -1003,7 +1003,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_file(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_json(
     handle: *mut KurokoPresenterHandle,
@@ -1037,7 +1037,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_json(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_remove_danmaku_track(
     handle: *mut KurokoPresenterHandle,
@@ -1052,7 +1052,7 @@ pub unsafe extern "C" fn kuroko_presenter_remove_danmaku_track(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_enabled(
     handle: *mut KurokoPresenterHandle,
@@ -1071,7 +1071,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_enabled(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_offset(
     handle: *mut KurokoPresenterHandle,
@@ -1090,7 +1090,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_offset(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_global_offset(
     handle: *mut KurokoPresenterHandle,
@@ -1102,7 +1102,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_global_offset(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_danmaku_tracks(
     handle: *mut KurokoPresenterHandle,
@@ -1123,7 +1123,7 @@ pub unsafe extern "C" fn kuroko_presenter_danmaku_tracks(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_clear_danmaku(
     handle: *mut KurokoPresenterHandle,
@@ -1134,7 +1134,7 @@ pub unsafe extern "C" fn kuroko_presenter_clear_danmaku(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_enabled(
     handle: *mut KurokoPresenterHandle,
@@ -1146,7 +1146,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_enabled(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config(
     handle: *mut KurokoPresenterHandle,
@@ -1165,7 +1165,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     handle: *mut KurokoPresenterHandle,
@@ -1177,7 +1177,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     unsafe { kuroko_presenter_set_danmaku_config(handle, *config) }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
     handle: *mut KurokoPresenterHandle,
@@ -1214,7 +1214,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_block_words_json(
     handle: *mut KurokoPresenterHandle,
@@ -1240,7 +1240,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_block_words_json(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_track_selection(
     handle: *mut KurokoPresenterHandle,
@@ -1255,7 +1255,7 @@ pub unsafe extern "C" fn kuroko_presenter_track_selection(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_tracks(
     handle: *mut KurokoPresenterHandle,
@@ -1271,7 +1271,7 @@ pub unsafe extern "C" fn kuroko_presenter_tracks(
     })
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_remove_subtitle_track(
     _handle: *mut std::ffi::c_void,
@@ -1280,7 +1280,7 @@ pub unsafe extern "C" fn kuroko_presenter_remove_subtitle_track(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_select_audio_track(
     _handle: *mut std::ffi::c_void,
@@ -1289,7 +1289,7 @@ pub unsafe extern "C" fn kuroko_presenter_select_audio_track(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_select_subtitle_track(
     _handle: *mut std::ffi::c_void,
@@ -1298,7 +1298,7 @@ pub unsafe extern "C" fn kuroko_presenter_select_subtitle_track(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_track_selection(
     _handle: *mut std::ffi::c_void,
@@ -1307,7 +1307,7 @@ pub unsafe extern "C" fn kuroko_presenter_track_selection(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_tracks(
     _handle: *mut std::ffi::c_void,
@@ -1318,7 +1318,7 @@ pub unsafe extern "C" fn kuroko_presenter_tracks(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     _handle: *mut std::ffi::c_void,
@@ -1327,7 +1327,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_volume(
     _handle: *mut std::ffi::c_void,
@@ -1345,7 +1345,7 @@ pub unsafe extern "C" fn kuroko_presenter_load_danmaku_file(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_load_danmaku_json(
     _handle: *mut std::ffi::c_void,
@@ -1354,7 +1354,7 @@ pub unsafe extern "C" fn kuroko_presenter_load_danmaku_json(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_file(
     _handle: *mut std::ffi::c_void,
@@ -1369,7 +1369,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_file(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_json(
     _handle: *mut std::ffi::c_void,
@@ -1384,7 +1384,7 @@ pub unsafe extern "C" fn kuroko_presenter_add_danmaku_track_json(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_remove_danmaku_track(
     _handle: *mut std::ffi::c_void,
@@ -1393,7 +1393,7 @@ pub unsafe extern "C" fn kuroko_presenter_remove_danmaku_track(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_enabled(
     _handle: *mut std::ffi::c_void,
@@ -1403,7 +1403,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_enabled(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_offset(
     _handle: *mut std::ffi::c_void,
@@ -1413,7 +1413,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_track_offset(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_global_offset(
     _handle: *mut std::ffi::c_void,
@@ -1422,7 +1422,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_global_offset(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_danmaku_tracks(
     _handle: *mut std::ffi::c_void,
@@ -1436,7 +1436,7 @@ pub unsafe extern "C" fn kuroko_presenter_danmaku_tracks(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_clear_danmaku(
     _handle: *mut std::ffi::c_void,
@@ -1444,7 +1444,7 @@ pub unsafe extern "C" fn kuroko_presenter_clear_danmaku(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_enabled(
     _handle: *mut std::ffi::c_void,
@@ -1453,7 +1453,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_enabled(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config(
     _handle: *mut std::ffi::c_void,
@@ -1462,7 +1462,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     _handle: *mut std::ffi::c_void,
@@ -1474,7 +1474,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
     _handle: *mut std::ffi::c_void,
@@ -1496,7 +1496,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_block_words_json(
     _handle: *mut std::ffi::c_void,
@@ -1508,7 +1508,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_block_words_json(
     KurokoStatus::PlayerError
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_attach_metal_layer(
     handle: *mut KurokoPresenterHandle,
@@ -1527,7 +1527,7 @@ pub unsafe extern "C" fn kuroko_presenter_attach_metal_layer(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_resize_surface(
     handle: *mut KurokoPresenterHandle,
@@ -1540,7 +1540,7 @@ pub unsafe extern "C" fn kuroko_presenter_resize_surface(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_detach_surface(
     handle: *mut KurokoPresenterHandle,
@@ -1550,7 +1550,7 @@ pub unsafe extern "C" fn kuroko_presenter_detach_surface(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_render_tick(
     handle: *mut KurokoPresenterHandle,
@@ -1570,7 +1570,7 @@ pub unsafe extern "C" fn kuroko_presenter_render_tick(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_poll_event(
     handle: *mut KurokoPresenterHandle,
@@ -1602,7 +1602,7 @@ fn with_handle_mut(
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn with_presenter_mut(
     handle: *mut KurokoPresenterHandle,
     f: impl FnOnce(&mut KurokoPresenterHandle) -> KurokoStatus,
@@ -1888,7 +1888,7 @@ fn duration_micros_u64(duration: Duration) -> u64 {
     duration.as_micros().min(u64::MAX as u128) as u64
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn presenter_stats_to_c(stats: PresenterStats) -> KurokoPresenterStats {
     KurokoPresenterStats {
         decoded_video_frames: stats.decoded_video_frames,
@@ -2083,7 +2083,7 @@ mod tests {
         unsafe { kuroko_destroy(handle) };
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn c_presenter_lifecycle_rejects_null_and_can_be_destroyed() {
         assert_eq!(
@@ -2095,7 +2095,7 @@ mod tests {
         unsafe { kuroko_presenter_destroy(handle) };
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn c_presenter_set_volume_accepts_valid_handle() {
         assert_eq!(
@@ -2127,7 +2127,7 @@ mod tests {
         unsafe { kuroko_presenter_destroy(handle) };
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn c_presenter_danmaku_api_loads_configures_and_clears() {
         let handle = kuroko_presenter_create();
@@ -2157,7 +2157,7 @@ mod tests {
         unsafe { kuroko_presenter_destroy(handle) };
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn c_presenter_config_maps_output_modes() {
         assert_eq!(

--- a/crates/kuroko_capi/src/lib.rs
+++ b/crates/kuroko_capi/src/lib.rs
@@ -851,7 +851,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_volume(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_add_external_subtitle(
     handle: *mut KurokoPresenterHandle,
@@ -1336,7 +1336,7 @@ pub unsafe extern "C" fn kuroko_presenter_set_volume(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_load_danmaku_file(
     _handle: *mut std::ffi::c_void,
@@ -2116,7 +2116,7 @@ mod tests {
         unsafe { kuroko_presenter_destroy(handle) };
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     #[test]
     fn c_presenter_can_be_created_with_edr_config() {
         let handle = kuroko_presenter_create_with_config(KurokoPresenterConfig {

--- a/crates/kuroko_capi/src/lib.rs
+++ b/crates/kuroko_capi/src/lib.rs
@@ -705,6 +705,30 @@ fn danmaku_config_from_c(
     }
 }
 
+fn danmaku_config_to_c(config: &DanmakuLayoutConfig) -> KurokoDanmakuConfig {
+    KurokoDanmakuConfig {
+        enabled: config.enabled,
+        font_size: config.font_size,
+        opacity: config.opacity,
+        display_area: config.display_area,
+        scroll_duration_seconds: config.scroll_duration_seconds,
+        scroll_speed_factor: config.scroll_speed_factor,
+        track_gap_ratio: config.track_gap_ratio,
+        outline_width: config.outline_width,
+        shadow_offset_x: config.shadow_offset[0],
+        shadow_offset_y: config.shadow_offset[1],
+        merge_duplicates: config.merge_duplicates,
+        allow_stacking: config.allow_stacking,
+        allow_scroll_overwrite: config.allow_scroll_overwrite,
+        max_quantity: config.max_quantity.unwrap_or(0),
+        max_lines_per_mode: config.max_lines_per_mode.unwrap_or(0),
+        block_top: config.block_top,
+        block_bottom: config.block_bottom,
+        block_scroll: config.block_scroll,
+        shadow_style: config.shadow_style.code(),
+    }
+}
+
 fn danmaku_block_words_from_json(json: &str) -> Result<Vec<String>, KurokoStatus> {
     let value: serde_json::Value =
         serde_json::from_str(json).map_err(|_| KurokoStatus::PlayerError)?;
@@ -812,6 +836,18 @@ pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
 ) -> KurokoStatus {
     with_presenter_mut(handle, |handle| {
         status_from_player_result(handle.presenter.set_playback_rate(rate))
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_set_volume(
+    handle: *mut KurokoPresenterHandle,
+    volume: f64,
+) -> KurokoStatus {
+    with_presenter_mut(handle, |handle| {
+        handle.presenter.set_volume(volume);
+        KurokoStatus::Ok
     })
 }
 
@@ -1143,6 +1179,28 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
 
 #[cfg(target_os = "macos")]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
+    handle: *mut KurokoPresenterHandle,
+    out_config: *mut KurokoDanmakuConfig,
+) -> KurokoStatus {
+    if out_config.is_null() {
+        return KurokoStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        let config = handle
+            .presenter
+            .danmaku_config()
+            .map(danmaku_config_to_c)
+            .unwrap_or_default();
+        unsafe {
+            *out_config = config;
+        }
+        KurokoStatus::Ok
+    })
+}
+
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     handle: *mut KurokoPresenterHandle,
     family: *const c_char,
@@ -1265,6 +1323,15 @@ pub unsafe extern "C" fn kuroko_presenter_tracks(
 pub unsafe extern "C" fn kuroko_presenter_set_playback_rate(
     _handle: *mut std::ffi::c_void,
     _rate: f64,
+) -> KurokoStatus {
+    KurokoStatus::PlayerError
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_set_volume(
+    _handle: *mut std::ffi::c_void,
+    _volume: f64,
 ) -> KurokoStatus {
     KurokoStatus::PlayerError
 }
@@ -1402,6 +1469,18 @@ pub unsafe extern "C" fn kuroko_presenter_set_danmaku_config_ptr(
     config: *const KurokoDanmakuConfig,
 ) -> KurokoStatus {
     if config.is_null() {
+        return KurokoStatus::NullPointer;
+    }
+    KurokoStatus::PlayerError
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
+    _handle: *mut std::ffi::c_void,
+    out_config: *mut KurokoDanmakuConfig,
+) -> KurokoStatus {
+    if out_config.is_null() {
         return KurokoStatus::NullPointer;
     }
     KurokoStatus::PlayerError
@@ -2013,6 +2092,27 @@ mod tests {
         );
         let handle = kuroko_presenter_create();
         assert!(!handle.is_null());
+        unsafe { kuroko_presenter_destroy(handle) };
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn c_presenter_set_volume_accepts_valid_handle() {
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(std::ptr::null_mut(), 0.5) },
+            KurokoStatus::NullPointer
+        );
+
+        let handle = kuroko_presenter_create();
+        assert!(!handle.is_null());
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(handle, 0.5) },
+            KurokoStatus::Ok
+        );
+        assert_eq!(
+            unsafe { kuroko_presenter_set_volume(handle, f64::NAN) },
+            KurokoStatus::Ok
+        );
         unsafe { kuroko_presenter_destroy(handle) };
     }
 

--- a/crates/kuroko_ffmpeg_sys/build.rs
+++ b/crates/kuroko_ffmpeg_sys/build.rs
@@ -28,7 +28,10 @@ fn main() {
     println!("cargo:rustc-link-lib=static=swscale");
     println!("cargo:rustc-link-lib=static=avutil");
 
-    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+    if matches!(
+        env::var("CARGO_CFG_TARGET_OS").as_deref(),
+        Ok("macos" | "ios")
+    ) {
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=framework=CoreMedia");
         println!("cargo:rustc-link-lib=framework=CoreVideo");

--- a/examples/danmaku_perf_lab/Cargo.toml
+++ b/examples/danmaku_perf_lab/Cargo.toml
@@ -6,5 +6,10 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+build = "build.rs"
+
 [dependencies]
 kuroko = { path = "../../crates/kuroko" }
+
+[build-dependencies]
+cc = "1.2.47"

--- a/examples/danmaku_perf_lab/Cargo.toml
+++ b/examples/danmaku_perf_lab/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "danmaku_perf_lab"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+kuroko = { path = "../../crates/kuroko" }

--- a/examples/danmaku_perf_lab/README.md
+++ b/examples/danmaku_perf_lab/README.md
@@ -28,6 +28,41 @@ cargo run -p danmaku_perf_lab -- \
 
 Use `--software` to force software decode when isolating CPU decode load.
 
+## Native Metal window stress
+
+Use release builds for renderer profiling; debug Rust is far too slow for useful
+GPU-path conclusions.
+
+```sh
+cargo run --release -p danmaku_perf_lab -- \
+  --window \
+  --fullscreen \
+  --target-fps 165 \
+  --video /path/to/video.mp4 \
+  --pattern scroll \
+  --rate 600 \
+  --duration 120 \
+  --font-size 16 \
+  --display-area 1.0 \
+  --scroll-duration 10 \
+  --stacking \
+  --window-size 1600x900 \
+  --hide-panel \
+  --surface-scale 1.0 \
+  --metrics-log /tmp/kuroko_lab_stress.jsonl \
+  --auto-exit 18
+```
+
+Use `--uncapped` instead of `--target-fps` for raw throughput tests. In uncapped
+mode the lab disables CAMetalLayer display sync and pumps frames as fast as the
+main run loop can present them; this is useful for renderer stress but noisier
+than a fixed refresh-rate run.
+
+This intentionally creates more visible danmaku than DFM collision avoidance would
+normally allow, so it is a renderer stress case rather than a real-world density
+profile. The JSONL log is the source of truth for performance; the window is only
+for visual sanity checks.
+
 ## Atlas prewarm comparison
 
 ```sh
@@ -48,5 +83,13 @@ cargo run -p danmaku_perf_lab -- \
 - `batched_target_draws`: estimated draw calls after batching shadow/outline/fill passes.
 - `atlas_changes`: number of atlas version changes during sampled frames.
 - `draw_call_reduction_target`: current draw calls divided by expected batched draw calls.
+
+Window JSONL fields worth watching:
+
+- `fps`, `tick_ms`, `pump_ms`, `render_ms`: overall frame health.
+- `video_pump_ms`, `danmaku_plan_ms`: presenter-side decode/import and render-plan cost.
+- `danmaku_vertex_build_ms`, `danmaku_vertex_copy_ms`, `danmaku_encode_ms`: Metal danmaku pass CPU cost.
+- `draw_items_per_new_pass`: glyph instances per newly rendered danmaku pass.
+- `danmaku_vertex_bytes`: bytes written into the Metal instance buffer for the current frame.
 
 This lab is the baseline for Metal/WGPU danmaku batching work.

--- a/examples/danmaku_perf_lab/README.md
+++ b/examples/danmaku_perf_lab/README.md
@@ -1,0 +1,52 @@
+# Kuroko Danmaku Perf Lab
+
+Controlled danmaku performance harness for Kuroko. This is intentionally outside
+NipaPlay so danmaku density, viewport size, media time, video decode, and trace
+output can be varied without Flutter/UI noise.
+
+## Synthetic danmaku load
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --size 1920x1080
+```
+
+## Video-driven media time
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --video /path/to/video.mp4 \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense
+```
+
+Use `--software` to force software decode when isolating CPU decode load.
+
+## Atlas prewarm comparison
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --prewarm-frames 720
+```
+
+## Reading the output
+
+- `prepare_ms`: DFM+ prepare, measurement, filtering, track allocation, collision avoidance.
+- `standalone_frame_layout_ms`: a direct frame query over the prepared layout.
+- `render_plan_total_ms`: frame query plus glyph instance expansion and atlas snapshot access.
+- `current_metal_draws`: estimated current Metal danmaku draw calls with per-glyph shadow/outline/fill.
+- `batched_target_draws`: estimated draw calls after batching shadow/outline/fill passes.
+- `atlas_changes`: number of atlas version changes during sampled frames.
+- `draw_call_reduction_target`: current draw calls divided by expected batched draw calls.
+
+This lab is the baseline for Metal/WGPU danmaku batching work.

--- a/examples/danmaku_perf_lab/build.rs
+++ b/examples/danmaku_perf_lab/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    println!("cargo:rerun-if-changed=native/DanmakuPerfLab.m");
+
+    cc::Build::new()
+        .file("native/DanmakuPerfLab.m")
+        .flag("-fobjc-arc")
+        .flag("-fmodules")
+        .compile("KurokoDanmakuPerfLab");
+
+    println!("cargo:rustc-link-lib=framework=AppKit");
+    println!("cargo:rustc-link-lib=framework=QuartzCore");
+    println!("cargo:rustc-link-lib=framework=Metal");
+}

--- a/examples/danmaku_perf_lab/native/DanmakuPerfLab.m
+++ b/examples/danmaku_perf_lab/native/DanmakuPerfLab.m
@@ -1,0 +1,546 @@
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+extern void kuroko_perf_lab_attach_layer(void *layer, unsigned int width, unsigned int height, double scale);
+extern void kuroko_perf_lab_resize_layer(unsigned int width, unsigned int height, double scale);
+extern void kuroko_perf_lab_render_frame(double host_time_seconds);
+extern bool kuroko_perf_lab_should_auto_exit(void);
+extern void kuroko_perf_lab_toggle_play_pause(void);
+extern void kuroko_perf_lab_seek_seconds(double seconds);
+extern double kuroko_perf_lab_position_seconds(void);
+extern double kuroko_perf_lab_duration_seconds(void);
+extern bool kuroko_perf_lab_is_playing(void);
+extern const char *kuroko_perf_lab_metrics_text(void);
+extern void kuroko_perf_lab_set_density(double comments_per_second);
+extern void kuroko_perf_lab_set_font_size(double font_size);
+extern void kuroko_perf_lab_set_display_area(double display_area);
+extern void kuroko_perf_lab_set_outline(double outline_width);
+extern double kuroko_perf_lab_density(void);
+extern double kuroko_perf_lab_font_size(void);
+extern double kuroko_perf_lab_display_area(void);
+extern double kuroko_perf_lab_outline(void);
+extern double kuroko_perf_lab_window_width(void);
+extern double kuroko_perf_lab_window_height(void);
+extern bool kuroko_perf_lab_fullscreen(void);
+extern bool kuroko_perf_lab_uncapped(void);
+extern double kuroko_perf_lab_target_fps(void);
+extern bool kuroko_perf_lab_hide_panel(void);
+extern double kuroko_perf_lab_surface_scale_override(void);
+extern void kuroko_perf_lab_run_app(void);
+
+static NSString *KurokoLabFormatTime(double seconds) {
+  if (!isfinite(seconds) || seconds < 0.0) {
+    seconds = 0.0;
+  }
+  NSInteger total = (NSInteger)llround(seconds);
+  NSInteger hours = total / 3600;
+  NSInteger minutes = (total / 60) % 60;
+  NSInteger secs = total % 60;
+  if (hours > 0) {
+    return [NSString stringWithFormat:@"%ld:%02ld:%02ld", (long)hours, (long)minutes, (long)secs];
+  }
+  return [NSString stringWithFormat:@"%ld:%02ld", (long)minutes, (long)secs];
+}
+
+@interface KurokoPerfLabVideoView : NSView
+@property(nonatomic, strong) CAMetalLayer *metalLayer;
+@property(nonatomic, strong) NSTimer *timer;
+@property(nonatomic, assign) CFTimeInterval startTime;
+@property(nonatomic, assign) BOOL uncappedPumpActive;
+@end
+
+@implementation KurokoPerfLabVideoView
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    self.wantsLayer = YES;
+    self.metalLayer = [CAMetalLayer layer];
+    self.metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    self.metalLayer.framebufferOnly = YES;
+    self.metalLayer.opaque = YES;
+    if ([self.metalLayer respondsToSelector:@selector(setDisplaySyncEnabled:)]) {
+      self.metalLayer.displaySyncEnabled = !kuroko_perf_lab_uncapped();
+    }
+    self.layer = self.metalLayer;
+    self.startTime = CACurrentMediaTime();
+  }
+  return self;
+}
+
+- (BOOL)wantsUpdateLayer {
+  return YES;
+}
+
+- (void)viewDidMoveToWindow {
+  [super viewDidMoveToWindow];
+  [self updateDrawableSizeAndAttach:YES];
+  if (self.window != nil && self.timer == nil) {
+    if (kuroko_perf_lab_uncapped()) {
+      self.uncappedPumpActive = YES;
+      [self scheduleUncappedRenderTick];
+    } else {
+      double targetFps = kuroko_perf_lab_target_fps();
+      if (!isfinite(targetFps) || targetFps <= 0.0) {
+        targetFps = 60.0;
+      }
+      self.timer = [NSTimer scheduledTimerWithTimeInterval:(1.0 / targetFps)
+                                                    target:self
+                                                  selector:@selector(renderTick:)
+                                                  userInfo:nil
+                                                   repeats:YES];
+      [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
+    }
+  }
+}
+
+- (void)viewWillMoveToWindow:(NSWindow *)newWindow {
+  if (newWindow == nil) {
+    self.uncappedPumpActive = NO;
+    [self.timer invalidate];
+    self.timer = nil;
+  }
+  [super viewWillMoveToWindow:newWindow];
+}
+
+- (void)setFrameSize:(NSSize)newSize {
+  [super setFrameSize:newSize];
+  [self updateDrawableSizeAndAttach:NO];
+}
+
+- (void)viewDidChangeBackingProperties {
+  [super viewDidChangeBackingProperties];
+  [self updateDrawableSizeAndAttach:NO];
+}
+
+- (void)updateDrawableSizeAndAttach:(BOOL)attach {
+  CGFloat scale = self.window.backingScaleFactor > 0 ? self.window.backingScaleFactor : NSScreen.mainScreen.backingScaleFactor;
+  double scaleOverride = kuroko_perf_lab_surface_scale_override();
+  if (isfinite(scaleOverride) && scaleOverride > 0.0) {
+    scale = (CGFloat)scaleOverride;
+  }
+  CGSize drawableSize = CGSizeMake(MAX(1.0, self.bounds.size.width * scale), MAX(1.0, self.bounds.size.height * scale));
+  self.metalLayer.drawableSize = drawableSize;
+  self.metalLayer.frame = self.bounds;
+  if (attach) {
+    kuroko_perf_lab_attach_layer((__bridge void *)self.metalLayer, (unsigned int)self.bounds.size.width, (unsigned int)self.bounds.size.height, scale);
+  } else {
+    kuroko_perf_lab_resize_layer((unsigned int)self.bounds.size.width, (unsigned int)self.bounds.size.height, scale);
+  }
+}
+
+- (void)renderTick:(NSTimer *)timer {
+  (void)timer;
+  kuroko_perf_lab_render_frame(CACurrentMediaTime() - self.startTime);
+  if (kuroko_perf_lab_should_auto_exit()) {
+    [NSApp terminate:nil];
+  }
+}
+
+- (void)scheduleUncappedRenderTick {
+  __weak KurokoPerfLabVideoView *weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    KurokoPerfLabVideoView *strongSelf = weakSelf;
+    if (strongSelf == nil || !strongSelf.uncappedPumpActive || strongSelf.window == nil) {
+      return;
+    }
+    kuroko_perf_lab_render_frame(CACurrentMediaTime() - strongSelf.startTime);
+    if (kuroko_perf_lab_should_auto_exit()) {
+      [NSApp terminate:nil];
+      return;
+    }
+    [strongSelf scheduleUncappedRenderTick];
+  });
+}
+
+@end
+
+@interface KurokoPerfLabSliderRow : NSView
+@property(nonatomic, strong) NSTextField *titleLabel;
+@property(nonatomic, strong) NSSlider *slider;
+@property(nonatomic, strong) NSTextField *valueLabel;
+@end
+
+@implementation KurokoPerfLabSliderRow
+
+- (instancetype)initWithTitle:(NSString *)title min:(double)min max:(double)max value:(double)value target:(id)target action:(SEL)action {
+  self = [super initWithFrame:NSZeroRect];
+  if (self) {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    self.titleLabel = [NSTextField labelWithString:title];
+    self.titleLabel.textColor = [NSColor colorWithWhite:0.78 alpha:1.0];
+    self.titleLabel.font = [NSFont systemFontOfSize:12.0 weight:NSFontWeightMedium];
+    self.titleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.titleLabel];
+
+    self.slider = [[NSSlider alloc] initWithFrame:NSZeroRect];
+    self.slider.minValue = min;
+    self.slider.maxValue = max;
+    self.slider.doubleValue = value;
+    self.slider.continuous = YES;
+    self.slider.target = target;
+    self.slider.action = action;
+    self.slider.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.slider];
+
+    self.valueLabel = [NSTextField labelWithString:@""];
+    self.valueLabel.textColor = NSColor.whiteColor;
+    self.valueLabel.alignment = NSTextAlignmentRight;
+    self.valueLabel.font = [NSFont monospacedDigitSystemFontOfSize:12.0 weight:NSFontWeightRegular];
+    self.valueLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.valueLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+      [self.titleLabel.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+      [self.titleLabel.topAnchor constraintEqualToAnchor:self.topAnchor],
+      [self.titleLabel.widthAnchor constraintEqualToConstant:112.0],
+      [self.slider.leadingAnchor constraintEqualToAnchor:self.titleLabel.trailingAnchor constant:8.0],
+      [self.slider.trailingAnchor constraintEqualToAnchor:self.valueLabel.leadingAnchor constant:-8.0],
+      [self.slider.centerYAnchor constraintEqualToAnchor:self.titleLabel.centerYAnchor],
+      [self.valueLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+      [self.valueLabel.centerYAnchor constraintEqualToAnchor:self.titleLabel.centerYAnchor],
+      [self.valueLabel.widthAnchor constraintEqualToConstant:72.0],
+      [self.heightAnchor constraintEqualToConstant:28.0],
+    ]];
+  }
+  return self;
+}
+
+@end
+
+@interface KurokoPerfLabPanel : NSView
+@property(nonatomic, strong) NSScrollView *metricsScrollView;
+@property(nonatomic, strong) NSTextView *metricsTextView;
+@property(nonatomic, strong) KurokoPerfLabSliderRow *densityRow;
+@property(nonatomic, strong) KurokoPerfLabSliderRow *fontRow;
+@property(nonatomic, strong) KurokoPerfLabSliderRow *areaRow;
+@property(nonatomic, strong) KurokoPerfLabSliderRow *outlineRow;
+@property(nonatomic, strong) NSTimer *timer;
+@end
+
+@implementation KurokoPerfLabPanel
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    self.wantsLayer = YES;
+    self.layer.backgroundColor = [NSColor colorWithWhite:0.075 alpha:1.0].CGColor;
+
+    NSTextField *title = [NSTextField labelWithString:@"Danmaku Perf Lab"];
+    title.textColor = NSColor.whiteColor;
+    title.font = [NSFont systemFontOfSize:18.0 weight:NSFontWeightSemibold];
+    title.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:title];
+
+    self.densityRow = [[KurokoPerfLabSliderRow alloc] initWithTitle:@"Density / s" min:1.0 max:600.0 value:kuroko_perf_lab_density() target:self action:@selector(densityChanged:)];
+    self.fontRow = [[KurokoPerfLabSliderRow alloc] initWithTitle:@"Font size" min:12.0 max:72.0 value:kuroko_perf_lab_font_size() target:self action:@selector(fontChanged:)];
+    self.areaRow = [[KurokoPerfLabSliderRow alloc] initWithTitle:@"Display area" min:0.25 max:1.0 value:kuroko_perf_lab_display_area() target:self action:@selector(areaChanged:)];
+    self.outlineRow = [[KurokoPerfLabSliderRow alloc] initWithTitle:@"Outline" min:0.0 max:5.0 value:kuroko_perf_lab_outline() target:self action:@selector(outlineChanged:)];
+    [self addSubview:self.densityRow];
+    [self addSubview:self.fontRow];
+    [self addSubview:self.areaRow];
+    [self addSubview:self.outlineRow];
+
+    self.metricsScrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+    self.metricsScrollView.hasVerticalScroller = YES;
+    self.metricsScrollView.hasHorizontalScroller = NO;
+    self.metricsScrollView.borderType = NSNoBorder;
+    self.metricsScrollView.drawsBackground = NO;
+    self.metricsScrollView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    self.metricsTextView = [[NSTextView alloc] initWithFrame:NSZeroRect];
+    self.metricsTextView.editable = NO;
+    self.metricsTextView.selectable = YES;
+    self.metricsTextView.drawsBackground = NO;
+    self.metricsTextView.textColor = [NSColor colorWithWhite:0.9 alpha:1.0];
+    self.metricsTextView.font = [NSFont monospacedDigitSystemFontOfSize:12.0 weight:NSFontWeightRegular];
+    self.metricsTextView.textContainerInset = NSMakeSize(0.0, 0.0);
+    self.metricsTextView.textContainer.lineFragmentPadding = 0.0;
+    self.metricsTextView.textContainer.widthTracksTextView = YES;
+    self.metricsTextView.horizontallyResizable = NO;
+    self.metricsTextView.verticallyResizable = YES;
+    self.metricsTextView.autoresizingMask = NSViewWidthSizable;
+    self.metricsScrollView.documentView = self.metricsTextView;
+    [self addSubview:self.metricsScrollView];
+
+    [NSLayoutConstraint activateConstraints:@[
+      [title.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:16.0],
+      [title.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0],
+      [title.topAnchor constraintEqualToAnchor:self.topAnchor constant:16.0],
+      [self.densityRow.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:16.0],
+      [self.densityRow.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0],
+      [self.densityRow.topAnchor constraintEqualToAnchor:title.bottomAnchor constant:16.0],
+      [self.fontRow.leadingAnchor constraintEqualToAnchor:self.densityRow.leadingAnchor],
+      [self.fontRow.trailingAnchor constraintEqualToAnchor:self.densityRow.trailingAnchor],
+      [self.fontRow.topAnchor constraintEqualToAnchor:self.densityRow.bottomAnchor constant:8.0],
+      [self.areaRow.leadingAnchor constraintEqualToAnchor:self.densityRow.leadingAnchor],
+      [self.areaRow.trailingAnchor constraintEqualToAnchor:self.densityRow.trailingAnchor],
+      [self.areaRow.topAnchor constraintEqualToAnchor:self.fontRow.bottomAnchor constant:8.0],
+      [self.outlineRow.leadingAnchor constraintEqualToAnchor:self.densityRow.leadingAnchor],
+      [self.outlineRow.trailingAnchor constraintEqualToAnchor:self.densityRow.trailingAnchor],
+      [self.outlineRow.topAnchor constraintEqualToAnchor:self.areaRow.bottomAnchor constant:8.0],
+      [self.metricsScrollView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:16.0],
+      [self.metricsScrollView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-16.0],
+      [self.metricsScrollView.topAnchor constraintEqualToAnchor:self.outlineRow.bottomAnchor constant:18.0],
+      [self.metricsScrollView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-16.0],
+    ]];
+    [self refreshPanel:nil];
+  }
+  return self;
+}
+
+- (void)viewDidMoveToWindow {
+  [super viewDidMoveToWindow];
+  if (self.window != nil && self.timer == nil) {
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:0.25
+                                                  target:self
+                                                selector:@selector(refreshPanel:)
+                                                userInfo:nil
+                                                 repeats:YES];
+    [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
+  }
+}
+
+- (void)viewWillMoveToWindow:(NSWindow *)newWindow {
+  if (newWindow == nil) {
+    [self.timer invalidate];
+    self.timer = nil;
+  }
+  [super viewWillMoveToWindow:newWindow];
+}
+
+- (void)densityChanged:(NSSlider *)sender {
+  kuroko_perf_lab_set_density(sender.doubleValue);
+  [self refreshPanel:nil];
+}
+
+- (void)fontChanged:(NSSlider *)sender {
+  kuroko_perf_lab_set_font_size(sender.doubleValue);
+  [self refreshPanel:nil];
+}
+
+- (void)areaChanged:(NSSlider *)sender {
+  kuroko_perf_lab_set_display_area(sender.doubleValue);
+  [self refreshPanel:nil];
+}
+
+- (void)outlineChanged:(NSSlider *)sender {
+  kuroko_perf_lab_set_outline(sender.doubleValue);
+  [self refreshPanel:nil];
+}
+
+- (void)refreshPanel:(NSTimer *)timer {
+  (void)timer;
+  self.densityRow.valueLabel.stringValue = [NSString stringWithFormat:@"%.0f", kuroko_perf_lab_density()];
+  self.fontRow.valueLabel.stringValue = [NSString stringWithFormat:@"%.1f", kuroko_perf_lab_font_size()];
+  self.areaRow.valueLabel.stringValue = [NSString stringWithFormat:@"%.2f", kuroko_perf_lab_display_area()];
+  self.outlineRow.valueLabel.stringValue = [NSString stringWithFormat:@"%.1f", kuroko_perf_lab_outline()];
+  const char *metrics = kuroko_perf_lab_metrics_text();
+  self.metricsTextView.string = metrics != NULL ? [NSString stringWithUTF8String:metrics] : @"";
+}
+
+@end
+
+@interface KurokoPerfLabControls : NSView
+@property(nonatomic, strong) NSButton *playPauseButton;
+@property(nonatomic, strong) NSSlider *progressSlider;
+@property(nonatomic, strong) NSTextField *timeLabel;
+@property(nonatomic, strong) NSTimer *timer;
+@property(nonatomic, assign) BOOL scrubbing;
+@end
+
+@implementation KurokoPerfLabControls
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    self.wantsLayer = YES;
+    self.layer.backgroundColor = [NSColor colorWithWhite:0.06 alpha:1.0].CGColor;
+
+    self.playPauseButton = [NSButton buttonWithTitle:@"Pause" target:self action:@selector(togglePlayPause:)];
+    self.playPauseButton.bezelStyle = NSBezelStyleRegularSquare;
+    self.playPauseButton.bordered = NO;
+    self.playPauseButton.wantsLayer = YES;
+    self.playPauseButton.layer.backgroundColor = [NSColor colorWithWhite:0.22 alpha:1.0].CGColor;
+    self.playPauseButton.layer.cornerRadius = 4.0;
+    self.playPauseButton.contentTintColor = NSColor.whiteColor;
+    self.playPauseButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.playPauseButton];
+
+    self.progressSlider = [[NSSlider alloc] initWithFrame:NSZeroRect];
+    self.progressSlider.minValue = 0.0;
+    self.progressSlider.maxValue = 1.0;
+    self.progressSlider.doubleValue = 0.0;
+    self.progressSlider.continuous = YES;
+    self.progressSlider.target = self;
+    self.progressSlider.action = @selector(sliderChanged:);
+    self.progressSlider.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.progressSlider];
+
+    self.timeLabel = [NSTextField labelWithString:@"0:00 / 0:00"];
+    self.timeLabel.textColor = NSColor.whiteColor;
+    self.timeLabel.alignment = NSTextAlignmentRight;
+    self.timeLabel.font = [NSFont monospacedDigitSystemFontOfSize:13.0 weight:NSFontWeightRegular];
+    self.timeLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.timeLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+      [self.playPauseButton.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:12.0],
+      [self.playPauseButton.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [self.playPauseButton.widthAnchor constraintEqualToConstant:84.0],
+      [self.progressSlider.leadingAnchor constraintEqualToAnchor:self.playPauseButton.trailingAnchor constant:12.0],
+      [self.progressSlider.trailingAnchor constraintEqualToAnchor:self.timeLabel.leadingAnchor constant:-12.0],
+      [self.progressSlider.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [self.timeLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-12.0],
+      [self.timeLabel.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [self.timeLabel.widthAnchor constraintEqualToConstant:132.0],
+    ]];
+  }
+  return self;
+}
+
+- (void)viewDidMoveToWindow {
+  [super viewDidMoveToWindow];
+  if (self.window != nil && self.timer == nil) {
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:0.25 target:self selector:@selector(refreshControls:) userInfo:nil repeats:YES];
+    [[NSRunLoop mainRunLoop] addTimer:self.timer forMode:NSRunLoopCommonModes];
+    [self refreshControls:nil];
+  }
+}
+
+- (void)viewWillMoveToWindow:(NSWindow *)newWindow {
+  if (newWindow == nil) {
+    [self.timer invalidate];
+    self.timer = nil;
+  }
+  [super viewWillMoveToWindow:newWindow];
+}
+
+- (void)togglePlayPause:(id)sender {
+  (void)sender;
+  kuroko_perf_lab_toggle_play_pause();
+  [self refreshControls:nil];
+}
+
+- (void)sliderChanged:(NSSlider *)sender {
+  double duration = kuroko_perf_lab_duration_seconds();
+  if (duration <= 0.0 || !isfinite(duration)) {
+    return;
+  }
+  self.scrubbing = YES;
+  kuroko_perf_lab_seek_seconds(sender.doubleValue);
+  [self refreshControls:nil];
+  self.scrubbing = NO;
+}
+
+- (void)refreshControls:(NSTimer *)timer {
+  (void)timer;
+  double duration = kuroko_perf_lab_duration_seconds();
+  double position = kuroko_perf_lab_position_seconds();
+  BOOL hasDuration = duration > 0.0 && isfinite(duration);
+  self.progressSlider.enabled = hasDuration;
+  self.progressSlider.maxValue = hasDuration ? duration : 1.0;
+  if (!self.scrubbing) {
+    self.progressSlider.doubleValue = hasDuration ? MIN(MAX(position, 0.0), duration) : 0.0;
+  }
+  self.playPauseButton.title = kuroko_perf_lab_is_playing() ? @"Pause" : @"Play";
+  self.timeLabel.stringValue = [NSString stringWithFormat:@"%@ / %@", KurokoLabFormatTime(position), KurokoLabFormatTime(duration)];
+}
+
+@end
+
+@interface KurokoPerfLabRootView : NSView
+@property(nonatomic, strong) KurokoPerfLabVideoView *videoView;
+@property(nonatomic, strong) KurokoPerfLabPanel *panelView;
+@property(nonatomic, strong) KurokoPerfLabControls *controlsView;
+@end
+
+@implementation KurokoPerfLabRootView
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    self.wantsLayer = YES;
+    self.layer.backgroundColor = NSColor.blackColor.CGColor;
+
+    self.videoView = [[KurokoPerfLabVideoView alloc] initWithFrame:NSZeroRect];
+    self.videoView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.videoView];
+
+    self.panelView = [[KurokoPerfLabPanel alloc] initWithFrame:NSZeroRect];
+    self.panelView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.panelView];
+
+    self.controlsView = [[KurokoPerfLabControls alloc] initWithFrame:NSZeroRect];
+    self.controlsView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:self.controlsView];
+
+    BOOL hidePanel = kuroko_perf_lab_hide_panel();
+    [NSLayoutConstraint activateConstraints:@[
+      [self.videoView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+      [self.videoView.topAnchor constraintEqualToAnchor:self.topAnchor],
+      [self.videoView.bottomAnchor constraintEqualToAnchor:self.controlsView.topAnchor],
+      [self.videoView.trailingAnchor constraintEqualToAnchor:hidePanel ? self.trailingAnchor : self.panelView.leadingAnchor],
+      [self.panelView.topAnchor constraintEqualToAnchor:self.topAnchor],
+      [self.panelView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+      [self.panelView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+      [self.panelView.widthAnchor constraintEqualToConstant:hidePanel ? 0.0 : 320.0],
+      [self.controlsView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+      [self.controlsView.trailingAnchor constraintEqualToAnchor:self.videoView.trailingAnchor],
+      [self.controlsView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+      [self.controlsView.heightAnchor constraintEqualToConstant:46.0],
+    ]];
+    self.panelView.hidden = hidePanel;
+  }
+  return self;
+}
+
+@end
+
+@interface KurokoPerfLabDelegate : NSObject <NSApplicationDelegate>
+@property(nonatomic, strong) NSWindow *window;
+@end
+
+@implementation KurokoPerfLabDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+  (void)notification;
+  NSRect visibleFrame = NSScreen.mainScreen.visibleFrame;
+  BOOL fullscreen = kuroko_perf_lab_fullscreen();
+  double requestedWidth = kuroko_perf_lab_window_width();
+  double requestedHeight = kuroko_perf_lab_window_height();
+  CGFloat width = fullscreen ? visibleFrame.size.width : (requestedWidth > 0.0 ? MIN((CGFloat)requestedWidth, visibleFrame.size.width * 0.96) : MIN(1280.0, visibleFrame.size.width * 0.90));
+  CGFloat height = fullscreen ? visibleFrame.size.height : (requestedHeight > 0.0 ? MIN((CGFloat)requestedHeight, visibleFrame.size.height * 0.90) : MIN(720.0, visibleFrame.size.height * 0.78));
+  NSRect frame = fullscreen ? visibleFrame : NSMakeRect(NSMidX(visibleFrame) - width * 0.5,
+                                                        NSMidY(visibleFrame) - height * 0.5,
+                                                        width,
+                                                        height);
+  self.window = [[NSWindow alloc] initWithContentRect:frame
+                                            styleMask:(NSWindowStyleMaskTitled |
+                                                       NSWindowStyleMaskClosable |
+                                                       NSWindowStyleMaskMiniaturizable |
+                                                       NSWindowStyleMaskResizable)
+                                              backing:NSBackingStoreBuffered
+                                                defer:NO];
+  self.window.title = @"Kuroko Danmaku Perf Lab";
+  self.window.contentView = [[KurokoPerfLabRootView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
+  [self.window makeKeyAndOrderFront:nil];
+  [NSApp activateIgnoringOtherApps:YES];
+}
+
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+  (void)sender;
+  return YES;
+}
+
+@end
+
+void kuroko_perf_lab_run_app(void) {
+  @autoreleasepool {
+    NSApplication *app = [NSApplication sharedApplication];
+    app.activationPolicy = NSApplicationActivationPolicyRegular;
+    KurokoPerfLabDelegate *delegate = [[KurokoPerfLabDelegate alloc] init];
+    app.delegate = delegate;
+    [app run];
+  }
+}

--- a/examples/danmaku_perf_lab/src/main.rs
+++ b/examples/danmaku_perf_lab/src/main.rs
@@ -1,0 +1,781 @@
+use std::env;
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use kuroko::MediaRequest;
+use kuroko::danmaku::{
+    DanmakuColor, DanmakuItem, DanmakuLayoutConfig, DanmakuMode, DanmakuShadowStyle,
+    DanmakuTimeline, DanmakuViewport, DfmLayoutEngine,
+};
+use kuroko::playback::{PlaybackSessionConfig, VideoDecodePreference, VideoPlaybackEngine};
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let options = parse_args(&args).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        eprintln!(
+            "usage: cargo run -p danmaku_perf_lab -- [--danmaku PATH] [--video PATH] [--software] \
+             [--items N|--rate N] [--duration SECONDS] [--frames N] [--fps N] [--size WxH] \
+             [--prewarm-frames N] \
+             [--font-size N] [--display-area N] [--scroll-duration N] [--pattern mixed|scroll|fixed|dense]"
+        );
+        process::exit(2);
+    });
+
+    match run(options) {
+        Ok(()) => {}
+        Err(error) => {
+            eprintln!("danmaku perf lab failed: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run(options: PerfOptions) -> Result<(), String> {
+    let timeline = load_or_generate_timeline(&options)?;
+    let config = DanmakuLayoutConfig {
+        font_size: options.font_size,
+        display_area: options.display_area,
+        scroll_duration_seconds: options.scroll_duration_seconds,
+        outline_width: options.outline_width,
+        shadow_style: options.shadow_style,
+        merge_duplicates: options.merge_duplicates,
+        allow_stacking: options.allow_stacking,
+        ..DanmakuLayoutConfig::default()
+    };
+    let viewport = DanmakuViewport::new(options.width, options.height);
+    let mut engine = DfmLayoutEngine::new(timeline, config);
+
+    println!("Kuroko danmaku perf lab");
+    println!(
+        "mode: {}",
+        if options.video_uri.is_some() {
+            "video-driven"
+        } else {
+            "synthetic-clock"
+        }
+    );
+    println!(
+        "viewport: {}x{} frames={} fps={:.3} duration={:.3}s",
+        viewport.width, viewport.height, options.frames, options.fps, options.duration_seconds
+    );
+    println!(
+        "danmaku: items={} rate={:.1}/s pattern={:?} font={:.1} display_area={:.2} scroll_dur={:.2}s",
+        options.item_count,
+        options.rate,
+        options.pattern,
+        options.font_size,
+        options.display_area,
+        options.scroll_duration_seconds
+    );
+
+    let prepare_started = Instant::now();
+    let prepared = engine.prepare(viewport, 1);
+    let prepare_elapsed = prepare_started.elapsed();
+    println!(
+        "prepare: {:.3}ms prepared_items={}",
+        ms(prepare_elapsed),
+        prepared.items().len()
+    );
+
+    let prewarm = prewarm_atlas(&mut engine, viewport, &options);
+    if prewarm.frames > 0 {
+        println!(
+            "prewarm: {:.3}ms frames={} glyph_instances={} atlas_version={} atlas_bytes={}",
+            ms(prewarm.elapsed),
+            prewarm.frames,
+            prewarm.glyph_instances,
+            prewarm.atlas_version,
+            prewarm.atlas_bytes
+        );
+    }
+
+    let mut samples = Vec::with_capacity(options.frames);
+    if let Some(uri) = &options.video_uri {
+        run_video_driven(uri, &options, viewport, &mut engine, &mut samples)?;
+    } else {
+        run_synthetic(&options, viewport, &mut engine, &mut samples);
+    }
+
+    print_report(prepare_elapsed, &samples);
+    Ok(())
+}
+
+fn run_synthetic(
+    options: &PerfOptions,
+    viewport: DanmakuViewport,
+    engine: &mut DfmLayoutEngine,
+    samples: &mut Vec<FrameSample>,
+) {
+    for frame_index in 0..options.frames {
+        let media_time = Duration::from_secs_f64(frame_index as f64 / options.fps);
+        samples.push(run_one_frame(
+            engine,
+            viewport,
+            media_time,
+            frame_index as u64 + 1,
+            None,
+        ));
+    }
+}
+
+fn run_video_driven(
+    uri: &str,
+    options: &PerfOptions,
+    viewport: DanmakuViewport,
+    engine: &mut DfmLayoutEngine,
+    samples: &mut Vec<FrameSample>,
+) -> Result<(), String> {
+    let mut playback = VideoPlaybackEngine::open(
+        &MediaRequest::new(uri),
+        PlaybackSessionConfig {
+            video_decode: options.decode_preference,
+            ..PlaybackSessionConfig::default()
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    let info = playback.info();
+    println!(
+        "video: duration={:?} params={:?} decoder={:?}",
+        info.duration, info.video_params, info.video_decode_backend
+    );
+    playback.play();
+    let started = Instant::now();
+    let mut empty_ticks = 0u64;
+    while samples.len() < options.frames {
+        if started.elapsed() > Duration::from_secs(30) {
+            return Err(format!(
+                "timed out waiting for video frames: got {} / {}",
+                samples.len(),
+                options.frames
+            ));
+        }
+        match playback.tick() {
+            Ok(Some(frame)) => {
+                let media_time = frame.pts.unwrap_or(frame.media_time);
+                samples.push(run_one_frame(
+                    engine,
+                    viewport,
+                    media_time,
+                    samples.len() as u64 + 1,
+                    Some(VideoSample {
+                        width: frame.frame.width() as usize,
+                        height: frame.frame.height() as usize,
+                        is_hardware: frame.frame.is_videotoolbox(),
+                        late_by: frame.late_by,
+                    }),
+                ));
+            }
+            Ok(None) => {
+                empty_ticks += 1;
+                thread::sleep(Duration::from_millis(1));
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+    println!("video_ticks: empty={empty_ticks}");
+    Ok(())
+}
+
+fn prewarm_atlas(
+    engine: &mut DfmLayoutEngine,
+    viewport: DanmakuViewport,
+    options: &PerfOptions,
+) -> PrewarmStats {
+    if options.prewarm_frames == 0 {
+        return PrewarmStats::default();
+    }
+    let started = Instant::now();
+    let mut glyph_instances = 0usize;
+    let mut atlas_version = 0u64;
+    let mut atlas_bytes = 0usize;
+    let denominator = options.prewarm_frames.saturating_sub(1).max(1) as f64;
+    for index in 0..options.prewarm_frames {
+        let ratio = index as f64 / denominator;
+        let media_time = Duration::from_secs_f64(options.duration_seconds * ratio);
+        let plan = engine.render_plan(media_time, viewport, index as u64 + 1);
+        glyph_instances = glyph_instances.saturating_add(plan.items.len());
+        if let Some(atlas) = plan.atlas.as_ref() {
+            atlas_version = atlas.version;
+            atlas_bytes = atlas.required_len().saturating_mul(2);
+        }
+    }
+    PrewarmStats {
+        elapsed: started.elapsed(),
+        frames: options.prewarm_frames,
+        glyph_instances,
+        atlas_version,
+        atlas_bytes,
+    }
+}
+
+fn run_one_frame(
+    engine: &mut DfmLayoutEngine,
+    viewport: DanmakuViewport,
+    media_time: Duration,
+    generation: u64,
+    video: Option<VideoSample>,
+) -> FrameSample {
+    let frame_started = Instant::now();
+    let layout_started = Instant::now();
+    let frame_layout = engine.frame_layout(media_time, viewport, generation);
+    let layout_elapsed = layout_started.elapsed();
+
+    let render_started = Instant::now();
+    let plan = engine.render_plan(media_time, viewport, generation);
+    let render_elapsed = render_started.elapsed();
+    let atlas = plan.atlas.as_ref();
+    let glyph_instances = plan.items.len();
+    let visible_items = frame_layout.items.len();
+    let shadow_draws = plan
+        .items
+        .iter()
+        .filter(|item| item.shadow_rgba[3] > 0.0)
+        .count();
+    let outline_draws = plan
+        .items
+        .iter()
+        .filter(|item| item.outline_rgba[3] > 0.0)
+        .count();
+    let fill_draws = glyph_instances;
+
+    FrameSample {
+        media_time,
+        total_elapsed: frame_started.elapsed(),
+        layout_elapsed,
+        render_plan_elapsed: render_elapsed,
+        visible_items,
+        glyph_instances,
+        current_metal_draws: shadow_draws + outline_draws + fill_draws,
+        batched_draws: estimated_batched_draws(shadow_draws, outline_draws, fill_draws),
+        atlas_version: atlas.map_or(0, |atlas| atlas.version),
+        atlas_bytes: atlas.map_or(0, |atlas| atlas.required_len().saturating_mul(2)),
+        video,
+    }
+}
+
+fn estimated_batched_draws(shadow_draws: usize, outline_draws: usize, fill_draws: usize) -> usize {
+    usize::from(shadow_draws > 0) + usize::from(outline_draws > 0) + usize::from(fill_draws > 0)
+}
+
+fn print_report(prepare_elapsed: Duration, samples: &[FrameSample]) {
+    let mut layout = samples
+        .iter()
+        .map(|sample| sample.layout_elapsed)
+        .collect::<Vec<_>>();
+    let mut render_plan = samples
+        .iter()
+        .map(|sample| sample.render_plan_elapsed)
+        .collect::<Vec<_>>();
+    let mut total = samples
+        .iter()
+        .map(|sample| sample.total_elapsed)
+        .collect::<Vec<_>>();
+    let visible = samples
+        .iter()
+        .map(|sample| sample.visible_items)
+        .collect::<Vec<_>>();
+    let glyphs = samples
+        .iter()
+        .map(|sample| sample.glyph_instances)
+        .collect::<Vec<_>>();
+    let current_draws = samples
+        .iter()
+        .map(|sample| sample.current_metal_draws)
+        .collect::<Vec<_>>();
+    let batched_draws = samples
+        .iter()
+        .map(|sample| sample.batched_draws)
+        .collect::<Vec<_>>();
+    let atlas_changes = samples
+        .windows(2)
+        .filter(|pair| pair[0].atlas_version != pair[1].atlas_version)
+        .count()
+        + usize::from(
+            samples
+                .first()
+                .is_some_and(|sample| sample.atlas_version > 0),
+        );
+    let max_atlas_bytes = samples
+        .iter()
+        .map(|sample| sample.atlas_bytes)
+        .max()
+        .unwrap_or(0);
+
+    println!("\nsummary");
+    println!("prepare_ms: {:.3}", ms(prepare_elapsed));
+    print_duration_stats("frame_total_ms", &mut total);
+    print_duration_stats("standalone_frame_layout_ms", &mut layout);
+    print_duration_stats("render_plan_total_ms", &mut render_plan);
+    print_usize_stats("visible_items", &visible);
+    print_usize_stats("glyph_instances", &glyphs);
+    print_usize_stats("current_metal_draws", &current_draws);
+    print_usize_stats("batched_target_draws", &batched_draws);
+    let current_avg = avg_usize(&current_draws);
+    let batched_avg = avg_usize(&batched_draws).max(1.0);
+    println!(
+        "draw_call_reduction_target: {:.1}x fewer draws after batching",
+        current_avg / batched_avg
+    );
+    println!("atlas_changes: {atlas_changes}");
+    println!("atlas_bytes_max: {max_atlas_bytes}");
+
+    if let Some(video) = samples.iter().find_map(|sample| sample.video) {
+        let hardware_frames = samples
+            .iter()
+            .filter(|sample| sample.video.is_some_and(|video| video.is_hardware))
+            .count();
+        let max_late = samples
+            .iter()
+            .filter_map(|sample| sample.video.and_then(|video| video.late_by))
+            .max()
+            .unwrap_or(Duration::ZERO);
+        println!(
+            "video_frames: {} first={}x{} hw_frames={} max_late_ms={:.3}",
+            samples
+                .iter()
+                .filter(|sample| sample.video.is_some())
+                .count(),
+            video.width,
+            video.height,
+            hardware_frames,
+            ms(max_late)
+        );
+    }
+
+    if let Some(worst) = samples
+        .iter()
+        .max_by_key(|sample| sample.render_plan_elapsed)
+    {
+        println!(
+            "worst_render_plan_frame: t={:.3}s render_plan_total_ms={:.3} visible={} glyphs={} atlas_version={}",
+            worst.media_time.as_secs_f64(),
+            ms(worst.render_plan_elapsed),
+            worst.visible_items,
+            worst.glyph_instances,
+            worst.atlas_version
+        );
+    }
+}
+
+fn print_duration_stats(label: &str, values: &mut [Duration]) {
+    values.sort_unstable();
+    println!(
+        "{label}: avg={:.3} p50={:.3} p95={:.3} max={:.3}",
+        ms(avg_duration(values)),
+        ms(percentile_duration(values, 50)),
+        ms(percentile_duration(values, 95)),
+        ms(*values.last().unwrap_or(&Duration::ZERO))
+    );
+}
+
+fn print_usize_stats(label: &str, values: &[usize]) {
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let avg = avg_usize(&sorted);
+    println!(
+        "{label}: avg={avg:.1} p50={} p95={} max={}",
+        percentile_usize(&sorted, 50),
+        percentile_usize(&sorted, 95),
+        sorted.last().copied().unwrap_or(0)
+    );
+}
+
+fn avg_usize(values: &[usize]) -> f64 {
+    if values.is_empty() {
+        0.0
+    } else {
+        values.iter().sum::<usize>() as f64 / values.len() as f64
+    }
+}
+
+fn percentile_duration(values: &[Duration], percentile: usize) -> Duration {
+    if values.is_empty() {
+        return Duration::ZERO;
+    }
+    values[percentile_index(values.len(), percentile)]
+}
+
+fn percentile_usize(values: &[usize], percentile: usize) -> usize {
+    if values.is_empty() {
+        return 0;
+    }
+    values[percentile_index(values.len(), percentile)]
+}
+
+fn percentile_index(len: usize, percentile: usize) -> usize {
+    let percentile = percentile.min(100);
+    (((len - 1) * percentile) + 50) / 100
+}
+
+fn avg_duration(values: &[Duration]) -> Duration {
+    if values.is_empty() {
+        return Duration::ZERO;
+    }
+    let total_ns = values.iter().map(Duration::as_nanos).sum::<u128>();
+    Duration::from_nanos((total_ns / values.len() as u128).min(u64::MAX as u128) as u64)
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn load_or_generate_timeline(options: &PerfOptions) -> Result<DanmakuTimeline, String> {
+    if let Some(path) = &options.danmaku_path {
+        return DanmakuTimeline::from_file(path).map_err(|error| error.to_string());
+    }
+    generate_timeline(options)
+}
+
+fn generate_timeline(options: &PerfOptions) -> Result<DanmakuTimeline, String> {
+    let mut items = Vec::with_capacity(options.item_count);
+    let duration = options.duration_seconds.max(0.001);
+    for index in 0..options.item_count {
+        let time = (index as f64 / options.rate.max(0.001)).min(duration);
+        let mode = mode_for(options.pattern, index);
+        let color = color_for(index);
+        let text = text_for(options.pattern, index);
+        items.push(DanmakuItem {
+            id: index as u64 + 1,
+            pts: Duration::from_secs_f64(time),
+            text,
+            mode,
+            font_size: 25.0,
+            color,
+            opacity: 1.0,
+            is_self: index % 97 == 0,
+        });
+    }
+    DanmakuTimeline::new(items).map_err(|error| error.to_string())
+}
+
+fn mode_for(pattern: PerfPattern, index: usize) -> DanmakuMode {
+    match pattern {
+        PerfPattern::Scroll => DanmakuMode::Scroll,
+        PerfPattern::Fixed => {
+            if index % 2 == 0 {
+                DanmakuMode::Top
+            } else {
+                DanmakuMode::Bottom
+            }
+        }
+        PerfPattern::Dense | PerfPattern::Mixed => match index % 20 {
+            0 | 1 => DanmakuMode::Top,
+            2 => DanmakuMode::Bottom,
+            3 if matches!(pattern, PerfPattern::Mixed) => DanmakuMode::ScrollReverse,
+            _ => DanmakuMode::Scroll,
+        },
+    }
+}
+
+fn text_for(pattern: PerfPattern, index: usize) -> String {
+    const BASE: &[&str] = &[
+        "这句好戳",
+        "现在这条应该跟着画面走",
+        "Kuroko 原生弹幕压测",
+        "seek 后不能回跳",
+        "DFM+ track collision",
+        "莉可丽丝",
+        "画面停弹幕也停",
+        "glyph atlas reuse",
+        "批量绘制前基准",
+        "高密度滚动测试",
+    ];
+    match pattern {
+        PerfPattern::Dense => format!("{} #{:05}", BASE[index % BASE.len()], index),
+        _ => format!("{} {}", BASE[index % BASE.len()], suffix_for(index)),
+    }
+}
+
+fn suffix_for(index: usize) -> &'static str {
+    match index % 8 {
+        0 => "草",
+        1 => "2333",
+        2 => "wwww",
+        3 => "!!!",
+        4 => "x5",
+        5 => "弹幕雨",
+        6 => "同步",
+        _ => "GPU",
+    }
+}
+
+fn color_for(index: usize) -> DanmakuColor {
+    const COLORS: &[(u8, u8, u8)] = &[
+        (255, 255, 255),
+        (255, 218, 86),
+        (101, 220, 255),
+        (255, 112, 169),
+        (122, 255, 159),
+        (218, 189, 255),
+    ];
+    let (red, green, blue) = COLORS[index % COLORS.len()];
+    DanmakuColor::rgb_u8(red, green, blue)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PerfOptions {
+    danmaku_path: Option<String>,
+    video_uri: Option<String>,
+    decode_preference: VideoDecodePreference,
+    item_count: usize,
+    rate: f64,
+    duration_seconds: f64,
+    frames: usize,
+    prewarm_frames: usize,
+    fps: f64,
+    width: u32,
+    height: u32,
+    font_size: f32,
+    display_area: f32,
+    scroll_duration_seconds: f32,
+    outline_width: f32,
+    shadow_style: DanmakuShadowStyle,
+    merge_duplicates: bool,
+    allow_stacking: bool,
+    pattern: PerfPattern,
+}
+
+impl Default for PerfOptions {
+    fn default() -> Self {
+        let duration_seconds = 120.0;
+        let rate = 50.0;
+        Self {
+            danmaku_path: None,
+            video_uri: None,
+            decode_preference: VideoDecodePreference::default(),
+            item_count: (duration_seconds * rate) as usize,
+            rate,
+            duration_seconds,
+            frames: 600,
+            prewarm_frames: 0,
+            fps: 60.0,
+            width: 1920,
+            height: 1080,
+            font_size: 30.0,
+            display_area: 1.0,
+            scroll_duration_seconds: 10.0,
+            outline_width: 1.0,
+            shadow_style: DanmakuShadowStyle::Strong,
+            merge_duplicates: false,
+            allow_stacking: false,
+            pattern: PerfPattern::Mixed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PerfPattern {
+    Mixed,
+    Scroll,
+    Fixed,
+    Dense,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VideoSample {
+    width: usize,
+    height: usize,
+    is_hardware: bool,
+    late_by: Option<Duration>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FrameSample {
+    media_time: Duration,
+    total_elapsed: Duration,
+    layout_elapsed: Duration,
+    render_plan_elapsed: Duration,
+    visible_items: usize,
+    glyph_instances: usize,
+    current_metal_draws: usize,
+    batched_draws: usize,
+    atlas_version: u64,
+    atlas_bytes: usize,
+    video: Option<VideoSample>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct PrewarmStats {
+    elapsed: Duration,
+    frames: usize,
+    glyph_instances: usize,
+    atlas_version: u64,
+    atlas_bytes: usize,
+}
+
+fn parse_args(args: &[String]) -> Result<PerfOptions, String> {
+    let mut options = PerfOptions::default();
+    let mut explicit_items = false;
+    let mut explicit_rate = false;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--danmaku" => options.danmaku_path = Some(next_string(args, &mut index, "--danmaku")?),
+            "--video" => options.video_uri = Some(next_string(args, &mut index, "--video")?),
+            "--software" => options.decode_preference = VideoDecodePreference::Software,
+            "--videotoolbox" => options.decode_preference = VideoDecodePreference::VideoToolbox,
+            "--items" => {
+                options.item_count = next_parse(args, &mut index, "--items")?;
+                explicit_items = true;
+            }
+            "--rate" => {
+                options.rate = next_parse(args, &mut index, "--rate")?;
+                explicit_rate = true;
+            }
+            "--duration" => options.duration_seconds = next_parse(args, &mut index, "--duration")?,
+            "--frames" => options.frames = next_parse(args, &mut index, "--frames")?,
+            "--prewarm-frames" => {
+                options.prewarm_frames = next_parse(args, &mut index, "--prewarm-frames")?
+            }
+            "--fps" => options.fps = next_parse(args, &mut index, "--fps")?,
+            "--size" => {
+                let value = next_string(args, &mut index, "--size")?;
+                let (width, height) = parse_size(&value)?;
+                options.width = width;
+                options.height = height;
+            }
+            "--font-size" => options.font_size = next_parse(args, &mut index, "--font-size")?,
+            "--display-area" => {
+                options.display_area = next_parse(args, &mut index, "--display-area")?
+            }
+            "--scroll-duration" => {
+                options.scroll_duration_seconds = next_parse(args, &mut index, "--scroll-duration")?
+            }
+            "--outline" => options.outline_width = next_parse(args, &mut index, "--outline")?,
+            "--no-shadow" => options.shadow_style = DanmakuShadowStyle::None,
+            "--merge" => options.merge_duplicates = true,
+            "--stacking" => options.allow_stacking = true,
+            "--pattern" => {
+                options.pattern = parse_pattern(&next_string(args, &mut index, "--pattern")?)?
+            }
+            value if value.starts_with("--") => return Err(format!("unknown option: {value}")),
+            value => {
+                if options.video_uri.replace(value.to_string()).is_some() {
+                    return Err("video path was provided more than once".to_string());
+                }
+            }
+        }
+        index += 1;
+    }
+    validate_options(&mut options, explicit_items, explicit_rate)?;
+    Ok(options)
+}
+
+fn validate_options(
+    options: &mut PerfOptions,
+    explicit_items: bool,
+    explicit_rate: bool,
+) -> Result<(), String> {
+    if !options.duration_seconds.is_finite() || options.duration_seconds <= 0.0 {
+        return Err("--duration must be positive and finite".to_string());
+    }
+    if !options.rate.is_finite() || options.rate <= 0.0 {
+        return Err("--rate must be positive and finite".to_string());
+    }
+    if options.frames == 0 {
+        return Err("--frames must be greater than zero".to_string());
+    }
+    if !options.fps.is_finite() || options.fps <= 0.0 {
+        return Err("--fps must be positive and finite".to_string());
+    }
+    if options.width == 0 || options.height == 0 {
+        return Err("--size dimensions must be greater than zero".to_string());
+    }
+    if !options.font_size.is_finite() || options.font_size <= 0.0 {
+        return Err("--font-size must be positive and finite".to_string());
+    }
+    if !options.display_area.is_finite() || options.display_area <= 0.0 {
+        return Err("--display-area must be positive and finite".to_string());
+    }
+    if !options.scroll_duration_seconds.is_finite() || options.scroll_duration_seconds <= 0.0 {
+        return Err("--scroll-duration must be positive and finite".to_string());
+    }
+    if !options.outline_width.is_finite() || options.outline_width < 0.0 {
+        return Err("--outline must be finite and non-negative".to_string());
+    }
+    if !explicit_items && explicit_rate {
+        options.item_count = (options.duration_seconds * options.rate).round() as usize;
+    } else if explicit_items && !explicit_rate {
+        options.rate = options.item_count as f64 / options.duration_seconds;
+    }
+    if options.item_count == 0 {
+        return Err("--items must be greater than zero".to_string());
+    }
+    Ok(())
+}
+
+fn next_string(args: &[String], index: &mut usize, flag: &str) -> Result<String, String> {
+    *index += 1;
+    args.get(*index)
+        .cloned()
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn next_parse<T>(args: &[String], index: &mut usize, flag: &str) -> Result<T, String>
+where
+    T: std::str::FromStr,
+{
+    let value = next_string(args, index, flag)?;
+    value
+        .parse::<T>()
+        .map_err(|_| format!("invalid {flag} value: {value}"))
+}
+
+fn parse_size(value: &str) -> Result<(u32, u32), String> {
+    let Some((width, height)) = value.split_once('x').or_else(|| value.split_once('X')) else {
+        return Err("--size must look like 1920x1080".to_string());
+    };
+    let width = width
+        .parse::<u32>()
+        .map_err(|_| format!("invalid width in --size: {value}"))?;
+    let height = height
+        .parse::<u32>()
+        .map_err(|_| format!("invalid height in --size: {value}"))?;
+    Ok((width, height))
+}
+
+fn parse_pattern(value: &str) -> Result<PerfPattern, String> {
+    match value {
+        "mixed" => Ok(PerfPattern::Mixed),
+        "scroll" => Ok(PerfPattern::Scroll),
+        "fixed" => Ok(PerfPattern::Fixed),
+        "dense" => Ok(PerfPattern::Dense),
+        _ => Err(format!("unknown pattern: {value}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_derives_items_from_rate_and_duration() {
+        let options = parse_args(&[
+            "--rate".to_string(),
+            "100".to_string(),
+            "--duration".to_string(),
+            "10".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(options.item_count, 1000);
+        assert_eq!(options.rate, 100.0);
+    }
+
+    #[test]
+    fn parse_args_accepts_size_and_pattern() {
+        let options = parse_args(&[
+            "--size".to_string(),
+            "1280x720".to_string(),
+            "--pattern".to_string(),
+            "dense".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(options.width, 1280);
+        assert_eq!(options.height, 720);
+        assert_eq!(options.pattern, PerfPattern::Dense);
+    }
+}

--- a/examples/danmaku_perf_lab/src/main.rs
+++ b/examples/danmaku_perf_lab/src/main.rs
@@ -1,24 +1,47 @@
+use std::cell::RefCell;
 use std::env;
+use std::ffi::CString;
+use std::ffi::c_void;
+use std::fs::File;
+use std::io::{BufWriter, Write};
 use std::process;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use kuroko::MediaRequest;
+use kuroko::core::PlayerConfig;
 use kuroko::danmaku::{
-    DanmakuColor, DanmakuItem, DanmakuLayoutConfig, DanmakuMode, DanmakuShadowStyle,
-    DanmakuTimeline, DanmakuViewport, DfmLayoutEngine,
+    DanmakuColor, DanmakuFrameStats, DanmakuItem, DanmakuLayoutConfig, DanmakuMode,
+    DanmakuShadowStyle, DanmakuTimeline, DanmakuViewport, DfmLayoutEngine,
 };
 use kuroko::playback::{PlaybackSessionConfig, VideoDecodePreference, VideoPlaybackEngine};
+use kuroko::presenter::{PresenterConfig, PresenterRuntime};
+use kuroko::renderer::metal::MetalRendererConfig;
+use kuroko::{MediaRequest, MetalSurfaceHandle, PlatformSurface};
+
+unsafe extern "C" {
+    fn kuroko_perf_lab_run_app();
+}
+
+static WINDOW_OPTIONS: OnceLock<PerfOptions> = OnceLock::new();
+static METRICS_TEXT: Mutex<Option<CString>> = Mutex::new(None);
+
+thread_local! {
+    static LAB: RefCell<Option<WindowLabState>> = const { RefCell::new(None) };
+}
 
 fn main() {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let options = parse_args(&args).unwrap_or_else(|error| {
         eprintln!("{error}");
         eprintln!(
-            "usage: cargo run -p danmaku_perf_lab -- [--danmaku PATH] [--video PATH] [--software] \
+            "usage: cargo run -p danmaku_perf_lab -- [--window] [--fullscreen] [--uncapped] [--danmaku PATH] [--video PATH] [--software] \
              [--items N|--rate N] [--duration SECONDS] [--frames N] [--fps N] [--size WxH] \
              [--prewarm-frames N] \
-             [--font-size N] [--display-area N] [--scroll-duration N] [--pattern mixed|scroll|fixed|dense]"
+             [--font-size N] [--display-area N] [--scroll-duration N] [--scroll-overwrite] \
+             [--window-size WxH] [--hide-panel] [--surface-scale N] [--target-fps N] \
+             [--start-time SECONDS] [--self-every N] [--metrics-log PATH] [--auto-exit SECONDS] \
+             [--pattern mixed|scroll|fixed|dense]"
         );
         process::exit(2);
     });
@@ -33,6 +56,9 @@ fn main() {
 }
 
 fn run(options: PerfOptions) -> Result<(), String> {
+    if options.window {
+        return run_window(options);
+    }
     let timeline = load_or_generate_timeline(&options)?;
     let config = DanmakuLayoutConfig {
         font_size: options.font_size,
@@ -42,6 +68,7 @@ fn run(options: PerfOptions) -> Result<(), String> {
         shadow_style: options.shadow_style,
         merge_duplicates: options.merge_duplicates,
         allow_stacking: options.allow_stacking,
+        allow_scroll_overwrite: options.allow_scroll_overwrite,
         ..DanmakuLayoutConfig::default()
     };
     let viewport = DanmakuViewport::new(options.width, options.height);
@@ -57,26 +84,52 @@ fn run(options: PerfOptions) -> Result<(), String> {
         }
     );
     println!(
-        "viewport: {}x{} frames={} fps={:.3} duration={:.3}s",
-        viewport.width, viewport.height, options.frames, options.fps, options.duration_seconds
+        "viewport: {}x{} frames={} fps={:.3} duration={:.3}s start={:.3}s",
+        viewport.width,
+        viewport.height,
+        options.frames,
+        options.fps,
+        options.duration_seconds,
+        options.start_time_seconds
     );
     println!(
-        "danmaku: items={} rate={:.1}/s pattern={:?} font={:.1} display_area={:.2} scroll_dur={:.2}s",
+        "danmaku: items={} rate={:.1}/s pattern={:?} font={:.1} display_area={:.2} scroll_dur={:.2}s self_every={}",
         options.item_count,
         options.rate,
         options.pattern,
         options.font_size,
         options.display_area,
-        options.scroll_duration_seconds
+        options.scroll_duration_seconds,
+        format_self_every(options.self_every)
     );
 
     let prepare_started = Instant::now();
     let prepared = engine.prepare(viewport, 1);
     let prepare_elapsed = prepare_started.elapsed();
+    let prepared_stats = prepared.stats();
     println!(
         "prepare: {:.3}ms prepared_items={}",
         ms(prepare_elapsed),
         prepared.items().len()
+    );
+    println!(
+        "prepare_sensor: source/supported/prepared/filtered={}/{}/{}/{} scroll/top/bottom={}/{}/{} expected/dfm_tracks={}/{} scroll_rows={} y={:.0}..{:.0} buckets={}",
+        prepared_stats.source_items,
+        prepared_stats.supported_items,
+        prepared_stats.prepared_items,
+        prepared_stats.filtered_items,
+        prepared_stats.prepared_scroll_items,
+        prepared_stats.prepared_top_items,
+        prepared_stats.prepared_bottom_items,
+        prepared_stats.expected_scroll_tracks,
+        prepared_stats.dfm_track_count,
+        prepared_stats.prepared_scroll_rows,
+        prepared_stats.prepared_scroll_min_y,
+        prepared_stats.prepared_scroll_max_y,
+        format_buckets(
+            prepared_stats.scroll_bucket_count,
+            &prepared_stats.scroll_buckets
+        ),
     );
 
     let prewarm = prewarm_atlas(&mut engine, viewport, &options);
@@ -102,6 +155,14 @@ fn run(options: PerfOptions) -> Result<(), String> {
     Ok(())
 }
 
+fn run_window(options: PerfOptions) -> Result<(), String> {
+    WINDOW_OPTIONS
+        .set(options)
+        .map_err(|_| "window options already initialized".to_string())?;
+    unsafe { kuroko_perf_lab_run_app() };
+    Ok(())
+}
+
 fn run_synthetic(
     options: &PerfOptions,
     viewport: DanmakuViewport,
@@ -109,7 +170,9 @@ fn run_synthetic(
     samples: &mut Vec<FrameSample>,
 ) {
     for frame_index in 0..options.frames {
-        let media_time = Duration::from_secs_f64(frame_index as f64 / options.fps);
+        let media_time = Duration::from_secs_f64(
+            options.start_time_seconds + frame_index as f64 / options.fps,
+        );
         samples.push(run_one_frame(
             engine,
             viewport,
@@ -178,6 +241,622 @@ fn run_video_driven(
     Ok(())
 }
 
+struct WindowLabState {
+    presenter: PresenterRuntime,
+    options: PerfOptions,
+    media_opened: bool,
+    started_at: Instant,
+    fps: f64,
+    last_fps_update: Instant,
+    last_presented_frames: u64,
+    metrics_log: Option<BufWriter<File>>,
+    last_metrics_log: Instant,
+    last_logged_danmaku_passes: u64,
+    last_logged_danmaku_draw_items: u64,
+    last_error: Option<String>,
+}
+
+impl WindowLabState {
+    fn new(options: PerfOptions) -> Result<Self, String> {
+        let timeline = load_or_generate_timeline(&options)?;
+        let presenter = PresenterRuntime::new(PresenterConfig {
+            player: PlayerConfig {
+                playback: PlaybackSessionConfig {
+                    video_decode: options.decode_preference,
+                    ..PlaybackSessionConfig::default()
+                },
+                ..PlayerConfig::default()
+            },
+            renderer: MetalRendererConfig::default(),
+            danmaku: Some(timeline),
+            danmaku_config: layout_config_from_options(&options),
+            ..PresenterConfig::default()
+        })
+        .map_err(|error| error.to_string())?;
+        let metrics_log = match options.metrics_log_path.as_deref() {
+            Some(path) => Some(BufWriter::new(
+                File::create(path).map_err(|error| format!("metrics log create failed: {error}"))?,
+            )),
+            None => None,
+        };
+        let now = Instant::now();
+        Ok(Self {
+            presenter,
+            options,
+            media_opened: false,
+            started_at: now,
+            fps: 0.0,
+            last_fps_update: now,
+            last_presented_frames: 0,
+            metrics_log,
+            last_metrics_log: now,
+            last_logged_danmaku_passes: 0,
+            last_logged_danmaku_draw_items: 0,
+            last_error: None,
+        })
+    }
+
+    fn attach_surface(&mut self, layer: *mut c_void, width: u32, height: u32, scale: f64) {
+        let surface =
+            PlatformSurface::Metal(MetalSurfaceHandle::new(layer as u64, width, height, scale));
+        match self.presenter.attach_surface(surface) {
+            Ok(()) => self.ensure_media_opened(),
+            Err(error) => self.last_error = Some(format!("attach failed: {error}")),
+        }
+    }
+
+    fn resize_surface(&mut self, width: u32, height: u32, scale: f64) {
+        if let Err(error) = self.presenter.resize_surface(width, height, scale) {
+            self.last_error = Some(format!("resize failed: {error}"));
+        }
+    }
+
+    fn render_tick(&mut self, host_time_seconds: f64) {
+        self.ensure_media_opened();
+        if let Err(error) = self.presenter.render_tick(host_time_seconds) {
+            self.last_error = Some(format!("render failed: {error}"));
+        }
+        self.update_fps();
+        self.log_metrics_if_due();
+    }
+
+    fn should_auto_exit(&self) -> bool {
+        self.options
+            .auto_exit_seconds
+            .is_some_and(|seconds| self.started_at.elapsed().as_secs_f64() >= seconds)
+    }
+
+    fn ensure_media_opened(&mut self) {
+        if self.media_opened {
+            return;
+        }
+        self.media_opened = true;
+        let Some(uri) = self.options.video_uri.clone() else {
+            return;
+        };
+        match self.presenter.open(MediaRequest::new(uri)) {
+            Ok(()) => {
+                if self.options.start_time_seconds > 0.0 {
+                    if let Err(error) = self
+                        .presenter
+                        .seek(Duration::from_secs_f64(self.options.start_time_seconds))
+                    {
+                        self.last_error = Some(format!("initial seek failed: {error}"));
+                    }
+                }
+                if let Err(error) = self.presenter.play() {
+                    self.last_error = Some(format!("play failed: {error}"));
+                }
+            }
+            Err(error) => self.last_error = Some(format!("open failed: {error}")),
+        }
+    }
+
+    fn toggle_play_pause(&mut self) {
+        let result = if self.presenter.is_playing() {
+            self.presenter.pause()
+        } else {
+            self.presenter.play()
+        };
+        if let Err(error) = result {
+            self.last_error = Some(format!("play/pause failed: {error}"));
+        }
+    }
+
+    fn seek(&mut self, seconds: f64) {
+        if !seconds.is_finite() || seconds < 0.0 {
+            return;
+        }
+        if let Err(error) = self.presenter.seek(Duration::from_secs_f64(seconds)) {
+            self.last_error = Some(format!("seek failed: {error}"));
+        }
+    }
+
+    fn set_density(&mut self, comments_per_second: f64) {
+        let comments_per_second = comments_per_second.clamp(1.0, 2_000.0);
+        self.options.rate = comments_per_second;
+        self.options.item_count =
+            (self.options.duration_seconds * comments_per_second).round() as usize;
+        match generate_timeline(&self.options) {
+            Ok(timeline) => self.presenter.set_danmaku_timeline(timeline),
+            Err(error) => self.last_error = Some(format!("danmaku regenerate failed: {error}")),
+        }
+    }
+
+    fn set_font_size(&mut self, font_size: f64) {
+        self.options.font_size = font_size.clamp(8.0, 120.0) as f32;
+        self.apply_config();
+    }
+
+    fn set_display_area(&mut self, display_area: f64) {
+        self.options.display_area = display_area.clamp(0.05, 1.0) as f32;
+        self.apply_config();
+    }
+
+    fn set_outline(&mut self, outline_width: f64) {
+        self.options.outline_width = outline_width.clamp(0.0, 12.0) as f32;
+        self.apply_config();
+    }
+
+    fn apply_config(&mut self) {
+        self.presenter
+            .set_danmaku_config(layout_config_from_options(&self.options));
+    }
+
+    fn update_fps(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_fps_update);
+        if elapsed < Duration::from_millis(250) {
+            return;
+        }
+        let snapshot = self.presenter.runtime_snapshot();
+        let presented = snapshot
+            .stats
+            .rendered_video_frames
+            .saturating_add(snapshot.stats.rendered_test_frames);
+        let delta = presented.saturating_sub(self.last_presented_frames);
+        self.fps = delta as f64 / elapsed.as_secs_f64().max(0.001);
+        self.last_presented_frames = presented;
+        self.last_fps_update = now;
+    }
+
+    fn metrics_text(&mut self) -> String {
+        self.update_fps();
+        let snapshot = self.presenter.runtime_snapshot();
+        let stats = snapshot.stats;
+        let renderer = snapshot.renderer;
+        let duration = self.presenter.duration().unwrap_or(Duration::ZERO);
+        let draw_ratio = if renderer.danmaku_passes > 0 {
+            renderer.danmaku_draw_items as f64 / renderer.danmaku_passes as f64
+        } else {
+            0.0
+        };
+        let atlas_mb = snapshot.current_danmaku_atlas_bytes as f64 / (1024.0 * 1024.0);
+        let error = self.last_error.as_deref().unwrap_or("-");
+        let prepared = snapshot.current_danmaku_prepared;
+        let prepared_buckets =
+            format_buckets(prepared.scroll_bucket_count, &prepared.scroll_buckets);
+        let frame_buckets = format_buckets(
+            snapshot.current_danmaku_scroll_bucket_count,
+            &snapshot.current_danmaku_scroll_buckets,
+        );
+        format!(
+            "Playback\n  fps: {fps:.1}\n  media: {media:.3}s / {duration:.3}s\n  generation: {generation}\n  state: {state}\n\nTick timings\n  total: {tick:.3} ms\n  pump/layout: {pump:.3} ms\n  render: {render:.3} ms\n\nDanmaku load\n  pattern: {pattern:?}\n  density: {density:.0}/s\n  items: {items}\n  font/area: {font:.1} / {area:.2}\n  scroll dur: {scroll_dur:.2}s\n  self every: {self_every}\n  stacking/overwrite: {stacking}/{overwrite}\n  visible glyph quads: {glyphs}\n  placed items: {placed}\n  scroll/top/bottom: {scroll}/{top}/{bottom}\n\nScroll frame sensor\n  rows: {scroll_rows}\n  tracks: {track_min}..{track_max}\n  y span: {scroll_min:.0}..{scroll_max:.0}\n  buckets: {frame_buckets}\n\nPrepared sensor\n  source/supported/prepared/filtered: {src}/{supported}/{prep}/{filtered}\n  scroll/top/bottom: {prep_scroll}/{prep_top}/{prep_bottom}\n  expected/dfm tracks: {expected_tracks}/{dfm_tracks}\n  area h scroll/display: {scroll_area:.0}/{display_area_h:.0}\n  track h: {track_h:.1}\n  scroll rows: {prep_rows}\n  scroll y span: {prep_min:.0}..{prep_max:.0}\n  buckets: {prepared_buckets}\n\nViewport/atlas\n  viewport: {dw}x{dh}\n  atlas: v{atlas_version} {atlas_mb:.2} MiB\n\nRenderer\n  surface: {sw}x{sh}\n  rendered video: {rendered_video}\n  rendered test: {rendered_test}\n  danmaku passes: {passes}\n  danmaku draw items: {draw_items}\n  draw items/pass: {draw_ratio:.1}\n  atlas uploads: {uploads}\n  atlas reuses: {reuses}\n\nDecoder / queues\n  decoded video: {decoded_video}\n  pushed audio: {pushed_audio}\n  import failures: {import_failures}\n  render failures: {render_failures}\n  audio failures: {audio_failures}\n\nError\n  {error}",
+            fps = self.fps,
+            media = snapshot.media_time.as_secs_f64(),
+            duration = duration.as_secs_f64(),
+            generation = snapshot.generation,
+            state = if snapshot.playing {
+                "playing"
+            } else {
+                "paused"
+            },
+            tick = ms(snapshot.last_tick_duration),
+            pump = ms(snapshot.last_pump_duration),
+            render = ms(snapshot.last_render_duration),
+            pattern = self.options.pattern,
+            density = self.options.rate,
+            items = self.options.item_count,
+            font = self.options.font_size,
+            area = self.options.display_area,
+            scroll_dur = self.options.scroll_duration_seconds,
+            self_every = format_self_every(self.options.self_every),
+            stacking = self.options.allow_stacking,
+            overwrite = self.options.allow_scroll_overwrite,
+            glyphs = snapshot.current_danmaku_items,
+            placed = snapshot.current_danmaku_placed_items,
+            scroll = snapshot.current_danmaku_scroll_items,
+            top = snapshot.current_danmaku_top_items,
+            bottom = snapshot.current_danmaku_bottom_items,
+            scroll_rows = snapshot.current_danmaku_scroll_rows,
+            track_min = snapshot.current_danmaku_scroll_track_min,
+            track_max = snapshot.current_danmaku_scroll_track_max,
+            scroll_min = snapshot.current_danmaku_scroll_min_y,
+            scroll_max = snapshot.current_danmaku_scroll_max_y,
+            frame_buckets = frame_buckets,
+            src = prepared.source_items,
+            supported = prepared.supported_items,
+            prep = prepared.prepared_items,
+            filtered = prepared.filtered_items,
+            prep_scroll = prepared.prepared_scroll_items,
+            prep_top = prepared.prepared_top_items,
+            prep_bottom = prepared.prepared_bottom_items,
+            expected_tracks = prepared.expected_scroll_tracks,
+            dfm_tracks = prepared.dfm_track_count,
+            scroll_area = prepared.scroll_area_height,
+            display_area_h = prepared.display_area_height,
+            track_h = prepared.track_height,
+            prep_rows = prepared.prepared_scroll_rows,
+            prep_min = prepared.prepared_scroll_min_y,
+            prep_max = prepared.prepared_scroll_max_y,
+            prepared_buckets = prepared_buckets,
+            dw = snapshot.current_danmaku_viewport_width,
+            dh = snapshot.current_danmaku_viewport_height,
+            atlas_version = snapshot.current_danmaku_atlas_version,
+            atlas_mb = atlas_mb,
+            sw = renderer.surface_width,
+            sh = renderer.surface_height,
+            rendered_video = stats.rendered_video_frames,
+            rendered_test = stats.rendered_test_frames,
+            passes = renderer.danmaku_passes,
+            draw_items = renderer.danmaku_draw_items,
+            uploads = renderer.overlay_alpha_atlas_uploads,
+            reuses = renderer.overlay_alpha_atlas_reuses,
+            decoded_video = stats.decoded_video_frames,
+            pushed_audio = stats.pushed_audio_frames,
+            import_failures = stats.import_failures,
+            render_failures = stats.render_failures,
+            audio_failures = stats.audio_failures,
+        )
+    }
+
+    fn log_metrics_if_due(&mut self) {
+        if self.metrics_log.is_none() {
+            return;
+        }
+        let now = Instant::now();
+        if now.duration_since(self.last_metrics_log) < Duration::from_millis(250) {
+            return;
+        }
+        self.last_metrics_log = now;
+        let line = self.metrics_json_line(now);
+        if let Some(log) = &mut self.metrics_log {
+            if let Err(error) = writeln!(log, "{line}").and_then(|_| log.flush()) {
+                self.last_error = Some(format!("metrics log write failed: {error}"));
+            }
+        }
+    }
+
+    fn metrics_json_line(&mut self, now: Instant) -> String {
+        self.update_fps();
+        let snapshot = self.presenter.runtime_snapshot();
+        let stats = snapshot.stats;
+        let renderer = snapshot.renderer;
+        let duration = self.presenter.duration().unwrap_or(Duration::ZERO);
+        let new_danmaku_passes = renderer
+            .danmaku_passes
+            .saturating_sub(self.last_logged_danmaku_passes);
+        let new_danmaku_draw_items = renderer
+            .danmaku_draw_items
+            .saturating_sub(self.last_logged_danmaku_draw_items);
+        self.last_logged_danmaku_passes = renderer.danmaku_passes;
+        self.last_logged_danmaku_draw_items = renderer.danmaku_draw_items;
+        format!(
+            "{{\"elapsed_s\":{elapsed:.3},\"fps\":{fps:.3},\"target_fps\":{target_fps:.3},\"uncapped\":{uncapped},\"media_s\":{media:.3},\"duration_s\":{duration:.3},\"generation\":{generation},\"playing\":{playing},\"tick_ms\":{tick:.3},\"pump_ms\":{pump:.3},\"audio_pump_ms\":{audio_pump:.3},\"subtitle_pump_ms\":{subtitle_pump:.3},\"video_pump_ms\":{video_pump:.3},\"clock_sync_ms\":{clock_sync:.3},\"danmaku_plan_ms\":{danmaku_plan:.3},\"render_ms\":{render:.3},\"render_current_ms\":{render_current:.3},\"render_test_ms\":{render_test:.3},\"density\":{density:.3},\"items\":{items},\"font_size\":{font:.3},\"display_area\":{area:.3},\"scroll_duration_s\":{scroll_dur:.3},\"self_every\":{self_every},\"visible_glyph_quads\":{glyphs},\"placed_items\":{placed},\"scroll_items\":{scroll},\"top_items\":{top},\"bottom_items\":{bottom},\"scroll_rows\":{scroll_rows},\"scroll_track_min\":{track_min},\"scroll_track_max\":{track_max},\"atlas_version\":{atlas_version},\"atlas_bytes\":{atlas_bytes},\"surface_width\":{sw},\"surface_height\":{sh},\"rendered_video\":{rendered_video},\"rendered_test\":{rendered_test},\"danmaku_passes\":{passes},\"danmaku_draw_items\":{draw_items},\"draw_items_per_pass\":{draw_ratio:.3},\"danmaku_passes_delta\":{passes_delta},\"danmaku_draw_items_delta\":{draw_items_delta},\"draw_items_per_new_pass\":{draw_ratio_delta:.3},\"danmaku_atlas_ms\":{danmaku_atlas:.3},\"danmaku_vertex_build_ms\":{danmaku_vertex_build:.3},\"danmaku_vertex_copy_ms\":{danmaku_vertex_copy:.3},\"danmaku_encode_ms\":{danmaku_encode:.3},\"danmaku_vertex_bytes\":{danmaku_vertex_bytes},\"danmaku_vertex_count\":{danmaku_vertex_count},\"atlas_uploads\":{uploads},\"atlas_reuses\":{reuses},\"decoded_video\":{decoded_video},\"pushed_audio\":{pushed_audio},\"import_failures\":{import_failures},\"render_failures\":{render_failures},\"audio_failures\":{audio_failures},\"error\":\"{error}\"}}",
+            elapsed = now.duration_since(self.started_at).as_secs_f64(),
+            fps = self.fps,
+            target_fps = self.options.target_fps,
+            uncapped = self.options.uncapped,
+            media = snapshot.media_time.as_secs_f64(),
+            duration = duration.as_secs_f64(),
+            generation = snapshot.generation,
+            playing = snapshot.playing,
+            tick = ms(snapshot.last_tick_duration),
+            pump = ms(snapshot.last_pump_duration),
+            audio_pump = ms(snapshot.last_audio_pump_duration),
+            subtitle_pump = ms(snapshot.last_subtitle_pump_duration),
+            video_pump = ms(snapshot.last_video_pump_duration),
+            clock_sync = ms(snapshot.last_clock_sync_duration),
+            danmaku_plan = ms(snapshot.last_danmaku_plan_duration),
+            render = ms(snapshot.last_render_duration),
+            render_current = ms(snapshot.last_render_current_duration),
+            render_test = ms(snapshot.last_render_test_duration),
+            density = self.options.rate,
+            items = self.options.item_count,
+            font = self.options.font_size,
+            area = self.options.display_area,
+            scroll_dur = self.options.scroll_duration_seconds,
+            self_every = self.options.self_every.unwrap_or(0),
+            glyphs = snapshot.current_danmaku_items,
+            placed = snapshot.current_danmaku_placed_items,
+            scroll = snapshot.current_danmaku_scroll_items,
+            top = snapshot.current_danmaku_top_items,
+            bottom = snapshot.current_danmaku_bottom_items,
+            scroll_rows = snapshot.current_danmaku_scroll_rows,
+            track_min = snapshot.current_danmaku_scroll_track_min,
+            track_max = snapshot.current_danmaku_scroll_track_max,
+            atlas_version = snapshot.current_danmaku_atlas_version,
+            atlas_bytes = snapshot.current_danmaku_atlas_bytes,
+            sw = renderer.surface_width,
+            sh = renderer.surface_height,
+            rendered_video = stats.rendered_video_frames,
+            rendered_test = stats.rendered_test_frames,
+            passes = renderer.danmaku_passes,
+            draw_items = renderer.danmaku_draw_items,
+            draw_ratio = if renderer.danmaku_passes > 0 {
+                renderer.danmaku_draw_items as f64 / renderer.danmaku_passes as f64
+            } else {
+                0.0
+            },
+            passes_delta = new_danmaku_passes,
+            draw_items_delta = new_danmaku_draw_items,
+            draw_ratio_delta = if new_danmaku_passes > 0 {
+                new_danmaku_draw_items as f64 / new_danmaku_passes as f64
+            } else {
+                0.0
+            },
+            danmaku_atlas = ms(renderer.last_danmaku_atlas_duration),
+            danmaku_vertex_build = ms(renderer.last_danmaku_vertex_build_duration),
+            danmaku_vertex_copy = ms(renderer.last_danmaku_vertex_copy_duration),
+            danmaku_encode = ms(renderer.last_danmaku_encode_duration),
+            danmaku_vertex_bytes = renderer.last_danmaku_vertex_bytes,
+            danmaku_vertex_count = renderer.last_danmaku_vertex_count,
+            uploads = renderer.overlay_alpha_atlas_uploads,
+            reuses = renderer.overlay_alpha_atlas_reuses,
+            decoded_video = stats.decoded_video_frames,
+            pushed_audio = stats.pushed_audio_frames,
+            import_failures = stats.import_failures,
+            render_failures = stats.render_failures,
+            audio_failures = stats.audio_failures,
+            error = json_escape(self.last_error.as_deref().unwrap_or("")),
+        )
+    }
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            ch if ch.is_control() => escaped.push_str(&format!("\\u{:04x}", ch as u32)),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn layout_config_from_options(options: &PerfOptions) -> DanmakuLayoutConfig {
+    DanmakuLayoutConfig {
+        font_size: options.font_size,
+        display_area: options.display_area,
+        scroll_duration_seconds: options.scroll_duration_seconds,
+        outline_width: options.outline_width,
+        shadow_style: options.shadow_style,
+        merge_duplicates: options.merge_duplicates,
+        allow_stacking: options.allow_stacking,
+        allow_scroll_overwrite: options.allow_scroll_overwrite,
+        ..DanmakuLayoutConfig::default()
+    }
+}
+
+fn format_buckets(
+    count: usize,
+    buckets: &[kuroko::danmaku::DanmakuDebugBucket; kuroko::danmaku::DANMAKU_DEBUG_BUCKETS],
+) -> String {
+    if count == 0 {
+        return "-".to_string();
+    }
+    let mut parts = Vec::new();
+    for bucket in buckets.iter().take(count.min(buckets.len())) {
+        if bucket.count == 0 {
+            continue;
+        }
+        parts.push(format!("{}:{}", bucket.key, bucket.count));
+    }
+    if count > buckets.len() {
+        parts.push(format!("+{}", count - buckets.len()));
+    }
+    if parts.is_empty() {
+        "-".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn with_lab_mut<R>(fallback: R, f: impl FnOnce(&mut WindowLabState) -> R) -> R {
+    LAB.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_none() {
+            let options = WINDOW_OPTIONS
+                .get()
+                .cloned()
+                .unwrap_or_else(PerfOptions::default);
+            match WindowLabState::new(options) {
+                Ok(state) => *slot = Some(state),
+                Err(error) => {
+                    eprintln!("danmaku perf lab create failed: {error}");
+                    return fallback;
+                }
+            }
+        }
+        slot.as_mut().map_or(fallback, f)
+    })
+}
+
+fn window_options_or_default() -> PerfOptions {
+    WINDOW_OPTIONS
+        .get()
+        .cloned()
+        .unwrap_or_else(PerfOptions::default)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_attach_layer(
+    layer: *mut c_void,
+    width: u32,
+    height: u32,
+    scale: f64,
+) {
+    with_lab_mut((), |lab| lab.attach_surface(layer, width, height, scale));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_resize_layer(width: u32, height: u32, scale: f64) {
+    with_lab_mut((), |lab| lab.resize_surface(width, height, scale));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_render_frame(host_time_seconds: f64) {
+    with_lab_mut((), |lab| lab.render_tick(host_time_seconds));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_should_auto_exit() -> bool {
+    with_lab_mut(false, |lab| lab.should_auto_exit())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_toggle_play_pause() {
+    with_lab_mut((), WindowLabState::toggle_play_pause);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_seek_seconds(seconds: f64) {
+    with_lab_mut((), |lab| lab.seek(seconds));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_position_seconds() -> f64 {
+    with_lab_mut(0.0, |lab| lab.presenter.media_time().as_secs_f64())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_duration_seconds() -> f64 {
+    with_lab_mut(0.0, |lab| {
+        lab.presenter
+            .duration()
+            .map(|duration| duration.as_secs_f64())
+            .unwrap_or(0.0)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_is_playing() -> bool {
+    with_lab_mut(false, |lab| lab.presenter.is_playing())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_metrics_text() -> *const i8 {
+    let text = with_lab_mut(String::new(), WindowLabState::metrics_text);
+    let c_string = CString::new(text).unwrap_or_else(|_| CString::new("invalid metrics").unwrap());
+    if let Ok(mut slot) = METRICS_TEXT.lock() {
+        *slot = Some(c_string);
+        slot.as_ref()
+            .map_or(std::ptr::null(), |value| value.as_ptr())
+    } else {
+        std::ptr::null()
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_set_density(comments_per_second: f64) {
+    with_lab_mut((), |lab| lab.set_density(comments_per_second));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_set_font_size(font_size: f64) {
+    with_lab_mut((), |lab| lab.set_font_size(font_size));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_set_display_area(display_area: f64) {
+    with_lab_mut((), |lab| lab.set_display_area(display_area));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_set_outline(outline_width: f64) {
+    with_lab_mut((), |lab| lab.set_outline(outline_width));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_density() -> f64 {
+    LAB.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|lab| lab.options.rate)
+            .unwrap_or_else(|| window_options_or_default().rate)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_font_size() -> f64 {
+    LAB.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|lab| lab.options.font_size as f64)
+            .unwrap_or_else(|| window_options_or_default().font_size as f64)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_display_area() -> f64 {
+    LAB.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|lab| lab.options.display_area as f64)
+            .unwrap_or_else(|| window_options_or_default().display_area as f64)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_outline() -> f64 {
+    LAB.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|lab| lab.options.outline_width as f64)
+            .unwrap_or_else(|| window_options_or_default().outline_width as f64)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_window_width() -> f64 {
+    window_options_or_default().window_width.map_or(0.0, f64::from)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_window_height() -> f64 {
+    window_options_or_default().window_height.map_or(0.0, f64::from)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_fullscreen() -> bool {
+    window_options_or_default().fullscreen
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_uncapped() -> bool {
+    window_options_or_default().uncapped
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_target_fps() -> f64 {
+    window_options_or_default().target_fps
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_hide_panel() -> bool {
+    window_options_or_default().hide_panel
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn kuroko_perf_lab_surface_scale_override() -> f64 {
+    window_options_or_default().surface_scale_override.unwrap_or(0.0)
+}
+
 fn prewarm_atlas(
     engine: &mut DfmLayoutEngine,
     viewport: DanmakuViewport,
@@ -225,6 +904,7 @@ fn run_one_frame(
     let render_started = Instant::now();
     let plan = engine.render_plan(media_time, viewport, generation);
     let render_elapsed = render_started.elapsed();
+    let frame_stats = plan.frame_stats;
     let atlas = plan.atlas.as_ref();
     let glyph_instances = plan.items.len();
     let visible_items = frame_layout.items.len();
@@ -249,6 +929,7 @@ fn run_one_frame(
         glyph_instances,
         current_metal_draws: shadow_draws + outline_draws + fill_draws,
         batched_draws: estimated_batched_draws(shadow_draws, outline_draws, fill_draws),
+        frame_stats,
         atlas_version: atlas.map_or(0, |atlas| atlas.version),
         atlas_bytes: atlas.map_or(0, |atlas| atlas.required_len().saturating_mul(2)),
         video,
@@ -356,7 +1037,29 @@ fn print_report(prepare_elapsed: Duration, samples: &[FrameSample]) {
             worst.glyph_instances,
             worst.atlas_version
         );
+        print_frame_sensor("worst_frame_sensor", worst);
     }
+    if let Some(last) = samples.last() {
+        print_frame_sensor("last_frame_sensor", last);
+    }
+}
+
+fn print_frame_sensor(label: &str, sample: &FrameSample) {
+    let stats = sample.frame_stats;
+    println!(
+        "{label}: t={:.3}s placed={} scroll/top/bottom={}/{}/{} scroll_rows={} tracks={}..{} y={:.0}..{:.0} buckets={}",
+        sample.media_time.as_secs_f64(),
+        stats.placed_items,
+        stats.scroll_items,
+        stats.top_items,
+        stats.bottom_items,
+        stats.scroll_rows,
+        stats.scroll_track_min,
+        stats.scroll_track_max,
+        stats.scroll_min_y,
+        stats.scroll_max_y,
+        format_buckets(stats.scroll_bucket_count, &stats.scroll_buckets),
+    );
 }
 
 fn print_duration_stats(label: &str, values: &mut [Duration]) {
@@ -444,10 +1147,14 @@ fn generate_timeline(options: &PerfOptions) -> Result<DanmakuTimeline, String> {
             font_size: 25.0,
             color,
             opacity: 1.0,
-            is_self: index % 97 == 0,
+            is_self: options.self_every.is_some_and(|every| index % every == 0),
         });
     }
     DanmakuTimeline::new(items).map_err(|error| error.to_string())
+}
+
+fn format_self_every(self_every: Option<usize>) -> String {
+    self_every.map_or_else(|| "off".to_string(), |every| every.to_string())
 }
 
 fn mode_for(pattern: PerfPattern, index: usize) -> DanmakuMode {
@@ -516,6 +1223,9 @@ fn color_for(index: usize) -> DanmakuColor {
 
 #[derive(Debug, Clone, PartialEq)]
 struct PerfOptions {
+    window: bool,
+    fullscreen: bool,
+    uncapped: bool,
     danmaku_path: Option<String>,
     video_uri: Option<String>,
     decode_preference: VideoDecodePreference,
@@ -525,6 +1235,7 @@ struct PerfOptions {
     frames: usize,
     prewarm_frames: usize,
     fps: f64,
+    start_time_seconds: f64,
     width: u32,
     height: u32,
     font_size: f32,
@@ -534,7 +1245,16 @@ struct PerfOptions {
     shadow_style: DanmakuShadowStyle,
     merge_duplicates: bool,
     allow_stacking: bool,
+    allow_scroll_overwrite: bool,
+    self_every: Option<usize>,
+    metrics_log_path: Option<String>,
+    auto_exit_seconds: Option<f64>,
     pattern: PerfPattern,
+    window_width: Option<u32>,
+    window_height: Option<u32>,
+    hide_panel: bool,
+    surface_scale_override: Option<f64>,
+    target_fps: f64,
 }
 
 impl Default for PerfOptions {
@@ -542,6 +1262,9 @@ impl Default for PerfOptions {
         let duration_seconds = 120.0;
         let rate = 50.0;
         Self {
+            window: false,
+            fullscreen: false,
+            uncapped: false,
             danmaku_path: None,
             video_uri: None,
             decode_preference: VideoDecodePreference::default(),
@@ -551,6 +1274,7 @@ impl Default for PerfOptions {
             frames: 600,
             prewarm_frames: 0,
             fps: 60.0,
+            start_time_seconds: 0.0,
             width: 1920,
             height: 1080,
             font_size: 30.0,
@@ -560,7 +1284,16 @@ impl Default for PerfOptions {
             shadow_style: DanmakuShadowStyle::Strong,
             merge_duplicates: false,
             allow_stacking: false,
+            allow_scroll_overwrite: false,
+            self_every: None,
+            metrics_log_path: None,
+            auto_exit_seconds: None,
             pattern: PerfPattern::Mixed,
+            window_width: None,
+            window_height: None,
+            hide_panel: false,
+            surface_scale_override: None,
+            target_fps: 60.0,
         }
     }
 }
@@ -591,6 +1324,7 @@ struct FrameSample {
     glyph_instances: usize,
     current_metal_draws: usize,
     batched_draws: usize,
+    frame_stats: DanmakuFrameStats,
     atlas_version: u64,
     atlas_bytes: usize,
     video: Option<VideoSample>,
@@ -612,6 +1346,15 @@ fn parse_args(args: &[String]) -> Result<PerfOptions, String> {
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
+            "--window" => options.window = true,
+            "--fullscreen" => {
+                options.window = true;
+                options.fullscreen = true;
+            }
+            "--uncapped" => {
+                options.window = true;
+                options.uncapped = true;
+            }
             "--danmaku" => options.danmaku_path = Some(next_string(args, &mut index, "--danmaku")?),
             "--video" => options.video_uri = Some(next_string(args, &mut index, "--video")?),
             "--software" => options.decode_preference = VideoDecodePreference::Software,
@@ -630,12 +1373,32 @@ fn parse_args(args: &[String]) -> Result<PerfOptions, String> {
                 options.prewarm_frames = next_parse(args, &mut index, "--prewarm-frames")?
             }
             "--fps" => options.fps = next_parse(args, &mut index, "--fps")?,
+            "--start-time" => {
+                let seconds: f64 = next_parse(args, &mut index, "--start-time")?;
+                options.start_time_seconds = if seconds.is_finite() {
+                    seconds.max(0.0)
+                } else {
+                    0.0
+                };
+            }
             "--size" => {
                 let value = next_string(args, &mut index, "--size")?;
                 let (width, height) = parse_size(&value)?;
                 options.width = width;
                 options.height = height;
             }
+            "--window-size" => {
+                let value = next_string(args, &mut index, "--window-size")?;
+                let (width, height) = parse_size(&value)?;
+                options.window_width = Some(width);
+                options.window_height = Some(height);
+            }
+            "--hide-panel" => options.hide_panel = true,
+            "--surface-scale" => {
+                let scale: f64 = next_parse(args, &mut index, "--surface-scale")?;
+                options.surface_scale_override = (scale.is_finite() && scale > 0.0).then_some(scale);
+            }
+            "--target-fps" => options.target_fps = next_parse(args, &mut index, "--target-fps")?,
             "--font-size" => options.font_size = next_parse(args, &mut index, "--font-size")?,
             "--display-area" => {
                 options.display_area = next_parse(args, &mut index, "--display-area")?
@@ -647,6 +1410,20 @@ fn parse_args(args: &[String]) -> Result<PerfOptions, String> {
             "--no-shadow" => options.shadow_style = DanmakuShadowStyle::None,
             "--merge" => options.merge_duplicates = true,
             "--stacking" => options.allow_stacking = true,
+            "--scroll-overwrite" => options.allow_scroll_overwrite = true,
+            "--self-every" => {
+                let value: usize = next_parse(args, &mut index, "--self-every")?;
+                options.self_every = (value > 0).then_some(value);
+            }
+            "--metrics-log" => {
+                options.metrics_log_path = Some(next_string(args, &mut index, "--metrics-log")?)
+            }
+            "--auto-exit" => {
+                let seconds: f64 = next_parse(args, &mut index, "--auto-exit")?;
+                if seconds.is_finite() && seconds > 0.0 {
+                    options.auto_exit_seconds = Some(seconds);
+                }
+            }
             "--pattern" => {
                 options.pattern = parse_pattern(&next_string(args, &mut index, "--pattern")?)?
             }
@@ -679,6 +1456,9 @@ fn validate_options(
     }
     if !options.fps.is_finite() || options.fps <= 0.0 {
         return Err("--fps must be positive and finite".to_string());
+    }
+    if !options.target_fps.is_finite() || options.target_fps <= 0.0 {
+        return Err("--target-fps must be positive and finite".to_string());
     }
     if options.width == 0 || options.height == 0 {
         return Err("--size dimensions must be greater than zero".to_string());

--- a/packages/kuroko_flutter/README.md
+++ b/packages/kuroko_flutter/README.md
@@ -6,6 +6,8 @@ The plugin keeps Dart out of the hot path:
 
 - Dart exposes low-frequency player commands and event streams.
 - The macOS plugin owns `NSView`/`CAMetalLayer` lifecycle.
+- The iOS plugin owns `UIView`/`CAMetalLayer` lifecycle and drives the same
+  Apple Metal presenter path.
 - Kuroko owns playback, rendering, audio, timing, and overlays through
   `KurokoPresenterHandle`.
 
@@ -27,3 +29,19 @@ final player = KurokoPlayer(
 ```
 
 Use `KurokoOutputMode.sdr` to force SDR output.
+
+## iOS status
+
+iOS support is in the first integration stage. The Rust presenter and C ABI now
+compile for `aarch64-apple-ios`, VideoToolbox frames are imported through the
+same `CVPixelBuffer` -> Metal path as macOS, and the Flutter plugin exposes a
+`UiKitView` backed by `CAMetalLayer`.
+
+Current limitations:
+
+- The app must link the Kuroko C ABI static library or XCFramework so the iOS
+  plugin can resolve `kuroko_presenter_*` symbols from the main executable.
+- iOS audio output is still a buffered placeholder; replace it with an
+  `AVAudioEngine` backend before treating playback as complete.
+- The macOS window-overlay surface is not implemented on iOS. Use
+  `KurokoVideoView` for the first iOS HDR path.

--- a/packages/kuroko_flutter/ios/Classes/KurokoFlutterPlugin.swift
+++ b/packages/kuroko_flutter/ios/Classes/KurokoFlutterPlugin.swift
@@ -1,0 +1,1259 @@
+import Darwin
+import Flutter
+import Metal
+import QuartzCore
+import UIKit
+
+private struct KurokoTrackSelectionC {
+  var video: Int64 = -1
+  var audio: Int64 = -1
+  var subtitle: Int64 = -1
+}
+
+private struct KurokoVideoParamsC {
+  var width: UInt32 = 0
+  var height: UInt32 = 0
+  var primaries: UInt32 = 0
+  var transfer: UInt32 = 0
+}
+
+private struct KurokoTrackCountsC {
+  var video: UInt32 = 0
+  var audio: UInt32 = 0
+  var subtitle: UInt32 = 0
+}
+
+private struct KurokoTrackInfoC {
+  var id: Int64 = -1
+  var kind: Int32 = 0
+  var source: Int32 = 0
+  var selected: UInt8 = 0
+  var canRemove: UInt8 = 0
+  var title: UnsafeMutablePointer<CChar>?
+  var language: UnsafeMutablePointer<CChar>?
+  var codec: UnsafeMutablePointer<CChar>?
+}
+
+private struct KurokoPresenterConfigC {
+  var outputMode: Int32 = 0
+  var edrHeadroom: Float = 1.0
+
+  static let sdr = KurokoPresenterConfigC()
+
+  static func appleEdr(headroom: Float) -> KurokoPresenterConfigC {
+    KurokoPresenterConfigC(outputMode: 1, edrHeadroom: max(1.0, headroom))
+  }
+}
+
+private struct KurokoEventC {
+  var kind: Int32 = 0
+  var status: Int32 = 0
+  var state: Int32 = 0
+  var durationMicros: Int64 = -1
+  var positionMicros: UInt64 = 0
+  var buffering: UInt8 = 0
+  var video: KurokoVideoParamsC = KurokoVideoParamsC()
+  var tracks: KurokoTrackCountsC = KurokoTrackCountsC()
+}
+
+private struct KurokoPresenterStatsC {
+  var decodedVideoFrames: UInt64 = 0
+  var renderedVideoFrames: UInt64 = 0
+  var renderedTestFrames: UInt64 = 0
+  var pushedAudioFrames: UInt64 = 0
+  var overlayFrames: UInt64 = 0
+  var danmakuFrames: UInt64 = 0
+  var danmakuItems: UInt64 = 0
+  var importFailures: UInt64 = 0
+  var renderFailures: UInt64 = 0
+  var audioFailures: UInt64 = 0
+}
+
+private struct KurokoDanmakuConfigC {
+  var enabled: UInt8 = 1
+  var fontSize: Float = 30.0
+  var opacity: Float = 1.0
+  var displayArea: Float = 1.0
+  var scrollDurationSeconds: Float = 10.0
+  var scrollSpeedFactor: Float = 1.0
+  var trackGapRatio: Float = 0.15
+  var outlineWidth: Float = 1.0
+  var shadowOffsetX: Float = 1.0
+  var shadowOffsetY: Float = 1.0
+  var mergeDuplicates: UInt8 = 0
+  var allowStacking: UInt8 = 0
+  var allowScrollOverwrite: UInt8 = 1
+  var maxQuantity: UInt32 = 0
+  var maxLinesPerMode: UInt32 = 0
+  var blockTop: UInt8 = 0
+  var blockBottom: UInt8 = 0
+  var blockScroll: UInt8 = 0
+  var shadowStyle: Int32 = 3
+}
+
+private struct KurokoDanmakuTrackInfoC {
+  var id: UInt64 = 0
+  var enabled: UInt8 = 0
+  var offsetMicros: Int64 = 0
+  var itemCount: Int = 0
+  var name: UnsafeMutablePointer<CChar>?
+  var source: UnsafeMutablePointer<CChar>?
+}
+
+private enum KurokoPluginError: Error, CustomStringConvertible {
+  case libraryNotFound([String])
+  case symbolMissing(String)
+  case invalidArguments(String)
+  case playerNotFound(Int64)
+  case viewNotFound(Int64)
+  case overlayNotAvailable
+  case presenterCreateFailed
+  case kurokoStatus(String, Int32)
+  case libraryLoadFailed(String, String?)
+
+  var description: String {
+    switch self {
+    case .libraryNotFound(let paths):
+      return "Unable to load Kuroko C ABI. Tried: \(paths.joined(separator: ", "))"
+    case .symbolMissing(let symbol):
+      return "Missing Kuroko C ABI symbol: \(symbol)"
+    case .invalidArguments(let message):
+      return message
+    case .playerNotFound(let playerId):
+      return "Kuroko player \(playerId) was not found."
+    case .viewNotFound(let viewId):
+      return "Kuroko video view \(viewId) was not found."
+    case .overlayNotAvailable:
+      return "Window overlay is not available on iOS. Use KurokoVideoView."
+    case .presenterCreateFailed:
+      return "kuroko_presenter_create returned null."
+    case .kurokoStatus(let operation, let status):
+      return "\(operation) failed with KurokoStatus \(status)."
+    case .libraryLoadFailed(let path, let detail):
+      if let detail, !detail.isEmpty {
+        return "\(path) (\(detail))"
+      }
+      return path
+    }
+  }
+}
+
+private final class KurokoNativeLibrary {
+  typealias CreateFn = @convention(c) () -> UnsafeMutableRawPointer?
+  typealias CreateWithOutputModeFn = @convention(c) (Int32, Float) -> UnsafeMutableRawPointer?
+  typealias DestroyFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
+  typealias OpenFn = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Int32
+  typealias CommandFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
+  typealias SeekFn = @convention(c) (UnsafeMutableRawPointer?, UInt64) -> Int32
+  typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
+  typealias AddExternalSubtitleFn = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafePointer<CChar>?,
+    UnsafeMutablePointer<Int64>?
+  ) -> Int32
+  typealias RemoveSubtitleTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
+  typealias LoadDanmakuFn = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Int32
+  typealias AddDanmakuTrackFn = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    Int64,
+    UnsafeMutablePointer<UInt64>?
+  ) -> Int32
+  typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
+  typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
+  typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
+  typealias SetDanmakuFontFn = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?
+  ) -> Int32
+  typealias SetDanmakuBlockWordsFn = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Int32
+  typealias RemoveDanmakuTrackFn = @convention(c) (UnsafeMutableRawPointer?, UInt64) -> Int32
+  typealias SetDanmakuTrackEnabledFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, Bool) -> Int32
+  typealias SetDanmakuTrackOffsetFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, Int64) -> Int32
+  typealias SetDanmakuGlobalOffsetFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
+  typealias TrackSelectionFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias TracksFn = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafeMutableRawPointer?,
+    Int,
+    UnsafeMutablePointer<Int>?
+  ) -> Int32
+  typealias TrackInfoFreeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
+  typealias DanmakuTrackInfoFreeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
+  typealias AttachMetalLayerFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, UInt32, UInt32, Double) -> Int32
+  typealias ResizeSurfaceFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, Double) -> Int32
+  typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
+  typealias PollEventFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+
+  static let shared = try? KurokoNativeLibrary()
+
+  let create: CreateFn
+  let createWithOutputMode: CreateWithOutputModeFn?
+  let destroy: DestroyFn
+  let open: OpenFn
+  let play: CommandFn
+  let pause: CommandFn
+  let stop: CommandFn
+  let close: CommandFn
+  let seek: SeekFn
+  let setPlaybackRate: SetPlaybackRateFn?
+  let selectAudioTrack: SelectTrackFn
+  let selectSubtitleTrack: SelectTrackFn
+  let addExternalSubtitle: AddExternalSubtitleFn
+  let removeSubtitleTrack: RemoveSubtitleTrackFn
+  let loadDanmakuFile: LoadDanmakuFn?
+  let loadDanmakuJson: LoadDanmakuFn?
+  let addDanmakuTrackFile: AddDanmakuTrackFn?
+  let addDanmakuTrackJson: AddDanmakuTrackFn?
+  let removeDanmakuTrack: RemoveDanmakuTrackFn?
+  let setDanmakuTrackEnabled: SetDanmakuTrackEnabledFn?
+  let setDanmakuTrackOffset: SetDanmakuTrackOffsetFn?
+  let setDanmakuGlobalOffset: SetDanmakuGlobalOffsetFn?
+  let danmakuTracks: TracksFn?
+  let clearDanmaku: ClearDanmakuFn?
+  let setDanmakuEnabled: SetDanmakuEnabledFn?
+  let setDanmakuConfig: SetDanmakuConfigFn?
+  let setDanmakuFont: SetDanmakuFontFn?
+  let setDanmakuBlockWords: SetDanmakuBlockWordsFn?
+  let trackSelection: TrackSelectionFn
+  let tracks: TracksFn
+  let freeTrackInfo: TrackInfoFreeFn
+  let freeDanmakuTrackInfo: DanmakuTrackInfoFreeFn?
+  let attachMetalLayer: AttachMetalLayerFn
+  let resizeSurface: ResizeSurfaceFn
+  let detachSurface: CommandFn
+  let renderTick: RenderTickFn
+  let pollEvent: PollEventFn
+
+  private let libraryHandle: UnsafeMutableRawPointer
+
+  private init() throws {
+    let loaded = try Self.openLibrary()
+    libraryHandle = loaded.handle
+
+    create = try Self.load("kuroko_presenter_create", from: libraryHandle, as: CreateFn.self)
+    createWithOutputMode = Self.loadOptional("kuroko_presenter_create_with_output_mode", from: libraryHandle, as: CreateWithOutputModeFn.self)
+    destroy = try Self.load("kuroko_presenter_destroy", from: libraryHandle, as: DestroyFn.self)
+    open = try Self.load("kuroko_presenter_open", from: libraryHandle, as: OpenFn.self)
+    play = try Self.load("kuroko_presenter_play", from: libraryHandle, as: CommandFn.self)
+    pause = try Self.load("kuroko_presenter_pause", from: libraryHandle, as: CommandFn.self)
+    stop = try Self.load("kuroko_presenter_stop", from: libraryHandle, as: CommandFn.self)
+    close = try Self.load("kuroko_presenter_close", from: libraryHandle, as: CommandFn.self)
+    seek = try Self.load("kuroko_presenter_seek", from: libraryHandle, as: SeekFn.self)
+    setPlaybackRate = Self.loadOptional("kuroko_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
+    selectAudioTrack = try Self.load("kuroko_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
+    selectSubtitleTrack = try Self.load("kuroko_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
+    addExternalSubtitle = try Self.load("kuroko_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
+    removeSubtitleTrack = try Self.load("kuroko_presenter_remove_subtitle_track", from: libraryHandle, as: RemoveSubtitleTrackFn.self)
+    loadDanmakuFile = Self.loadOptional("kuroko_presenter_load_danmaku_file", from: libraryHandle, as: LoadDanmakuFn.self)
+    loadDanmakuJson = Self.loadOptional("kuroko_presenter_load_danmaku_json", from: libraryHandle, as: LoadDanmakuFn.self)
+    addDanmakuTrackFile = Self.loadOptional("kuroko_presenter_add_danmaku_track_file", from: libraryHandle, as: AddDanmakuTrackFn.self)
+    addDanmakuTrackJson = Self.loadOptional("kuroko_presenter_add_danmaku_track_json", from: libraryHandle, as: AddDanmakuTrackFn.self)
+    removeDanmakuTrack = Self.loadOptional("kuroko_presenter_remove_danmaku_track", from: libraryHandle, as: RemoveDanmakuTrackFn.self)
+    setDanmakuTrackEnabled = Self.loadOptional("kuroko_presenter_set_danmaku_track_enabled", from: libraryHandle, as: SetDanmakuTrackEnabledFn.self)
+    setDanmakuTrackOffset = Self.loadOptional("kuroko_presenter_set_danmaku_track_offset", from: libraryHandle, as: SetDanmakuTrackOffsetFn.self)
+    setDanmakuGlobalOffset = Self.loadOptional("kuroko_presenter_set_danmaku_global_offset", from: libraryHandle, as: SetDanmakuGlobalOffsetFn.self)
+    danmakuTracks = Self.loadOptional("kuroko_presenter_danmaku_tracks", from: libraryHandle, as: TracksFn.self)
+    clearDanmaku = Self.loadOptional("kuroko_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
+    setDanmakuEnabled = Self.loadOptional("kuroko_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
+    setDanmakuConfig = Self.loadOptional("kuroko_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
+    setDanmakuFont = Self.loadOptional("kuroko_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
+    setDanmakuBlockWords = Self.loadOptional("kuroko_presenter_set_danmaku_block_words_json", from: libraryHandle, as: SetDanmakuBlockWordsFn.self)
+    trackSelection = try Self.load("kuroko_presenter_track_selection", from: libraryHandle, as: TrackSelectionFn.self)
+    tracks = try Self.load("kuroko_presenter_tracks", from: libraryHandle, as: TracksFn.self)
+    freeTrackInfo = try Self.load("kuroko_track_info_free", from: libraryHandle, as: TrackInfoFreeFn.self)
+    freeDanmakuTrackInfo = Self.loadOptional("kuroko_danmaku_track_info_free", from: libraryHandle, as: DanmakuTrackInfoFreeFn.self)
+    attachMetalLayer = try Self.load("kuroko_presenter_attach_metal_layer", from: libraryHandle, as: AttachMetalLayerFn.self)
+    resizeSurface = try Self.load("kuroko_presenter_resize_surface", from: libraryHandle, as: ResizeSurfaceFn.self)
+    detachSurface = try Self.load("kuroko_presenter_detach_surface", from: libraryHandle, as: CommandFn.self)
+    renderTick = try Self.load("kuroko_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
+    pollEvent = try Self.load("kuroko_presenter_poll_event", from: libraryHandle, as: PollEventFn.self)
+  }
+
+  private static func openLibrary() throws -> (handle: UnsafeMutableRawPointer, path: String) {
+    if let handle = dlopen(nil, RTLD_NOW), dlsym(handle, "kuroko_presenter_create") != nil {
+      return (handle, "main executable")
+    }
+
+    var candidates: [String] = []
+    let environment = ProcessInfo.processInfo.environment
+    if let override = environment["KUROKO_CAPI_DYLIB"], !override.isEmpty {
+      candidates.append(override)
+    }
+    let bundle = Bundle(for: KurokoFlutterPlugin.self)
+    if let resourcePath = bundle.path(forResource: "libkuroko_capi", ofType: "dylib") {
+      candidates.append(resourcePath)
+    }
+    if let frameworksPath = Bundle.main.privateFrameworksPath {
+      candidates.append(URL(fileURLWithPath: frameworksPath).appendingPathComponent("libkuroko_capi.dylib").path)
+    }
+    if let executablePath = Bundle.main.executablePath {
+      let executableDirectory = URL(fileURLWithPath: executablePath).deletingLastPathComponent().path
+      candidates.append(URL(fileURLWithPath: executableDirectory).appendingPathComponent("libkuroko_capi.dylib").path)
+    }
+
+    var failures: [KurokoPluginError] = []
+    for path in candidates {
+      if let handle = dlopen(path, RTLD_NOW | RTLD_LOCAL) {
+        return (handle, path)
+      }
+      let detail = dlerror().map { String(cString: $0) }
+      failures.append(.libraryLoadFailed(path, detail))
+    }
+    throw KurokoPluginError.libraryNotFound(failures.map(String.init(describing:)))
+  }
+
+  private static func load<T>(_ symbol: String, from handle: UnsafeMutableRawPointer, as type: T.Type) throws -> T {
+    guard let raw = dlsym(handle, symbol) else {
+      throw KurokoPluginError.symbolMissing(symbol)
+    }
+    return unsafeBitCast(raw, to: type)
+  }
+
+  private static func loadOptional<T>(_ symbol: String, from handle: UnsafeMutableRawPointer, as type: T.Type) -> T? {
+    guard let raw = dlsym(handle, symbol) else {
+      return nil
+    }
+    return unsafeBitCast(raw, to: type)
+  }
+
+  func createPresenter(config: KurokoPresenterConfigC) -> UnsafeMutableRawPointer? {
+    if let createWithOutputMode {
+      return createWithOutputMode(config.outputMode, config.edrHeadroom)
+    }
+    return create()
+  }
+}
+
+private final class KurokoPlayerHost {
+  let id: Int64
+
+  private let library: KurokoNativeLibrary
+  private let handle: UnsafeMutableRawPointer
+  private weak var attachedView: KurokoMetalSurfaceView?
+  private var displayLink: CADisplayLink?
+  private var displayLinkProxy: DisplayLinkProxy?
+  private var startTimeSeconds: CFTimeInterval = CACurrentMediaTime()
+
+  init(id: Int64, library: KurokoNativeLibrary, config: KurokoPresenterConfigC) throws {
+    self.id = id
+    self.library = library
+    guard let handle = library.createPresenter(config: config) else {
+      throw KurokoPluginError.presenterCreateFailed
+    }
+    self.handle = handle
+  }
+
+  deinit {
+    displayLink?.invalidate()
+    _ = library.detachSurface(handle)
+    library.destroy(handle)
+  }
+
+  func open(uri: String) throws {
+    try uri.withCString { cString in
+      try check(library.open(handle, cString), operation: "open")
+    }
+  }
+
+  func play() throws { try check(library.play(handle), operation: "play") }
+  func pause() throws { try check(library.pause(handle), operation: "pause") }
+  func stop() throws { try check(library.stop(handle), operation: "stop") }
+  func close() throws { try check(library.close(handle), operation: "close") }
+
+  func seek(positionMicros: UInt64) throws {
+    try check(library.seek(handle, positionMicros), operation: "seek")
+  }
+
+  func setPlaybackRate(_ rate: Double) throws {
+    guard let setRate = library.setPlaybackRate else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_playback_rate")
+    }
+    try check(setRate(handle, rate), operation: "set_playback_rate")
+  }
+
+  func addExternalSubtitle(uri: String) throws -> Int64 {
+    var trackId: Int64 = 0
+    try uri.withCString { cString in
+      try check(library.addExternalSubtitle(handle, cString, &trackId), operation: "add_external_subtitle")
+    }
+    return trackId
+  }
+
+  func removeSubtitleTrack(trackId: Int64) throws {
+    try check(library.removeSubtitleTrack(handle, trackId), operation: "remove_subtitle_track")
+  }
+
+  func loadDanmakuFile(uri: String) throws {
+    guard let load = library.loadDanmakuFile else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_load_danmaku_file")
+    }
+    try uri.withCString { cString in
+      try check(load(handle, cString), operation: "load_danmaku_file")
+    }
+  }
+
+  func loadDanmakuJson(_ json: String) throws {
+    guard let load = library.loadDanmakuJson else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_load_danmaku_json")
+    }
+    try json.withCString { cString in
+      try check(load(handle, cString), operation: "load_danmaku_json")
+    }
+  }
+
+  func addDanmakuTrackFile(uri: String, name: String?, offsetMicros: Int64) throws -> UInt64 {
+    guard let add = library.addDanmakuTrackFile else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_add_danmaku_track_file")
+    }
+    var trackId: UInt64 = 0
+    let status = uri.withCString { uriCString in
+      withOptionalCString(name) { nameCString in
+        add(handle, uriCString, nameCString, offsetMicros, &trackId)
+      }
+    }
+    try check(status, operation: "add_danmaku_track_file")
+    return trackId
+  }
+
+  func addDanmakuTrackJson(_ json: String, name: String?, offsetMicros: Int64) throws -> UInt64 {
+    guard let add = library.addDanmakuTrackJson else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_add_danmaku_track_json")
+    }
+    var trackId: UInt64 = 0
+    let status = json.withCString { jsonCString in
+      withOptionalCString(name) { nameCString in
+        add(handle, jsonCString, nameCString, offsetMicros, &trackId)
+      }
+    }
+    try check(status, operation: "add_danmaku_track_json")
+    return trackId
+  }
+
+  func removeDanmakuTrack(trackId: UInt64) throws {
+    guard let remove = library.removeDanmakuTrack else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_remove_danmaku_track")
+    }
+    try check(remove(handle, trackId), operation: "remove_danmaku_track")
+  }
+
+  func setDanmakuTrackEnabled(trackId: UInt64, enabled: Bool) throws {
+    guard let setEnabled = library.setDanmakuTrackEnabled else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_track_enabled")
+    }
+    try check(setEnabled(handle, trackId, enabled), operation: "set_danmaku_track_enabled")
+  }
+
+  func setDanmakuTrackOffset(trackId: UInt64, offsetMicros: Int64) throws {
+    guard let setOffset = library.setDanmakuTrackOffset else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_track_offset")
+    }
+    try check(setOffset(handle, trackId, offsetMicros), operation: "set_danmaku_track_offset")
+  }
+
+  func setDanmakuGlobalOffset(offsetMicros: Int64) throws {
+    guard let setOffset = library.setDanmakuGlobalOffset else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_global_offset")
+    }
+    try check(setOffset(handle, offsetMicros), operation: "set_danmaku_global_offset")
+  }
+
+  func danmakuTracks() throws -> [[String: Any]] {
+    guard let danmakuTracks = library.danmakuTracks else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_danmaku_tracks")
+    }
+    var count: Int = 0
+    try check(danmakuTracks(handle, nil, 0, &count), operation: "danmaku_tracks_len")
+    if count <= 0 { return [] }
+    var tracks = Array(repeating: KurokoDanmakuTrackInfoC(), count: count)
+    var written: Int = 0
+    let status = tracks.withUnsafeMutableBufferPointer { buffer in
+      danmakuTracks(handle, UnsafeMutableRawPointer(buffer.baseAddress), buffer.count, &written)
+    }
+    try check(status, operation: "danmaku_tracks")
+    let result = tracks.prefix(min(written, tracks.count)).map { $0.toFlutterMap() }
+    if let free = library.freeDanmakuTrackInfo {
+      for index in tracks.indices {
+        withUnsafeMutablePointer(to: &tracks[index]) { pointer in
+          free(UnsafeMutableRawPointer(pointer))
+        }
+      }
+    }
+    return result
+  }
+
+  func clearDanmaku() throws {
+    guard let clear = library.clearDanmaku else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_clear_danmaku")
+    }
+    try check(clear(handle), operation: "clear_danmaku")
+  }
+
+  func setDanmakuEnabled(_ enabled: Bool) throws {
+    guard let setEnabled = library.setDanmakuEnabled else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_enabled")
+    }
+    try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
+  }
+
+  func setDanmakuConfig(_ config: KurokoDanmakuConfigC) throws {
+    guard let setConfig = library.setDanmakuConfig else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_config_ptr")
+    }
+    var config = config
+    let status = withUnsafePointer(to: &config) { pointer in
+      setConfig(handle, UnsafeRawPointer(pointer))
+    }
+    try check(status, operation: "set_danmaku_config")
+  }
+
+  func setDanmakuFont(family: String?, filePath: String?) throws {
+    guard let setFont = library.setDanmakuFont else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_font")
+    }
+    let status = withOptionalCString(family ?? "") { familyCString in
+      withOptionalCString(filePath ?? "") { filePathCString in
+        setFont(handle, familyCString, filePathCString)
+      }
+    }
+    try check(status, operation: "set_danmaku_font")
+  }
+
+  func setDanmakuBlockWordsJson(_ json: String) throws {
+    guard let setBlockWords = library.setDanmakuBlockWords else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_block_words_json")
+    }
+    try json.withCString { cString in
+      try check(setBlockWords(handle, cString), operation: "set_danmaku_block_words")
+    }
+  }
+
+  func selectAudioTrack(trackId: Int64?) throws {
+    try check(library.selectAudioTrack(handle, trackId ?? -1), operation: "select_audio_track")
+  }
+
+  func selectSubtitleTrack(trackId: Int64?) throws {
+    try check(library.selectSubtitleTrack(handle, trackId ?? -1), operation: "select_subtitle_track")
+  }
+
+  func tracks() throws -> [[String: Any]] {
+    var count: Int = 0
+    try check(library.tracks(handle, nil, 0, &count), operation: "tracks_len")
+    if count <= 0 { return [] }
+    var tracks = Array(repeating: KurokoTrackInfoC(), count: count)
+    var written: Int = 0
+    let status = tracks.withUnsafeMutableBufferPointer { buffer in
+      library.tracks(handle, UnsafeMutableRawPointer(buffer.baseAddress), buffer.count, &written)
+    }
+    try check(status, operation: "tracks")
+    let result = tracks.prefix(min(written, tracks.count)).map { $0.toFlutterMap() }
+    for index in tracks.indices {
+      withUnsafeMutablePointer(to: &tracks[index]) { pointer in
+        library.freeTrackInfo(UnsafeMutableRawPointer(pointer))
+      }
+    }
+    return result
+  }
+
+  func trackSelection() throws -> [String: Any] {
+    var selection = KurokoTrackSelectionC()
+    let status = withUnsafeMutablePointer(to: &selection) { pointer in
+      library.trackSelection(handle, UnsafeMutableRawPointer(pointer))
+    }
+    try check(status, operation: "track_selection")
+    return selection.toFlutterMap()
+  }
+
+  func attach(view: KurokoMetalSurfaceView) throws {
+    attachedView = view
+    view.attachedPlayerId = id
+    try attachOrResize(view: view, attach: true)
+    startDisplayLinkIfNeeded()
+  }
+
+  func detach(viewId: Int64?) {
+    guard viewId == nil || attachedView?.platformViewId == viewId else { return }
+    attachedView?.attachedPlayerId = nil
+    attachedView = nil
+    displayLink?.invalidate()
+    displayLink = nil
+    displayLinkProxy = nil
+    _ = library.detachSurface(handle)
+  }
+
+  func resizeFromAttachedView() {
+    guard let view = attachedView else { return }
+    do {
+      try attachOrResize(view: view, attach: false)
+    } catch {
+      NSLog("KurokoFlutterPlugin: resize failed: \(error)")
+    }
+  }
+
+  func renderTick(sendEvent: (([String: Any]) -> Void)?) {
+    let timeSeconds = CACurrentMediaTime() - startTimeSeconds
+    var stats = KurokoPresenterStatsC()
+    let status = withUnsafeMutablePointer(to: &stats) { pointer in
+      library.renderTick(handle, timeSeconds, UnsafeMutableRawPointer(pointer))
+    }
+    if status != 0 {
+      NSLog("KurokoFlutterPlugin: render_tick failed with status \(status)")
+    }
+    pollEvents(sendEvent: sendEvent)
+  }
+
+  func pollEvents(sendEvent: (([String: Any]) -> Void)?) {
+    guard let sendEvent else { return }
+    while true {
+      var event = KurokoEventC()
+      let status = withUnsafeMutablePointer(to: &event) { pointer in
+        library.pollEvent(handle, UnsafeMutableRawPointer(pointer))
+      }
+      if status == 0 {
+        sendEvent(event.toFlutterMap(playerId: id, host: self))
+        continue
+      }
+      if status != 5 {
+        NSLog("KurokoFlutterPlugin: poll_event failed with status \(status)")
+      }
+      break
+    }
+  }
+
+  private func attachOrResize(view: KurokoMetalSurfaceView, attach: Bool) throws {
+    view.updateDrawableSize()
+    let width = UInt32(max(1.0, view.bounds.width).rounded())
+    let height = UInt32(max(1.0, view.bounds.height).rounded())
+    let scale = view.currentScale
+    if attach {
+      let rawLayer = UInt64(UInt(bitPattern: Unmanaged.passUnretained(view.metalLayer).toOpaque()))
+      try check(library.attachMetalLayer(handle, rawLayer, width, height, scale), operation: "attach_metal_layer")
+    } else {
+      try check(library.resizeSurface(handle, width, height, scale), operation: "resize_surface")
+    }
+  }
+
+  private func startDisplayLinkIfNeeded() {
+    guard displayLink == nil else { return }
+    startTimeSeconds = CACurrentMediaTime()
+    let proxy = DisplayLinkProxy { [weak self] in
+      self?.renderTick(sendEvent: KurokoFlutterPlugin.sharedEventSink)
+    }
+    let link = CADisplayLink(target: proxy, selector: #selector(DisplayLinkProxy.tick))
+    link.preferredFramesPerSecond = 60
+    link.add(to: .main, forMode: .common)
+    displayLinkProxy = proxy
+    displayLink = link
+  }
+
+  private func check(_ status: Int32, operation: String) throws {
+    if status != 0 {
+      throw KurokoPluginError.kurokoStatus(operation, status)
+    }
+  }
+}
+
+private final class DisplayLinkProxy: NSObject {
+  private let body: () -> Void
+
+  init(_ body: @escaping () -> Void) {
+    self.body = body
+  }
+
+  @objc func tick() {
+    body()
+  }
+}
+
+private protocol KurokoMetalSurfaceView: AnyObject {
+  var platformViewId: Int64 { get }
+  var metalLayer: CAMetalLayer { get }
+  var attachedPlayerId: Int64? { get set }
+  var bounds: CGRect { get }
+  var currentScale: Double { get }
+
+  func updateDrawableSize()
+}
+
+private final class WeakKurokoVideoPlatformViewBox {
+  weak var view: KurokoMetalSurfaceView?
+
+  init(view: KurokoMetalSurfaceView) {
+    self.view = view
+  }
+}
+
+private final class KurokoMetalUIView: UIView, KurokoMetalSurfaceView {
+  let platformViewId: Int64
+  weak var plugin: KurokoFlutterPlugin?
+  var attachedPlayerId: Int64?
+
+  override class var layerClass: AnyClass { CAMetalLayer.self }
+
+  var metalLayer: CAMetalLayer { layer as! CAMetalLayer }
+
+  var currentScale: Double {
+    Double(max(1.0, window?.screen.scale ?? UIScreen.main.scale))
+  }
+
+  init(frame: CGRect, viewId: Int64, arguments: Any?, plugin: KurokoFlutterPlugin?) {
+    platformViewId = viewId
+    self.plugin = plugin
+    super.init(frame: frame)
+    isOpaque = true
+    backgroundColor = .black
+    contentScaleFactor = CGFloat(currentScale)
+    metalLayer.pixelFormat = .bgra8Unorm
+    metalLayer.framebufferOnly = true
+    metalLayer.isOpaque = true
+    metalLayer.backgroundColor = UIColor.black.cgColor
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  deinit {
+    plugin?.unregisterView(viewId: platformViewId)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    updateDrawableSize()
+    plugin?.resizePlayerAttachedToView(viewId: platformViewId)
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    updateDrawableSize()
+    plugin?.resizePlayerAttachedToView(viewId: platformViewId)
+  }
+
+  func updateDrawableSize() {
+    let scale = CGFloat(currentScale)
+    contentScaleFactor = scale
+    metalLayer.contentsScale = scale
+    metalLayer.frame = bounds
+    metalLayer.drawableSize = CGSize(
+      width: max(1.0, bounds.width * scale),
+      height: max(1.0, bounds.height * scale)
+    )
+  }
+}
+
+private final class KurokoVideoPlatformView: NSObject, FlutterPlatformView {
+  let metalView: KurokoMetalUIView
+
+  init(frame: CGRect, viewId: Int64, arguments: Any?, plugin: KurokoFlutterPlugin?) {
+    metalView = KurokoMetalUIView(frame: frame, viewId: viewId, arguments: arguments, plugin: plugin)
+    super.init()
+  }
+
+  func view() -> UIView {
+    metalView
+  }
+}
+
+private final class KurokoVideoViewFactory: NSObject, FlutterPlatformViewFactory {
+  private weak var plugin: KurokoFlutterPlugin?
+
+  init(plugin: KurokoFlutterPlugin) {
+    self.plugin = plugin
+    super.init()
+  }
+
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    FlutterStandardMessageCodec.sharedInstance()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    let platformView = KurokoVideoPlatformView(frame: frame, viewId: viewId, arguments: args, plugin: plugin)
+    plugin?.registerView(platformView.metalView, viewId: viewId)
+    return platformView
+  }
+}
+
+public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
+  static var sharedEventSink: FlutterEventSink?
+
+  private static let playerChannelName = "kuroko_flutter/player"
+  private static let eventsChannelName = "kuroko_flutter/events"
+  private static let videoViewType = "kuroko_flutter/video_view"
+
+  private var players: [Int64: KurokoPlayerHost] = [:]
+  private var views: [Int64: WeakKurokoVideoPlatformViewBox] = [:]
+  private var nextPlayerId: Int64 = 1
+  private var pollTimer: Timer?
+
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let instance = KurokoFlutterPlugin()
+    let playerChannel = FlutterMethodChannel(name: playerChannelName, binaryMessenger: registrar.messenger())
+    let eventsChannel = FlutterEventChannel(name: eventsChannelName, binaryMessenger: registrar.messenger())
+    registrar.addMethodCallDelegate(instance, channel: playerChannel)
+    eventsChannel.setStreamHandler(instance)
+    registrar.register(KurokoVideoViewFactory(plugin: instance), withId: videoViewType)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    do {
+      switch call.method {
+      case "create":
+        result(try createPlayer(arguments: call.arguments))
+      case "dispose":
+        let args = try dictionaryArgs(call.arguments)
+        let playerId = try requiredInt64(args["playerId"], name: "playerId")
+        players.removeValue(forKey: playerId)
+        result(nil)
+      case "open":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        guard let uri = args["uri"] as? String, !uri.isEmpty else {
+          throw KurokoPluginError.invalidArguments("uri is required.")
+        }
+        try host.open(uri: uri)
+        result(nil)
+      case "play":
+        try playerHost(from: try dictionaryArgs(call.arguments)).play()
+        result(nil)
+      case "pause":
+        try playerHost(from: try dictionaryArgs(call.arguments)).pause()
+        result(nil)
+      case "stop":
+        try playerHost(from: try dictionaryArgs(call.arguments)).stop()
+        result(nil)
+      case "close":
+        try playerHost(from: try dictionaryArgs(call.arguments)).close()
+        result(nil)
+      case "seek":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).seek(positionMicros: try requiredUInt64(args["positionMicros"], name: "positionMicros"))
+        result(nil)
+      case "setPlaybackRate":
+        let args = try dictionaryArgs(call.arguments)
+        guard let rate = doubleValue(args["rate"]) else {
+          throw KurokoPluginError.invalidArguments("rate is required.")
+        }
+        try playerHost(from: args).setPlaybackRate(rate)
+        result(nil)
+      case "addExternalSubtitle":
+        let args = try dictionaryArgs(call.arguments)
+        guard let uri = args["uri"] as? String, !uri.isEmpty else {
+          throw KurokoPluginError.invalidArguments("uri is required.")
+        }
+        result(try playerHost(from: args).addExternalSubtitle(uri: uri))
+      case "removeSubtitleTrack":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).removeSubtitleTrack(trackId: try requiredInt64(args["trackId"], name: "trackId"))
+        result(nil)
+      case "loadDanmakuFile":
+        let args = try dictionaryArgs(call.arguments)
+        guard let uri = args["uri"] as? String, !uri.isEmpty else {
+          throw KurokoPluginError.invalidArguments("uri is required.")
+        }
+        try playerHost(from: args).loadDanmakuFile(uri: uri)
+        result(nil)
+      case "loadDanmakuJson":
+        let args = try dictionaryArgs(call.arguments)
+        guard let json = args["json"] as? String, !json.isEmpty else {
+          throw KurokoPluginError.invalidArguments("json is required.")
+        }
+        try playerHost(from: args).loadDanmakuJson(json)
+        result(nil)
+      case "addDanmakuTrackFile":
+        let args = try dictionaryArgs(call.arguments)
+        guard let uri = args["uri"] as? String, !uri.isEmpty else {
+          throw KurokoPluginError.invalidArguments("uri is required.")
+        }
+        result(Int64(clamping: try playerHost(from: args).addDanmakuTrackFile(
+          uri: uri,
+          name: args["name"] as? String,
+          offsetMicros: int64Value(args["offsetMicros"]) ?? 0
+        )))
+      case "addDanmakuTrackJson":
+        let args = try dictionaryArgs(call.arguments)
+        guard let json = args["json"] as? String, !json.isEmpty else {
+          throw KurokoPluginError.invalidArguments("json is required.")
+        }
+        result(Int64(clamping: try playerHost(from: args).addDanmakuTrackJson(
+          json,
+          name: args["name"] as? String,
+          offsetMicros: int64Value(args["offsetMicros"]) ?? 0
+        )))
+      case "removeDanmakuTrack":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).removeDanmakuTrack(trackId: try requiredUInt64(args["trackId"], name: "trackId"))
+        result(nil)
+      case "setDanmakuTrackEnabled":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDanmakuTrackEnabled(
+          trackId: try requiredUInt64(args["trackId"], name: "trackId"),
+          enabled: boolValue(args["enabled"]) ?? true
+        )
+        result(nil)
+      case "setDanmakuTrackOffset":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDanmakuTrackOffset(
+          trackId: try requiredUInt64(args["trackId"], name: "trackId"),
+          offsetMicros: int64Value(args["offsetMicros"]) ?? 0
+        )
+        result(nil)
+      case "setDanmakuGlobalOffset":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDanmakuGlobalOffset(offsetMicros: int64Value(args["offsetMicros"]) ?? 0)
+        result(nil)
+      case "danmakuTracks":
+        result(try playerHost(from: try dictionaryArgs(call.arguments)).danmakuTracks())
+      case "clearDanmaku":
+        try playerHost(from: try dictionaryArgs(call.arguments)).clearDanmaku()
+        result(nil)
+      case "setDanmakuEnabled":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDanmakuEnabled(boolValue(args["enabled"]) ?? true)
+        result(nil)
+      case "setDanmakuConfig":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        try host.setDanmakuConfig(danmakuConfig(from: args))
+        if args.keys.contains("customFontFamily") || args.keys.contains("customFontFilePath") {
+          try host.setDanmakuFont(
+            family: args["customFontFamily"] as? String,
+            filePath: args["customFontFilePath"] as? String
+          )
+        }
+        if let blockWordsJson = args["blockWordsJson"] as? String {
+          try host.setDanmakuBlockWordsJson(blockWordsJson)
+        }
+        result(nil)
+      case "selectAudioTrack":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).selectAudioTrack(trackId: optionalTrackId(args["trackId"]))
+        result(nil)
+      case "selectSubtitleTrack":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).selectSubtitleTrack(trackId: optionalTrackId(args["trackId"]))
+        result(nil)
+      case "tracks":
+        result(try playerHost(from: try dictionaryArgs(call.arguments)).tracks())
+      case "attachView":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        let viewId = try requiredInt64(args["viewId"], name: "viewId")
+        guard let view = views[viewId]?.view else {
+          throw KurokoPluginError.viewNotFound(viewId)
+        }
+        try host.attach(view: view)
+        result(nil)
+      case "detachView":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        let viewId = try requiredInt64(args["viewId"], name: "viewId")
+        host.detach(viewId: viewId)
+        result(nil)
+      case "attachOverlay", "detachOverlay", "setOverlayFrame":
+        throw KurokoPluginError.overlayNotAvailable
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    } catch {
+      result(flutterError(error))
+    }
+  }
+
+  public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+    Self.sharedEventSink = events
+    startPollTimerIfNeeded()
+    return nil
+  }
+
+  public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    Self.sharedEventSink = nil
+    pollTimer?.invalidate()
+    pollTimer = nil
+    return nil
+  }
+
+  fileprivate func registerView(_ view: KurokoMetalSurfaceView, viewId: Int64) {
+    views[viewId] = WeakKurokoVideoPlatformViewBox(view: view)
+  }
+
+  fileprivate func unregisterView(viewId: Int64) {
+    views.removeValue(forKey: viewId)
+    for host in players.values {
+      host.detach(viewId: viewId)
+    }
+  }
+
+  fileprivate func resizePlayerAttachedToView(viewId: Int64) {
+    for host in players.values {
+      if let attachedPlayerId = views[viewId]?.view?.attachedPlayerId,
+         attachedPlayerId == host.id {
+        host.resizeFromAttachedView()
+      }
+    }
+  }
+
+  private func createPlayer(arguments: Any?) throws -> Int64 {
+    guard let library = KurokoNativeLibrary.shared else {
+      throw KurokoPluginError.libraryNotFound(["main executable", "KUROKO_CAPI_DYLIB", "app bundle"])
+    }
+    let id = nextPlayerId
+    nextPlayerId += 1
+    players[id] = try KurokoPlayerHost(id: id, library: library, config: presenterConfigForNewPlayer(arguments: arguments))
+    startPollTimerIfNeeded()
+    return id
+  }
+
+  private func presenterConfigForNewPlayer(arguments: Any?) throws -> KurokoPresenterConfigC {
+    if let args = arguments as? [String: Any], let explicitMode = int32Value(args["outputMode"]) {
+      let headroom = floatValue(args["edrHeadroom"]) ?? 4.0
+      return explicitMode == 1 ? .appleEdr(headroom: headroom) : .sdr
+    }
+    let headroom = resolvedEdrHeadroom()
+    return headroom > 1.0 ? .appleEdr(headroom: headroom) : .sdr
+  }
+
+  private func resolvedEdrHeadroom() -> Float {
+    let environment = ProcessInfo.processInfo.environment
+    if boolEnvironmentFlag("KUROKO_DISABLE_EDR", environment: environment) { return 1.0 }
+    if let override = floatEnvironmentValue("KUROKO_EDR_HEADROOM", environment: environment), override > 1.0 {
+      return override
+    }
+    let screenHeadroom = currentScreenEdrHeadroom()
+    if screenHeadroom > 1.0 { return screenHeadroom }
+    if boolEnvironmentFlag("KUROKO_ENABLE_EDR", environment: environment) { return 4.0 }
+    return 1.0
+  }
+
+  private func currentScreenEdrHeadroom() -> Float {
+    let screen = UIScreen.main
+    for key in ["currentEDRHeadroom", "potentialEDRHeadroom", "maximumPotentialExtendedDynamicRangeColorComponentValue"] {
+      let selector = Selector(key)
+      if screen.responds(to: selector), let number = screen.value(forKey: key) as? NSNumber {
+        let value = number.floatValue
+        if value.isFinite && value > 1.0 { return value }
+      }
+    }
+    return 1.0
+  }
+
+  private func startPollTimerIfNeeded() {
+    guard pollTimer == nil else { return }
+    let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+      guard let self else { return }
+      let sink = Self.sharedEventSink
+      for host in self.players.values {
+        host.pollEvents(sendEvent: sink)
+      }
+    }
+    pollTimer = timer
+    RunLoop.main.add(timer, forMode: .common)
+  }
+
+  private func playerHost(from args: [String: Any]) throws -> KurokoPlayerHost {
+    let playerId = try requiredInt64(args["playerId"], name: "playerId")
+    guard let host = players[playerId] else {
+      throw KurokoPluginError.playerNotFound(playerId)
+    }
+    return host
+  }
+
+  private func optionalTrackId(_ value: Any?) throws -> Int64? {
+    if value == nil || value is NSNull { return nil }
+    guard let trackId = int64Value(value) else {
+      throw KurokoPluginError.invalidArguments("trackId must be an integer or null.")
+    }
+    return trackId >= 0 ? trackId : nil
+  }
+
+  private func danmakuConfig(from args: [String: Any]) -> KurokoDanmakuConfigC {
+    var config = KurokoDanmakuConfigC()
+    if let value = boolValue(args["enabled"]) { config.enabled = value ? 1 : 0 }
+    if let value = doubleValue(args["fontSize"]) { config.fontSize = Float(value) }
+    if let value = doubleValue(args["opacity"]) { config.opacity = Float(value) }
+    if let value = doubleValue(args["displayArea"]) { config.displayArea = Float(value) }
+    if let value = doubleValue(args["scrollDurationSeconds"]) { config.scrollDurationSeconds = Float(value) }
+    if let value = doubleValue(args["scrollSpeedFactor"]) { config.scrollSpeedFactor = Float(value) }
+    if let value = doubleValue(args["trackGapRatio"]) { config.trackGapRatio = Float(value) }
+    if let value = doubleValue(args["outlineWidth"]) { config.outlineWidth = Float(value) }
+    if let value = doubleValue(args["shadowOffsetX"]) { config.shadowOffsetX = Float(value) }
+    if let value = doubleValue(args["shadowOffsetY"]) { config.shadowOffsetY = Float(value) }
+    if let value = boolValue(args["mergeDuplicates"]) { config.mergeDuplicates = value ? 1 : 0 }
+    if let value = boolValue(args["allowStacking"]) { config.allowStacking = value ? 1 : 0 }
+    if let value = boolValue(args["allowScrollOverwrite"]) { config.allowScrollOverwrite = value ? 1 : 0 }
+    if let value = int64Value(args["maxQuantity"]), value > 0 { config.maxQuantity = UInt32(clamping: value) }
+    if let value = int64Value(args["maxLinesPerMode"]), value > 0 { config.maxLinesPerMode = UInt32(clamping: value) }
+    if let value = boolValue(args["blockTop"]) { config.blockTop = value ? 1 : 0 }
+    if let value = boolValue(args["blockBottom"]) { config.blockBottom = value ? 1 : 0 }
+    if let value = boolValue(args["blockScroll"]) { config.blockScroll = value ? 1 : 0 }
+    if let value = int64Value(args["shadowStyle"]) { config.shadowStyle = Int32(clamping: value) }
+    return config
+  }
+
+  private func dictionaryArgs(_ arguments: Any?) throws -> [String: Any] {
+    guard let args = arguments as? [String: Any] else {
+      throw KurokoPluginError.invalidArguments("Arguments must be a dictionary.")
+    }
+    return args
+  }
+
+  private func int32Value(_ value: Any?) -> Int32? {
+    if let value = value as? Int32 { return value }
+    if let value = value as? NSNumber { return value.int32Value }
+    if let value = value as? String { return Int32(value) }
+    return nil
+  }
+
+  private func int64Value(_ value: Any?) -> Int64? {
+    if let value = value as? Int64 { return value }
+    if let value = value as? NSNumber { return value.int64Value }
+    if let value = value as? String { return Int64(value) }
+    return nil
+  }
+
+  private func doubleValue(_ value: Any?) -> Double? {
+    if let value = value as? Double { return value }
+    if let value = value as? NSNumber { return value.doubleValue }
+    if let value = value as? String { return Double(value) }
+    return nil
+  }
+
+  private func floatValue(_ value: Any?) -> Float? {
+    if let value = value as? Float, value.isFinite { return value }
+    if let value = value as? Double, value.isFinite { return Float(value) }
+    if let value = value as? NSNumber {
+      let result = value.floatValue
+      return result.isFinite ? result : nil
+    }
+    if let value = value as? String, let result = Float(value), result.isFinite { return result }
+    return nil
+  }
+
+  private func boolValue(_ value: Any?) -> Bool? {
+    if let value = value as? Bool { return value }
+    if let value = value as? NSNumber { return value.boolValue }
+    if let value = value as? String {
+      switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+      case "1", "true", "yes", "on": return true
+      case "0", "false", "no", "off": return false
+      default: return nil
+      }
+    }
+    return nil
+  }
+
+  private func requiredInt64(_ value: Any?, name: String) throws -> Int64 {
+    if let value = int64Value(value) { return value }
+    throw KurokoPluginError.invalidArguments("\(name) is required.")
+  }
+
+  private func requiredUInt64(_ value: Any?, name: String) throws -> UInt64 {
+    if let value = value as? UInt64 { return value }
+    if let value = value as? Int64, value >= 0 { return UInt64(value) }
+    if let value = value as? NSNumber { return value.uint64Value }
+    if let value = value as? String, let parsed = UInt64(value) { return parsed }
+    throw KurokoPluginError.invalidArguments("\(name) is required.")
+  }
+
+  private func boolEnvironmentFlag(_ name: String, environment: [String: String]) -> Bool {
+    switch environment[name]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "1", "true", "yes", "on": return true
+    default: return false
+    }
+  }
+
+  private func floatEnvironmentValue(_ name: String, environment: [String: String]) -> Float? {
+    guard let raw = environment[name]?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !raw.isEmpty,
+          let value = Float(raw),
+          value.isFinite else {
+      return nil
+    }
+    return value
+  }
+
+  private func flutterError(_ error: Error) -> FlutterError {
+    FlutterError(code: "KUROKO_ERROR", message: String(describing: error), details: nil)
+  }
+}
+
+private extension KurokoEventC {
+  func toFlutterMap(playerId: Int64, host: KurokoPlayerHost? = nil) -> [String: Any] {
+    var map: [String: Any] = [
+      "playerId": playerId,
+      "kind": Int(kind),
+      "status": Int(status),
+      "state": Int(state),
+      "durationMicros": Int(durationMicros),
+      "positionMicros": Int64(positionMicros),
+      "buffering": buffering != 0,
+      "video": [
+        "width": Int(video.width),
+        "height": Int(video.height),
+        "primaries": Int(video.primaries),
+        "transfer": Int(video.transfer),
+      ],
+      "tracks": [
+        "video": Int(tracks.video),
+        "audio": Int(tracks.audio),
+        "subtitle": Int(tracks.subtitle),
+      ],
+    ]
+    if kind == 4 || kind == 10 {
+      map["trackList"] = (try? host?.tracks()) ?? []
+      map["trackSelection"] = (try? host?.trackSelection()) ?? [
+        "video": -1,
+        "audio": -1,
+        "subtitle": -1,
+      ]
+    }
+    return map
+  }
+}
+
+private extension KurokoTrackSelectionC {
+  func toFlutterMap() -> [String: Any] {
+    ["video": Int(video), "audio": Int(audio), "subtitle": Int(subtitle)]
+  }
+}
+
+private extension KurokoTrackInfoC {
+  func toFlutterMap() -> [String: Any] {
+    [
+      "id": Int(id),
+      "kind": Int(kind),
+      "source": Int(source),
+      "selected": selected != 0,
+      "canRemove": canRemove != 0,
+      "title": title.map { String(cString: $0) } as Any,
+      "language": language.map { String(cString: $0) } as Any,
+      "codec": codec.map { String(cString: $0) } as Any,
+    ]
+  }
+}
+
+private extension KurokoDanmakuTrackInfoC {
+  func toFlutterMap() -> [String: Any] {
+    [
+      "id": Int64(clamping: id),
+      "enabled": enabled != 0,
+      "offsetMicros": offsetMicros,
+      "itemCount": itemCount,
+      "name": name.map { String(cString: $0) } as Any,
+      "source": source.map { String(cString: $0) } as Any,
+    ]
+  }
+}
+
+private func withOptionalCString<R>(_ value: String?, _ body: (UnsafePointer<CChar>?) -> R) -> R {
+  guard let value, !value.isEmpty else {
+    return body(nil)
+  }
+  return value.withCString { pointer in body(pointer) }
+}

--- a/packages/kuroko_flutter/ios/kuroko_flutter.podspec
+++ b/packages/kuroko_flutter/ios/kuroko_flutter.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name             = 'kuroko_flutter'
+  s.version          = '0.0.1'
+  s.summary          = 'Flutter embedder glue for the Kuroko Rust media engine.'
+  s.description      = <<-DESC
+Flutter iOS plugin that hosts a CAMetalLayer and drives Kuroko through its C ABI.
+                       DESC
+  s.homepage         = 'https://github.com/AimesSoft/Kuroko'
+  s.license          = { :type => 'MPL-2.0' }
+  s.author           = { 'AimesSoft' => 'dev@aimesoft.com' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '13.0'
+  s.swift_version = '5.0'
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'OTHER_LDFLAGS' => '$(inherited) -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox',
+  }
+end

--- a/packages/kuroko_flutter/lib/src/kuroko_player.dart
+++ b/packages/kuroko_flutter/lib/src/kuroko_player.dart
@@ -127,6 +127,14 @@ class KurokoPlayer {
     });
   }
 
+  Future<void> setVolume(double volume) async {
+    final playerId = await ensureCreated();
+    await _invoke('setVolume', <String, Object?>{
+      'playerId': playerId,
+      'volume': volume.clamp(0.0, 1.0),
+    });
+  }
+
   Future<int> addExternalSubtitle(String uri) async {
     final playerId = await ensureCreated();
     final trackId = await _channel.invokeMethod<int>(

--- a/packages/kuroko_flutter/lib/src/kuroko_player.dart
+++ b/packages/kuroko_flutter/lib/src/kuroko_player.dart
@@ -45,6 +45,213 @@ class KurokoDanmakuTrackInfo {
   }
 }
 
+class _KurokoDanmakuConfigPatch {
+  _KurokoDanmakuConfigPatch({
+    this.enabled,
+    this.fontSize,
+    this.opacity,
+    this.displayArea,
+    this.scrollDurationSeconds,
+    this.scrollSpeedFactor,
+    this.trackGapRatio,
+    this.outlineWidth,
+    this.shadowOffsetX,
+    this.shadowOffsetY,
+    this.shadowStyle,
+    this.customFontFamily,
+    this.customFontFilePath,
+    this.mergeDuplicates,
+    this.allowStacking,
+    this.allowScrollOverwrite,
+    this.maxQuantity,
+    this.maxLinesPerMode,
+    this.blockTop,
+    this.blockBottom,
+    this.blockScroll,
+    List<String>? blockWords,
+  }) : blockWords =
+            blockWords == null ? null : List<String>.unmodifiable(blockWords);
+
+  final bool? enabled;
+  final double? fontSize;
+  final double? opacity;
+  final double? displayArea;
+  final double? scrollDurationSeconds;
+  final double? scrollSpeedFactor;
+  final double? trackGapRatio;
+  final double? outlineWidth;
+  final double? shadowOffsetX;
+  final double? shadowOffsetY;
+  final int? shadowStyle;
+  final String? customFontFamily;
+  final String? customFontFilePath;
+  final bool? mergeDuplicates;
+  final bool? allowStacking;
+  final bool? allowScrollOverwrite;
+  final int? maxQuantity;
+  final int? maxLinesPerMode;
+  final bool? blockTop;
+  final bool? blockBottom;
+  final bool? blockScroll;
+  final List<String>? blockWords;
+
+  bool get isEmpty =>
+      enabled == null &&
+      fontSize == null &&
+      opacity == null &&
+      displayArea == null &&
+      scrollDurationSeconds == null &&
+      scrollSpeedFactor == null &&
+      trackGapRatio == null &&
+      outlineWidth == null &&
+      shadowOffsetX == null &&
+      shadowOffsetY == null &&
+      shadowStyle == null &&
+      customFontFamily == null &&
+      customFontFilePath == null &&
+      mergeDuplicates == null &&
+      allowStacking == null &&
+      allowScrollOverwrite == null &&
+      maxQuantity == null &&
+      maxLinesPerMode == null &&
+      blockTop == null &&
+      blockBottom == null &&
+      blockScroll == null &&
+      blockWords == null;
+
+  _KurokoDanmakuConfigPatch merge(_KurokoDanmakuConfigPatch other) {
+    return _KurokoDanmakuConfigPatch(
+      enabled: other.enabled ?? enabled,
+      fontSize: other.fontSize ?? fontSize,
+      opacity: other.opacity ?? opacity,
+      displayArea: other.displayArea ?? displayArea,
+      scrollDurationSeconds:
+          other.scrollDurationSeconds ?? scrollDurationSeconds,
+      scrollSpeedFactor: other.scrollSpeedFactor ?? scrollSpeedFactor,
+      trackGapRatio: other.trackGapRatio ?? trackGapRatio,
+      outlineWidth: other.outlineWidth ?? outlineWidth,
+      shadowOffsetX: other.shadowOffsetX ?? shadowOffsetX,
+      shadowOffsetY: other.shadowOffsetY ?? shadowOffsetY,
+      shadowStyle: other.shadowStyle ?? shadowStyle,
+      customFontFamily: other.customFontFamily ?? customFontFamily,
+      customFontFilePath: other.customFontFilePath ?? customFontFilePath,
+      mergeDuplicates: other.mergeDuplicates ?? mergeDuplicates,
+      allowStacking: other.allowStacking ?? allowStacking,
+      allowScrollOverwrite: other.allowScrollOverwrite ?? allowScrollOverwrite,
+      maxQuantity: other.maxQuantity ?? maxQuantity,
+      maxLinesPerMode: other.maxLinesPerMode ?? maxLinesPerMode,
+      blockTop: other.blockTop ?? blockTop,
+      blockBottom: other.blockBottom ?? blockBottom,
+      blockScroll: other.blockScroll ?? blockScroll,
+      blockWords: other.blockWords ?? blockWords,
+    );
+  }
+
+  _KurokoDanmakuConfigPatch differenceFrom(
+    _KurokoDanmakuConfigPatch? previous,
+  ) {
+    return _KurokoDanmakuConfigPatch(
+      enabled: _changed(enabled, previous?.enabled) ? enabled : null,
+      fontSize: _changed(fontSize, previous?.fontSize) ? fontSize : null,
+      opacity: _changed(opacity, previous?.opacity) ? opacity : null,
+      displayArea:
+          _changed(displayArea, previous?.displayArea) ? displayArea : null,
+      scrollDurationSeconds: _changed(
+        scrollDurationSeconds,
+        previous?.scrollDurationSeconds,
+      )
+          ? scrollDurationSeconds
+          : null,
+      scrollSpeedFactor: _changed(
+        scrollSpeedFactor,
+        previous?.scrollSpeedFactor,
+      )
+          ? scrollSpeedFactor
+          : null,
+      trackGapRatio: _changed(trackGapRatio, previous?.trackGapRatio)
+          ? trackGapRatio
+          : null,
+      outlineWidth:
+          _changed(outlineWidth, previous?.outlineWidth) ? outlineWidth : null,
+      shadowOffsetX: _changed(shadowOffsetX, previous?.shadowOffsetX)
+          ? shadowOffsetX
+          : null,
+      shadowOffsetY: _changed(shadowOffsetY, previous?.shadowOffsetY)
+          ? shadowOffsetY
+          : null,
+      shadowStyle:
+          _changed(shadowStyle, previous?.shadowStyle) ? shadowStyle : null,
+      customFontFamily: _changed(customFontFamily, previous?.customFontFamily)
+          ? customFontFamily
+          : null,
+      customFontFilePath:
+          _changed(customFontFilePath, previous?.customFontFilePath)
+              ? customFontFilePath
+              : null,
+      mergeDuplicates: _changed(mergeDuplicates, previous?.mergeDuplicates)
+          ? mergeDuplicates
+          : null,
+      allowStacking: _changed(allowStacking, previous?.allowStacking)
+          ? allowStacking
+          : null,
+      allowScrollOverwrite: _changed(
+        allowScrollOverwrite,
+        previous?.allowScrollOverwrite,
+      )
+          ? allowScrollOverwrite
+          : null,
+      maxQuantity:
+          _changed(maxQuantity, previous?.maxQuantity) ? maxQuantity : null,
+      maxLinesPerMode: _changed(maxLinesPerMode, previous?.maxLinesPerMode)
+          ? maxLinesPerMode
+          : null,
+      blockTop: _changed(blockTop, previous?.blockTop) ? blockTop : null,
+      blockBottom:
+          _changed(blockBottom, previous?.blockBottom) ? blockBottom : null,
+      blockScroll:
+          _changed(blockScroll, previous?.blockScroll) ? blockScroll : null,
+      blockWords:
+          _changedList(blockWords, previous?.blockWords) ? blockWords : null,
+    );
+  }
+
+  Map<String, Object?> toArguments(int playerId) {
+    return <String, Object?>{
+      'playerId': playerId,
+      if (enabled != null) 'enabled': enabled,
+      if (fontSize != null) 'fontSize': fontSize,
+      if (opacity != null) 'opacity': opacity,
+      if (displayArea != null) 'displayArea': displayArea,
+      if (scrollDurationSeconds != null)
+        'scrollDurationSeconds': scrollDurationSeconds,
+      if (scrollSpeedFactor != null) 'scrollSpeedFactor': scrollSpeedFactor,
+      if (trackGapRatio != null) 'trackGapRatio': trackGapRatio,
+      if (outlineWidth != null) 'outlineWidth': outlineWidth,
+      if (shadowOffsetX != null) 'shadowOffsetX': shadowOffsetX,
+      if (shadowOffsetY != null) 'shadowOffsetY': shadowOffsetY,
+      if (shadowStyle != null) 'shadowStyle': shadowStyle,
+      if (customFontFamily != null) 'customFontFamily': customFontFamily,
+      if (customFontFilePath != null) 'customFontFilePath': customFontFilePath,
+      if (mergeDuplicates != null) 'mergeDuplicates': mergeDuplicates,
+      if (allowStacking != null) 'allowStacking': allowStacking,
+      if (allowScrollOverwrite != null)
+        'allowScrollOverwrite': allowScrollOverwrite,
+      if (maxQuantity != null) 'maxQuantity': maxQuantity,
+      if (maxLinesPerMode != null) 'maxLinesPerMode': maxLinesPerMode,
+      if (blockTop != null) 'blockTop': blockTop,
+      if (blockBottom != null) 'blockBottom': blockBottom,
+      if (blockScroll != null) 'blockScroll': blockScroll,
+      if (blockWords != null) 'blockWordsJson': jsonEncode(blockWords),
+    };
+  }
+
+  static bool _changed<T>(T? value, T? previous) =>
+      value != null && value != previous;
+
+  static bool _changedList(List<String>? value, List<String>? previous) =>
+      value != null && !listEquals(value, previous);
+}
+
 class KurokoPlayer {
   KurokoPlayer({
     this.outputMode,
@@ -68,6 +275,14 @@ class KurokoPlayer {
   int? _id;
   Future<int>? _createFuture;
   bool _disposed = false;
+  static const Duration _danmakuConfigCoalesceDelay =
+      Duration(milliseconds: 50);
+  Timer? _danmakuConfigTimer;
+  bool _danmakuConfigInFlight = false;
+  _KurokoDanmakuConfigPatch? _pendingDanmakuConfig;
+  _KurokoDanmakuConfigPatch? _lastAppliedDanmakuConfig;
+  final List<Completer<void>> _pendingDanmakuConfigCompleters =
+      <Completer<void>>[];
 
   final KurokoOutputMode? outputMode;
   final double? edrHeadroom;
@@ -300,34 +515,107 @@ class KurokoPlayer {
     bool? blockScroll,
     List<String>? blockWords,
   }) async {
+    if (_disposed) {
+      return;
+    }
     final playerId = await ensureCreated();
-    await _invoke('setDanmakuConfig', <String, Object?>{
-      'playerId': playerId,
-      if (enabled != null) 'enabled': enabled,
-      if (fontSize != null) 'fontSize': fontSize,
-      if (opacity != null) 'opacity': opacity,
-      if (displayArea != null) 'displayArea': displayArea,
-      if (scrollDurationSeconds != null)
-        'scrollDurationSeconds': scrollDurationSeconds,
-      if (scrollSpeedFactor != null) 'scrollSpeedFactor': scrollSpeedFactor,
-      if (trackGapRatio != null) 'trackGapRatio': trackGapRatio,
-      if (outlineWidth != null) 'outlineWidth': outlineWidth,
-      if (shadowOffsetX != null) 'shadowOffsetX': shadowOffsetX,
-      if (shadowOffsetY != null) 'shadowOffsetY': shadowOffsetY,
-      if (shadowStyle != null) 'shadowStyle': shadowStyle,
-      if (customFontFamily != null) 'customFontFamily': customFontFamily,
-      if (customFontFilePath != null) 'customFontFilePath': customFontFilePath,
-      if (mergeDuplicates != null) 'mergeDuplicates': mergeDuplicates,
-      if (allowStacking != null) 'allowStacking': allowStacking,
-      if (allowScrollOverwrite != null)
-        'allowScrollOverwrite': allowScrollOverwrite,
-      if (maxQuantity != null) 'maxQuantity': maxQuantity,
-      if (maxLinesPerMode != null) 'maxLinesPerMode': maxLinesPerMode,
-      if (blockTop != null) 'blockTop': blockTop,
-      if (blockBottom != null) 'blockBottom': blockBottom,
-      if (blockScroll != null) 'blockScroll': blockScroll,
-      if (blockWords != null) 'blockWordsJson': jsonEncode(blockWords),
+    final patch = _KurokoDanmakuConfigPatch(
+      enabled: enabled,
+      fontSize: fontSize,
+      opacity: opacity,
+      displayArea: displayArea,
+      scrollDurationSeconds: scrollDurationSeconds,
+      scrollSpeedFactor: scrollSpeedFactor,
+      trackGapRatio: trackGapRatio,
+      outlineWidth: outlineWidth,
+      shadowOffsetX: shadowOffsetX,
+      shadowOffsetY: shadowOffsetY,
+      shadowStyle: shadowStyle,
+      customFontFamily: customFontFamily,
+      customFontFilePath: customFontFilePath,
+      mergeDuplicates: mergeDuplicates,
+      allowStacking: allowStacking,
+      allowScrollOverwrite: allowScrollOverwrite,
+      maxQuantity: maxQuantity,
+      maxLinesPerMode: maxLinesPerMode,
+      blockTop: blockTop,
+      blockBottom: blockBottom,
+      blockScroll: blockScroll,
+      blockWords: blockWords,
+    );
+    if (patch.isEmpty) {
+      return;
+    }
+
+    final completer = Completer<void>();
+    _pendingDanmakuConfig = _pendingDanmakuConfig?.merge(patch) ?? patch;
+    _pendingDanmakuConfigCompleters.add(completer);
+    _scheduleDanmakuConfigFlush(playerId);
+    return completer.future;
+  }
+
+  void _scheduleDanmakuConfigFlush(int playerId) {
+    if (_disposed || _danmakuConfigInFlight || _danmakuConfigTimer != null) {
+      return;
+    }
+    _danmakuConfigTimer = Timer(_danmakuConfigCoalesceDelay, () {
+      _danmakuConfigTimer = null;
+      unawaited(_flushDanmakuConfig(playerId));
     });
+  }
+
+  Future<void> _flushDanmakuConfig(int playerId) async {
+    if (_disposed || _danmakuConfigInFlight) {
+      return;
+    }
+
+    final requestedPatch = _pendingDanmakuConfig;
+    if (requestedPatch == null) {
+      return;
+    }
+    final completers = List<Completer<void>>.of(
+      _pendingDanmakuConfigCompleters,
+    );
+    _pendingDanmakuConfigCompleters.clear();
+    _pendingDanmakuConfig = null;
+
+    final outgoingPatch = requestedPatch.differenceFrom(
+      _lastAppliedDanmakuConfig,
+    );
+    if (outgoingPatch.isEmpty) {
+      for (final completer in completers) {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      }
+      if (_pendingDanmakuConfig != null) {
+        _scheduleDanmakuConfigFlush(playerId);
+      }
+      return;
+    }
+
+    _danmakuConfigInFlight = true;
+    try {
+      await _invoke('setDanmakuConfig', outgoingPatch.toArguments(playerId));
+      _lastAppliedDanmakuConfig =
+          _lastAppliedDanmakuConfig?.merge(requestedPatch) ?? requestedPatch;
+      for (final completer in completers) {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      }
+    } catch (error, stackTrace) {
+      for (final completer in completers) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      }
+    } finally {
+      _danmakuConfigInFlight = false;
+      if (_pendingDanmakuConfig != null) {
+        _scheduleDanmakuConfigFlush(playerId);
+      }
+    }
   }
 
   Future<void> selectAudioTrack(int? trackId) async {
@@ -423,6 +711,15 @@ class KurokoPlayer {
       return;
     }
     _disposed = true;
+    _danmakuConfigTimer?.cancel();
+    _danmakuConfigTimer = null;
+    for (final completer in _pendingDanmakuConfigCompleters) {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+    }
+    _pendingDanmakuConfigCompleters.clear();
+    _pendingDanmakuConfig = null;
     final playerId = _id;
     _id = null;
     _createFuture = null;

--- a/packages/kuroko_flutter/lib/src/kuroko_video_view.dart
+++ b/packages/kuroko_flutter/lib/src/kuroko_video_view.dart
@@ -58,18 +58,35 @@ class _KurokoVideoViewState extends State<KurokoVideoView> {
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) {
+    if (kIsWeb) {
       return const SizedBox.shrink();
     }
-    return AppKitView(
-      viewType: 'kuroko_flutter/video_view',
-      layoutDirection: TextDirection.ltr,
-      creationParamsCodec: const StandardMessageCodec(),
-      creationParams: <String, Object?>{
-        if (widget.debugLabel case final label?) 'debugLabel': label,
-      },
-      onPlatformViewCreated: _handlePlatformViewCreated,
-    );
+    final creationParams = <String, Object?>{
+      if (widget.debugLabel case final label?) 'debugLabel': label,
+    };
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.macOS:
+        return AppKitView(
+          viewType: 'kuroko_flutter/video_view',
+          layoutDirection: TextDirection.ltr,
+          creationParamsCodec: const StandardMessageCodec(),
+          creationParams: creationParams,
+          onPlatformViewCreated: _handlePlatformViewCreated,
+        );
+      case TargetPlatform.iOS:
+        return UiKitView(
+          viewType: 'kuroko_flutter/video_view',
+          layoutDirection: TextDirection.ltr,
+          creationParamsCodec: const StandardMessageCodec(),
+          creationParams: creationParams,
+          onPlatformViewCreated: _handlePlatformViewCreated,
+        );
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return const SizedBox.shrink();
+    }
   }
 }
 

--- a/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
+++ b/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
@@ -152,6 +152,7 @@ private final class KurokoNativeLibrary {
   typealias CommandFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SeekFn = @convention(c) (UnsafeMutableRawPointer?, UInt64) -> Int32
   typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -170,6 +171,7 @@ private final class KurokoNativeLibrary {
   typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
   typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
+  typealias GetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuFontFn = @convention(c) (
     UnsafeMutableRawPointer?,
     UnsafePointer<CChar>?,
@@ -206,6 +208,7 @@ private final class KurokoNativeLibrary {
   let close: CommandFn
   let seek: SeekFn
   let setPlaybackRate: SetPlaybackRateFn?
+  let setVolume: SetVolumeFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -222,6 +225,7 @@ private final class KurokoNativeLibrary {
   let clearDanmaku: ClearDanmakuFn?
   let setDanmakuEnabled: SetDanmakuEnabledFn?
   let setDanmakuConfig: SetDanmakuConfigFn?
+  let getDanmakuConfig: GetDanmakuConfigFn?
   let setDanmakuFont: SetDanmakuFontFn?
   let setDanmakuBlockWords: SetDanmakuBlockWordsFn?
   let trackSelection: TrackSelectionFn
@@ -250,6 +254,7 @@ private final class KurokoNativeLibrary {
     close = try Self.load("kuroko_presenter_close", from: libraryHandle, as: CommandFn.self)
     seek = try Self.load("kuroko_presenter_seek", from: libraryHandle, as: SeekFn.self)
     setPlaybackRate = Self.loadOptional("kuroko_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
+    setVolume = Self.loadOptional("kuroko_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     selectAudioTrack = try Self.load("kuroko_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("kuroko_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("kuroko_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -266,6 +271,7 @@ private final class KurokoNativeLibrary {
     clearDanmaku = Self.loadOptional("kuroko_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
     setDanmakuEnabled = Self.loadOptional("kuroko_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
     setDanmakuConfig = Self.loadOptional("kuroko_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
+    getDanmakuConfig = Self.loadOptional("kuroko_presenter_get_danmaku_config", from: libraryHandle, as: GetDanmakuConfigFn.self)
     setDanmakuFont = Self.loadOptional("kuroko_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
     setDanmakuBlockWords = Self.loadOptional("kuroko_presenter_set_danmaku_block_words_json", from: libraryHandle, as: SetDanmakuBlockWordsFn.self)
     trackSelection = try Self.load("kuroko_presenter_track_selection", from: libraryHandle, as: TrackSelectionFn.self)
@@ -363,6 +369,7 @@ private final class KurokoPlayerHost {
   private weak var attachedView: KurokoMetalSurfaceView?
   private var displayTimer: Timer?
   private var startTimeSeconds: CFTimeInterval = CACurrentMediaTime()
+  private var currentDanmakuConfig = KurokoDanmakuConfigC()
 
   init(id: Int64, library: KurokoNativeLibrary, config: KurokoPresenterConfigC) throws {
     self.id = id
@@ -371,6 +378,7 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.presenterCreateFailed
     }
     self.handle = handle
+    refreshDanmakuConfigSnapshot()
   }
 
   deinit {
@@ -410,6 +418,14 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_playback_rate")
     }
     try check(setRate(handle, rate), operation: "set_playback_rate")
+  }
+
+  func setVolume(_ volume: Double) throws {
+    guard let setVolume = library.setVolume else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_volume")
+    }
+    let clampedVolume = volume.isFinite ? min(max(volume, 0.0), 1.0) : 1.0
+    try check(setVolume(handle, clampedVolume), operation: "set_volume")
   }
 
   func addExternalSubtitle(uri: String) throws -> Int64 {
@@ -542,6 +558,24 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_enabled")
     }
     try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
+    currentDanmakuConfig.enabled = enabled ? 1 : 0
+  }
+
+  func danmakuConfigSnapshot() -> KurokoDanmakuConfigC {
+    currentDanmakuConfig
+  }
+
+  private func refreshDanmakuConfigSnapshot() {
+    guard let getConfig = library.getDanmakuConfig else {
+      return
+    }
+    var config = KurokoDanmakuConfigC()
+    let status = withUnsafeMutablePointer(to: &config) { pointer in
+      getConfig(handle, UnsafeMutableRawPointer(pointer))
+    }
+    if status == 0 {
+      currentDanmakuConfig = config
+    }
   }
 
   func setDanmakuConfig(_ config: KurokoDanmakuConfigC) throws {
@@ -553,6 +587,7 @@ private final class KurokoPlayerHost {
       setConfig(handle, UnsafeRawPointer(pointer))
     }
     try check(status, operation: "set_danmaku_config")
+    currentDanmakuConfig = config
   }
 
   func setDanmakuFont(family: String?, filePath: String?) throws {
@@ -567,6 +602,7 @@ private final class KurokoPlayerHost {
       }
     }
     try check(status, operation: "set_danmaku_font")
+    refreshDanmakuConfigSnapshot()
   }
 
   func setDanmakuBlockWordsJson(_ json: String) throws {
@@ -576,6 +612,7 @@ private final class KurokoPlayerHost {
     try json.withCString { cString in
       try check(setBlockWords(handle, cString), operation: "set_danmaku_block_words")
     }
+    refreshDanmakuConfigSnapshot()
   }
 
   func selectAudioTrack(trackId: Int64?) throws {
@@ -1135,6 +1172,14 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         }
         try host.setPlaybackRate(rate)
         result(nil)
+      case "setVolume":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        guard let volume = doubleValue(args["volume"]) else {
+          throw KurokoPluginError.invalidArguments("volume is required.")
+        }
+        try host.setVolume(volume)
+        result(nil)
       case "addExternalSubtitle":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
@@ -1229,7 +1274,9 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       case "setDanmakuConfig":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
-        try host.setDanmakuConfig(danmakuConfig(from: args))
+        try host.setDanmakuConfig(
+          danmakuConfig(from: args, base: host.danmakuConfigSnapshot())
+        )
         if args.keys.contains("customFontFamily") || args.keys.contains("customFontFilePath") {
           try host.setDanmakuFont(
             family: args["customFontFamily"] as? String,
@@ -1591,8 +1638,11 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     return trackId >= 0 ? trackId : nil
   }
 
-  private func danmakuConfig(from args: [String: Any]) -> KurokoDanmakuConfigC {
-    var config = KurokoDanmakuConfigC()
+  private func danmakuConfig(
+    from args: [String: Any],
+    base: KurokoDanmakuConfigC
+  ) -> KurokoDanmakuConfigC {
+    var config = base
     if let value = boolValue(args["enabled"]) {
       config.enabled = value ? 1 : 0
     }

--- a/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
+++ b/packages/kuroko_flutter/macos/Classes/KurokoFlutterPlugin.swift
@@ -8,6 +8,8 @@ import QuartzCore
 private let kurokoWindowHostedVideoSurfaceId: Int64 = -1
 private let kurokoDebugLabelsEnabled =
   ProcessInfo.processInfo.environment["KUROKO_DEBUG_LABELS"] == "1"
+private let kurokoDefaultDisplayFps = 60.0
+private let kurokoDisplayFpsEpsilon = 0.5
 
 private struct KurokoVideoParamsC {
   var width: UInt32 = 0
@@ -368,6 +370,7 @@ private final class KurokoPlayerHost {
   private let handle: UnsafeMutableRawPointer
   private weak var attachedView: KurokoMetalSurfaceView?
   private var displayTimer: Timer?
+  private var displayTimerFps: Double = 0.0
   private var startTimeSeconds: CFTimeInterval = CACurrentMediaTime()
   private var currentDanmakuConfig = KurokoDanmakuConfigC()
 
@@ -382,7 +385,7 @@ private final class KurokoPlayerHost {
   }
 
   deinit {
-    displayTimer?.invalidate()
+    stopDisplayTimer()
     _ = library.detachSurface(handle)
     library.destroy(handle)
   }
@@ -667,7 +670,7 @@ private final class KurokoPlayerHost {
     attachedView = view
     view.attachedPlayerId = id
     try attachOrResize(view: view, attach: true)
-    startDisplayTimerIfNeeded()
+    startDisplayTimerIfNeeded(resetClock: true)
   }
 
   func detach(viewId: Int64?) {
@@ -676,8 +679,7 @@ private final class KurokoPlayerHost {
     }
     attachedView?.attachedPlayerId = nil
     attachedView = nil
-    displayTimer?.invalidate()
-    displayTimer = nil
+    stopDisplayTimer()
     _ = library.detachSurface(handle)
   }
 
@@ -687,6 +689,7 @@ private final class KurokoPlayerHost {
     }
     do {
       try attachOrResize(view: view, attach: false)
+      startDisplayTimerIfNeeded(resetClock: false)
     } catch {
       NSLog("KurokoFlutterPlugin: resize failed: \(error)")
     }
@@ -743,19 +746,45 @@ private final class KurokoPlayerHost {
     }
   }
 
-  private func startDisplayTimerIfNeeded() {
-    guard displayTimer == nil else {
+  private func startDisplayTimerIfNeeded(resetClock: Bool) {
+    let targetFps = resolvedDisplayTimerFps()
+    if displayTimer != nil && abs(displayTimerFps - targetFps) <= kurokoDisplayFpsEpsilon {
       return
     }
-    startTimeSeconds = CACurrentMediaTime()
-    let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+    stopDisplayTimer()
+    if resetClock {
+      startTimeSeconds = CACurrentMediaTime()
+    }
+    let timer = Timer(timeInterval: 1.0 / targetFps, repeats: true) { [weak self] _ in
       guard let self else {
         return
       }
       self.renderTick(sendEvent: KurokoFlutterPlugin.sharedEventSink)
     }
     displayTimer = timer
+    displayTimerFps = targetFps
     RunLoop.main.add(timer, forMode: .common)
+  }
+
+  private func stopDisplayTimer() {
+    displayTimer?.invalidate()
+    displayTimer = nil
+    displayTimerFps = 0.0
+  }
+
+  private func resolvedDisplayTimerFps() -> Double {
+    if let override = ProcessInfo.processInfo.environment["KUROKO_FLUTTER_TARGET_FPS"],
+       let fps = Double(override), fps.isFinite, fps > 0.0 {
+      return min(max(fps, 1.0), 1000.0)
+    }
+    let screen = attachedView?.window?.screen ?? NSScreen.main
+    if #available(macOS 10.15, *), let screen = screen {
+      let fps = Double(screen.maximumFramesPerSecond)
+      if fps.isFinite && fps > 0.0 {
+        return fps
+      }
+    }
+    return kurokoDefaultDisplayFps
   }
 
   private func check(_ status: Int32, operation: String) throws {

--- a/packages/kuroko_flutter/pubspec.yaml
+++ b/packages/kuroko_flutter/pubspec.yaml
@@ -18,5 +18,7 @@ dev_dependencies:
 flutter:
   plugin:
     platforms:
+      ios:
+        pluginClass: KurokoFlutterPlugin
       macos:
         pluginClass: KurokoFlutterPlugin

--- a/packages/kuroko_flutter/test/kuroko_player_test.dart
+++ b/packages/kuroko_flutter/test/kuroko_player_test.dart
@@ -176,6 +176,33 @@ void main() {
     await player.dispose();
   });
 
+  test('danmaku config coalesces rapid updates', () async {
+    final player = KurokoPlayer();
+
+    final first = player.setDanmakuConfig(fontSize: 24.0);
+    final second = player.setDanmakuConfig(fontSize: 30.0);
+    final third = player.setDanmakuConfig(fontSize: 30.0, opacity: 0.75);
+    await Future.wait(<Future<void>>[first, second, third]);
+
+    final calls = playerCalls
+        .where((MethodCall call) => call.method == 'setDanmakuConfig')
+        .toList(growable: false);
+    expect(calls, hasLength(1));
+    expect(calls.single.arguments, <String, Object?>{
+      'playerId': 7,
+      'fontSize': 30.0,
+      'opacity': 0.75,
+    });
+
+    await player.setDanmakuConfig(fontSize: 30.0, opacity: 0.75);
+    final callsAfterDuplicate = playerCalls
+        .where((MethodCall call) => call.method == 'setDanmakuConfig')
+        .toList(growable: false);
+    expect(callsAfterDuplicate, hasLength(1));
+
+    await player.dispose();
+  });
+
   test('danmaku track controls forward multi-track input', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(playerChannel, (MethodCall call) async {


### PR DESCRIPTION
## Summary
- add the native danmaku performance lab and instrumentation controls
- add the iOS Metal Flutter plugin path alongside the existing macOS path
- coalesce danmaku config/font-size updates and deduplicate Apple volume helpers after the volume-control merge

## Checks
- cargo check -p kuroko
- cargo check -p kuroko_capi
- cargo check --workspace --exclude xtask
