### PR TITLE
Add iOS audio output and plugin parity

### DIFF
--- a/crates/kuroko/build.rs
+++ b/crates/kuroko/build.rs
@@ -9,6 +9,10 @@ fn main() {
     println!("cargo:rerun-if-env-changed=KUROKO_HARFBUZZ_DIR");
     println!("cargo:rerun-if-env-changed=KUROKO_FRIBIDI_DIR");
 
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("ios") {
+        println!("cargo:rustc-link-lib=framework=AudioToolbox");
+    }
+
     if env::var("CARGO_FEATURE_LIBASS").is_err() {
         return;
     }

--- a/crates/kuroko/src/apple.rs
+++ b/crates/kuroko/src/apple.rs
@@ -19,6 +19,438 @@ pub enum AppleDecodeBackend {
     Software,
 }
 
+#[cfg(target_os = "ios")]
+pub mod iosaudio {
+    use std::ffi::c_void;
+    use std::ptr::{self, NonNull};
+    use std::sync::{Arc, Mutex, atomic::{AtomicU32, Ordering}};
+
+    use thiserror::Error;
+
+    use crate::audio::{
+        AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult,
+        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats, apply_volume,
+        normalize_volume,
+    };
+    use crate::ffmpeg::{PcmAudioFrame, PcmFormat, PcmSampleFormat};
+
+    type OSStatus = i32;
+    type UInt32 = u32;
+    type Float64 = f64;
+    type Boolean = u8;
+    type AudioQueueRef = *mut c_void;
+    type AudioQueueBufferRef = *mut AudioQueueBuffer;
+    type CFRunLoopRef = *const c_void;
+    type CFStringRef = *const c_void;
+
+    const NO_ERR: OSStatus = 0;
+    const BUFFER_COUNT: usize = 3;
+    const BUFFER_MILLIS: u32 = 20;
+    const K_AUDIO_FORMAT_LINEAR_PCM: UInt32 = 0x6c70_636d;
+    const K_AUDIO_FORMAT_FLAG_IS_FLOAT: UInt32 = 1 << 0;
+    const K_AUDIO_FORMAT_FLAG_IS_PACKED: UInt32 = 1 << 3;
+
+    #[repr(C)]
+    struct AudioStreamBasicDescription {
+        sample_rate: Float64,
+        format_id: UInt32,
+        format_flags: UInt32,
+        bytes_per_packet: UInt32,
+        frames_per_packet: UInt32,
+        bytes_per_frame: UInt32,
+        channels_per_frame: UInt32,
+        bits_per_channel: UInt32,
+        reserved: UInt32,
+    }
+
+    #[repr(C)]
+    struct AudioQueueBuffer {
+        audio_data_bytes_capacity: UInt32,
+        audio_data: *mut c_void,
+        audio_data_byte_size: UInt32,
+        user_data: *mut c_void,
+        packet_description_capacity: UInt32,
+        packet_descriptions: *mut c_void,
+        packet_description_count: UInt32,
+    }
+
+    type AudioQueueOutputCallback = unsafe extern "C" fn(
+        user_data: *mut c_void,
+        queue: AudioQueueRef,
+        buffer: AudioQueueBufferRef,
+    );
+
+    #[link(name = "AudioToolbox", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioQueueNewOutput(
+            format: *const AudioStreamBasicDescription,
+            callback: AudioQueueOutputCallback,
+            user_data: *mut c_void,
+            run_loop: CFRunLoopRef,
+            run_loop_mode: CFStringRef,
+            flags: UInt32,
+            out_queue: *mut AudioQueueRef,
+        ) -> OSStatus;
+        fn AudioQueueAllocateBuffer(
+            queue: AudioQueueRef,
+            buffer_byte_size: UInt32,
+            out_buffer: *mut AudioQueueBufferRef,
+        ) -> OSStatus;
+        fn AudioQueueEnqueueBuffer(
+            queue: AudioQueueRef,
+            buffer: AudioQueueBufferRef,
+            packet_description_count: UInt32,
+            packet_descriptions: *const c_void,
+        ) -> OSStatus;
+        fn AudioQueueStart(queue: AudioQueueRef, start_time: *const c_void) -> OSStatus;
+        fn AudioQueuePause(queue: AudioQueueRef) -> OSStatus;
+        fn AudioQueueDispose(queue: AudioQueueRef, immediate: Boolean) -> OSStatus;
+    }
+
+    #[derive(Debug, Error)]
+    pub enum IosAudioQueueOutputError {
+        #[error("audio error: {0}")]
+        Audio(#[from] crate::audio::AudioError),
+        #[error("AudioQueue {operation} failed with OSStatus {status}")]
+        AudioQueue { operation: &'static str, status: OSStatus },
+        #[error("AudioQueue output buffer is not configured")]
+        NotConfigured,
+        #[error("AudioQueue output lock was poisoned")]
+        LockPoisoned,
+    }
+
+    pub type Result<T> = std::result::Result<T, IosAudioQueueOutputError>;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct IosAudioQueueOutputConfig {
+        pub ring_buffer: AudioRingBufferConfig,
+    }
+
+    impl Default for IosAudioQueueOutputConfig {
+        fn default() -> Self {
+            Self {
+                ring_buffer: AudioRingBufferConfig {
+                    capacity_frames: 96_000,
+                    drop_oldest_on_overflow: true,
+                },
+            }
+        }
+    }
+
+    struct CallbackState {
+        buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
+    }
+
+    pub struct IosAudioQueueOutput {
+        state: AudioOutputState,
+        format: Option<PcmFormat>,
+        queue: Option<AudioQueueRef>,
+        buffers: Vec<AudioQueueBufferRef>,
+        callback_state: Option<NonNull<CallbackState>>,
+        buffer: Arc<Mutex<AudioRingBuffer>>,
+        volume: Arc<AtomicU32>,
+    }
+
+    impl IosAudioQueueOutput {
+        pub fn new(config: IosAudioQueueOutputConfig) -> Self {
+            Self {
+                state: AudioOutputState::Stopped,
+                format: None,
+                queue: None,
+                buffers: Vec::new(),
+                callback_state: None,
+                buffer: Arc::new(Mutex::new(AudioRingBuffer::new(config.ring_buffer))),
+                volume: Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            }
+        }
+
+        pub fn configure(&mut self, format: PcmFormat) -> Result<()> {
+            self.dispose_queue(true)?;
+            configure_buffer(&self.buffer, format)?;
+            let description = audio_stream_description(format);
+            let state = Box::new(CallbackState {
+                buffer: Arc::clone(&self.buffer),
+                volume: Arc::clone(&self.volume),
+            });
+            let state = NonNull::new(Box::into_raw(state)).expect("Box::into_raw is non-null");
+            let mut queue: AudioQueueRef = ptr::null_mut();
+            check_status(
+                unsafe {
+                    AudioQueueNewOutput(
+                        &description,
+                        audio_queue_output_callback,
+                        state.as_ptr().cast(),
+                        ptr::null(),
+                        ptr::null(),
+                        0,
+                        &mut queue,
+                    )
+                },
+                "AudioQueueNewOutput",
+            )?;
+            if queue.is_null() {
+                unsafe { drop(Box::from_raw(state.as_ptr())) };
+                return Err(IosAudioQueueOutputError::NotConfigured);
+            }
+
+            let buffer_byte_size = audio_queue_buffer_size(format);
+            let mut buffers = Vec::with_capacity(BUFFER_COUNT);
+            for _ in 0..BUFFER_COUNT {
+                let mut audio_buffer: AudioQueueBufferRef = ptr::null_mut();
+                if let Err(error) = check_status(
+                    unsafe { AudioQueueAllocateBuffer(queue, buffer_byte_size, &mut audio_buffer) },
+                    "AudioQueueAllocateBuffer",
+                ) {
+                    unsafe {
+                        let _ = AudioQueueDispose(queue, true as Boolean);
+                        drop(Box::from_raw(state.as_ptr()));
+                    }
+                    return Err(error);
+                }
+                buffers.push(audio_buffer);
+            }
+
+            self.queue = Some(queue);
+            self.buffers = buffers;
+            self.callback_state = Some(state);
+            self.format = Some(format);
+            self.state = AudioOutputState::Stopped;
+            Ok(())
+        }
+
+        pub fn set_volume(&mut self, volume: f32) {
+            self.volume
+                .store(normalize_volume(volume).to_bits(), Ordering::Relaxed);
+        }
+
+        pub fn volume(&self) -> f32 {
+            f32::from_bits(self.volume.load(Ordering::Relaxed))
+        }
+
+        pub fn start(&mut self) -> Result<()> {
+            let queue = self.queue.ok_or(IosAudioQueueOutputError::NotConfigured)?;
+            if self.state != AudioOutputState::Paused {
+                for &buffer in &self.buffers {
+                    fill_audio_queue_buffer(queue, buffer, &self.buffer, &self.volume)?;
+                }
+            }
+            check_status(unsafe { AudioQueueStart(queue, ptr::null()) }, "AudioQueueStart")?;
+            self.state = AudioOutputState::Playing;
+            Ok(())
+        }
+
+        pub fn pause(&mut self) -> Result<()> {
+            if let Some(queue) = self.queue {
+                check_status(unsafe { AudioQueuePause(queue) }, "AudioQueuePause")?;
+            }
+            self.state = AudioOutputState::Paused;
+            Ok(())
+        }
+
+        pub fn stop(&mut self) -> Result<()> {
+            self.dispose_queue(true)?;
+            clear_buffer(&self.buffer)?;
+            self.format = None;
+            self.state = AudioOutputState::Stopped;
+            Ok(())
+        }
+
+        pub fn push(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult> {
+            let mut buffer = self
+                .buffer
+                .lock()
+                .map_err(|_| IosAudioQueueOutputError::LockPoisoned)?;
+            Ok(buffer.push_frame(frame)?)
+        }
+
+        pub fn state(&self) -> AudioOutputState {
+            self.state
+        }
+
+        pub fn stats(&self) -> Result<AudioRingBufferStats> {
+            let buffer = self
+                .buffer
+                .lock()
+                .map_err(|_| IosAudioQueueOutputError::LockPoisoned)?;
+            Ok(buffer.stats())
+        }
+
+        pub fn clock_snapshot(&self) -> Result<AudioClockSnapshot> {
+            let buffer = self
+                .buffer
+                .lock()
+                .map_err(|_| IosAudioQueueOutputError::LockPoisoned)?;
+            Ok(buffer.clock_snapshot())
+        }
+
+        fn dispose_queue(&mut self, immediate: bool) -> Result<()> {
+            if let Some(queue) = self.queue.take() {
+                let status = unsafe { AudioQueueDispose(queue, immediate as Boolean) };
+                self.buffers.clear();
+                if let Some(state) = self.callback_state.take() {
+                    unsafe { drop(Box::from_raw(state.as_ptr())) };
+                }
+                check_status(status, "AudioQueueDispose")?;
+            }
+            Ok(())
+        }
+    }
+
+    impl Default for IosAudioQueueOutput {
+        fn default() -> Self {
+            Self::new(IosAudioQueueOutputConfig::default())
+        }
+    }
+
+    impl Drop for IosAudioQueueOutput {
+        fn drop(&mut self) {
+            let _ = self.dispose_queue(true);
+        }
+    }
+
+    impl AudioOutputBackend for IosAudioQueueOutput {
+        fn configure(&mut self, format: PcmFormat) -> crate::audio::Result<()> {
+            IosAudioQueueOutput::configure(self, format)
+                .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn start(&mut self) -> crate::audio::Result<()> {
+            IosAudioQueueOutput::start(self)
+                .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn pause(&mut self) -> crate::audio::Result<()> {
+            IosAudioQueueOutput::pause(self)
+                .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn stop(&mut self) -> crate::audio::Result<()> {
+            IosAudioQueueOutput::stop(self)
+                .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn set_volume(&mut self, volume: f32) {
+            IosAudioQueueOutput::set_volume(self, volume);
+        }
+
+        fn volume(&self) -> f32 {
+            IosAudioQueueOutput::volume(self)
+        }
+
+        fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {
+            IosAudioQueueOutput::push(self, frame)
+                .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
+        }
+
+        fn state(&self) -> AudioOutputState {
+            self.state()
+        }
+
+        fn stats(&self) -> AudioRingBufferStats {
+            self.stats().unwrap_or_default()
+        }
+
+        fn clock_snapshot(&self) -> Option<AudioClockSnapshot> {
+            self.clock_snapshot().ok()
+        }
+    }
+
+    unsafe extern "C" fn audio_queue_output_callback(
+        user_data: *mut c_void,
+        queue: AudioQueueRef,
+        audio_buffer: AudioQueueBufferRef,
+    ) {
+        if user_data.is_null() || queue.is_null() || audio_buffer.is_null() {
+            return;
+        }
+        let state = unsafe { &*(user_data as *const CallbackState) };
+        let _ = fill_audio_queue_buffer(queue, audio_buffer, &state.buffer, &state.volume);
+    }
+
+    fn fill_audio_queue_buffer(
+        queue: AudioQueueRef,
+        audio_buffer: AudioQueueBufferRef,
+        ring_buffer: &Arc<Mutex<AudioRingBuffer>>,
+        volume: &Arc<AtomicU32>,
+    ) -> Result<()> {
+        if queue.is_null() || audio_buffer.is_null() {
+            return Err(IosAudioQueueOutputError::NotConfigured);
+        }
+        let buffer = unsafe { &mut *audio_buffer };
+        let sample_count = (buffer.audio_data_bytes_capacity as usize) / std::mem::size_of::<f32>();
+        if buffer.audio_data.is_null() || sample_count == 0 {
+            buffer.audio_data_byte_size = 0;
+            return Ok(());
+        }
+        let samples = unsafe { std::slice::from_raw_parts_mut(buffer.audio_data.cast::<f32>(), sample_count) };
+        match ring_buffer.lock() {
+            Ok(mut ring) => {
+                if ring.read_interleaved(samples).is_err() {
+                    samples.fill(0.0);
+                }
+            }
+            Err(_) => samples.fill(0.0),
+        }
+        apply_volume(samples, f32::from_bits(volume.load(Ordering::Relaxed)));
+        buffer.audio_data_byte_size = buffer.audio_data_bytes_capacity;
+        check_status(
+            unsafe { AudioQueueEnqueueBuffer(queue, audio_buffer, 0, ptr::null()) },
+            "AudioQueueEnqueueBuffer",
+        )
+    }
+
+    fn audio_stream_description(format: PcmFormat) -> AudioStreamBasicDescription {
+        match format.sample_format {
+            PcmSampleFormat::F32Interleaved => {
+                let channels = format.channels.max(1);
+                let bytes_per_frame = channels * std::mem::size_of::<f32>() as u32;
+                AudioStreamBasicDescription {
+                    sample_rate: format.sample_rate.max(1) as f64,
+                    format_id: K_AUDIO_FORMAT_LINEAR_PCM,
+                    format_flags: K_AUDIO_FORMAT_FLAG_IS_FLOAT | K_AUDIO_FORMAT_FLAG_IS_PACKED,
+                    bytes_per_packet: bytes_per_frame,
+                    frames_per_packet: 1,
+                    bytes_per_frame,
+                    channels_per_frame: channels,
+                    bits_per_channel: 32,
+                    reserved: 0,
+                }
+            }
+        }
+    }
+
+    fn audio_queue_buffer_size(format: PcmFormat) -> UInt32 {
+        let channels = format.channels.max(1) as usize;
+        let frames = ((format.sample_rate.max(1) as u64 * BUFFER_MILLIS as u64) / 1_000)
+            .clamp(256, 4_096) as usize;
+        (frames * channels * std::mem::size_of::<f32>()).min(UInt32::MAX as usize) as UInt32
+    }
+
+    fn configure_buffer(buffer: &Arc<Mutex<AudioRingBuffer>>, format: PcmFormat) -> Result<()> {
+        let mut buffer = buffer
+            .lock()
+            .map_err(|_| IosAudioQueueOutputError::LockPoisoned)?;
+        Ok(buffer.configure(format)?)
+    }
+
+    fn clear_buffer(buffer: &Arc<Mutex<AudioRingBuffer>>) -> Result<()> {
+        let mut buffer = buffer
+            .lock()
+            .map_err(|_| IosAudioQueueOutputError::LockPoisoned)?;
+        buffer.clear();
+        Ok(())
+    }
+
+    fn check_status(status: OSStatus, operation: &'static str) -> Result<()> {
+        if status == NO_ERR {
+            Ok(())
+        } else {
+            Err(IosAudioQueueOutputError::AudioQueue { operation, status })
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub mod coreaudio {
     use std::sync::{

--- a/crates/kuroko/src/presenter.rs
+++ b/crates/kuroko/src/presenter.rs
@@ -10,7 +10,9 @@ use crossbeam_channel::Receiver;
 
 #[cfg(target_os = "macos")]
 use crate::apple::coreaudio::{CoreAudioOutput, CoreAudioOutputConfig};
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "ios")]
+use crate::apple::iosaudio::{IosAudioQueueOutput, IosAudioQueueOutputConfig};
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 use crate::audio::BufferedAudioOutput;
 use crate::audio::{AudioClockSnapshot, AudioOutputBackend, AudioRingBufferConfig};
 use crate::core::{
@@ -64,7 +66,14 @@ impl Default for PresenterAudioConfig {
                 ring_buffer: config.ring_buffer,
             }
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "ios")]
+        {
+            let config = IosAudioQueueOutputConfig::default();
+            Self {
+                ring_buffer: config.ring_buffer,
+            }
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
             Self {
                 ring_buffer: AudioRingBufferConfig {
@@ -1136,7 +1145,13 @@ fn build_audio_output(config: PresenterAudioConfig) -> Box<dyn AudioOutputBacken
             ring_buffer: config.ring_buffer,
         }))
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "ios")]
+    {
+        Box::new(IosAudioQueueOutput::new(IosAudioQueueOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     {
         Box::new(BufferedAudioOutput::new(config.ring_buffer))
     }

--- a/crates/kuroko_capi/src/lib.rs
+++ b/crates/kuroko_capi/src/lib.rs
@@ -1199,7 +1199,7 @@ pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     handle: *mut KurokoPresenterHandle,
@@ -1486,7 +1486,7 @@ pub unsafe extern "C" fn kuroko_presenter_get_danmaku_config(
     KurokoStatus::PlayerError
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kuroko_presenter_set_danmaku_font(
     _handle: *mut std::ffi::c_void,

--- a/packages/kuroko_flutter/ios/Classes/KurokoFlutterPlugin.swift
+++ b/packages/kuroko_flutter/ios/Classes/KurokoFlutterPlugin.swift
@@ -1,4 +1,5 @@
 import Darwin
+import AVFoundation
 import Flutter
 import Metal
 import QuartzCore
@@ -146,6 +147,7 @@ private final class KurokoNativeLibrary {
   typealias CommandFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SeekFn = @convention(c) (UnsafeMutableRawPointer?, UInt64) -> Int32
   typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -164,6 +166,7 @@ private final class KurokoNativeLibrary {
   typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
   typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
+  typealias GetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuFontFn = @convention(c) (
     UnsafeMutableRawPointer?,
     UnsafePointer<CChar>?,
@@ -200,6 +203,7 @@ private final class KurokoNativeLibrary {
   let close: CommandFn
   let seek: SeekFn
   let setPlaybackRate: SetPlaybackRateFn?
+  let setVolume: SetVolumeFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -216,6 +220,7 @@ private final class KurokoNativeLibrary {
   let clearDanmaku: ClearDanmakuFn?
   let setDanmakuEnabled: SetDanmakuEnabledFn?
   let setDanmakuConfig: SetDanmakuConfigFn?
+  let getDanmakuConfig: GetDanmakuConfigFn?
   let setDanmakuFont: SetDanmakuFontFn?
   let setDanmakuBlockWords: SetDanmakuBlockWordsFn?
   let trackSelection: TrackSelectionFn
@@ -244,6 +249,7 @@ private final class KurokoNativeLibrary {
     close = try Self.load("kuroko_presenter_close", from: libraryHandle, as: CommandFn.self)
     seek = try Self.load("kuroko_presenter_seek", from: libraryHandle, as: SeekFn.self)
     setPlaybackRate = Self.loadOptional("kuroko_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
+    setVolume = Self.loadOptional("kuroko_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     selectAudioTrack = try Self.load("kuroko_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("kuroko_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("kuroko_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -260,6 +266,7 @@ private final class KurokoNativeLibrary {
     clearDanmaku = Self.loadOptional("kuroko_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
     setDanmakuEnabled = Self.loadOptional("kuroko_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
     setDanmakuConfig = Self.loadOptional("kuroko_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
+    getDanmakuConfig = Self.loadOptional("kuroko_presenter_get_danmaku_config", from: libraryHandle, as: GetDanmakuConfigFn.self)
     setDanmakuFont = Self.loadOptional("kuroko_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
     setDanmakuBlockWords = Self.loadOptional("kuroko_presenter_set_danmaku_block_words_json", from: libraryHandle, as: SetDanmakuBlockWordsFn.self)
     trackSelection = try Self.load("kuroko_presenter_track_selection", from: libraryHandle, as: TrackSelectionFn.self)
@@ -337,6 +344,7 @@ private final class KurokoPlayerHost {
   private var displayLink: CADisplayLink?
   private var displayLinkProxy: DisplayLinkProxy?
   private var startTimeSeconds: CFTimeInterval = CACurrentMediaTime()
+  private var currentDanmakuConfig = KurokoDanmakuConfigC()
 
   init(id: Int64, library: KurokoNativeLibrary, config: KurokoPresenterConfigC) throws {
     self.id = id
@@ -359,7 +367,10 @@ private final class KurokoPlayerHost {
     }
   }
 
-  func play() throws { try check(library.play(handle), operation: "play") }
+  func play() throws {
+    try configureAudioSessionForPlayback()
+    try check(library.play(handle), operation: "play")
+  }
   func pause() throws { try check(library.pause(handle), operation: "pause") }
   func stop() throws { try check(library.stop(handle), operation: "stop") }
   func close() throws { try check(library.close(handle), operation: "close") }
@@ -373,6 +384,14 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_playback_rate")
     }
     try check(setRate(handle, rate), operation: "set_playback_rate")
+  }
+
+  func setVolume(_ volume: Double) throws {
+    guard let setVolume = library.setVolume else {
+      throw KurokoPluginError.symbolMissing("kuroko_presenter_set_volume")
+    }
+    let clampedVolume = volume.isFinite ? min(max(volume, 0.0), 1.0) : 1.0
+    try check(setVolume(handle, clampedVolume), operation: "set_volume")
   }
 
   func addExternalSubtitle(uri: String) throws -> Int64 {
@@ -497,6 +516,24 @@ private final class KurokoPlayerHost {
       throw KurokoPluginError.symbolMissing("kuroko_presenter_set_danmaku_enabled")
     }
     try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
+    currentDanmakuConfig.enabled = enabled ? 1 : 0
+  }
+
+  func danmakuConfigSnapshot() -> KurokoDanmakuConfigC {
+    currentDanmakuConfig
+  }
+
+  private func refreshDanmakuConfigSnapshot() {
+    guard let getConfig = library.getDanmakuConfig else {
+      return
+    }
+    var config = KurokoDanmakuConfigC()
+    let status = withUnsafeMutablePointer(to: &config) { pointer in
+      getConfig(handle, UnsafeMutableRawPointer(pointer))
+    }
+    if status == 0 {
+      currentDanmakuConfig = config
+    }
   }
 
   func setDanmakuConfig(_ config: KurokoDanmakuConfigC) throws {
@@ -508,6 +545,7 @@ private final class KurokoPlayerHost {
       setConfig(handle, UnsafeRawPointer(pointer))
     }
     try check(status, operation: "set_danmaku_config")
+    currentDanmakuConfig = config
   }
 
   func setDanmakuFont(family: String?, filePath: String?) throws {
@@ -520,6 +558,7 @@ private final class KurokoPlayerHost {
       }
     }
     try check(status, operation: "set_danmaku_font")
+    refreshDanmakuConfigSnapshot()
   }
 
   func setDanmakuBlockWordsJson(_ json: String) throws {
@@ -529,6 +568,7 @@ private final class KurokoPlayerHost {
     try json.withCString { cString in
       try check(setBlockWords(handle, cString), operation: "set_danmaku_block_words")
     }
+    refreshDanmakuConfigSnapshot()
   }
 
   func selectAudioTrack(trackId: Int64?) throws {
@@ -653,6 +693,12 @@ private final class KurokoPlayerHost {
     if status != 0 {
       throw KurokoPluginError.kurokoStatus(operation, status)
     }
+  }
+
+  private func configureAudioSessionForPlayback() throws {
+    let session = AVAudioSession.sharedInstance()
+    try session.setCategory(.playback, mode: .moviePlayback, options: [])
+    try session.setActive(true)
   }
 }
 
@@ -842,6 +888,13 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         }
         try playerHost(from: args).setPlaybackRate(rate)
         result(nil)
+      case "setVolume":
+        let args = try dictionaryArgs(call.arguments)
+        guard let volume = doubleValue(args["volume"]) else {
+          throw KurokoPluginError.invalidArguments("volume is required.")
+        }
+        try playerHost(from: args).setVolume(volume)
+        result(nil)
       case "addExternalSubtitle":
         let args = try dictionaryArgs(call.arguments)
         guard let uri = args["uri"] as? String, !uri.isEmpty else {
@@ -920,7 +973,9 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       case "setDanmakuConfig":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
-        try host.setDanmakuConfig(danmakuConfig(from: args))
+        try host.setDanmakuConfig(
+          danmakuConfig(from: args, base: host.danmakuConfigSnapshot())
+        )
         if args.keys.contains("customFontFamily") || args.keys.contains("customFontFilePath") {
           try host.setDanmakuFont(
             family: args["customFontFamily"] as? String,
@@ -1072,8 +1127,11 @@ public final class KurokoFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     return trackId >= 0 ? trackId : nil
   }
 
-  private func danmakuConfig(from args: [String: Any]) -> KurokoDanmakuConfigC {
-    var config = KurokoDanmakuConfigC()
+  private func danmakuConfig(
+    from args: [String: Any],
+    base: KurokoDanmakuConfigC
+  ) -> KurokoDanmakuConfigC {
+    var config = base
     if let value = boolValue(args["enabled"]) { config.enabled = value ? 1 : 0 }
     if let value = doubleValue(args["fontSize"]) { config.fontSize = Float(value) }
     if let value = doubleValue(args["opacity"]) { config.opacity = Float(value) }

--- a/packages/kuroko_flutter/ios/kuroko_flutter.podspec
+++ b/packages/kuroko_flutter/ios/kuroko_flutter.podspec
@@ -16,6 +16,6 @@ Flutter iOS plugin that hosts a CAMetalLayer and drives Kuroko through its C ABI
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    'OTHER_LDFLAGS' => '$(inherited) -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox',
+    'OTHER_LDFLAGS' => '$(inherited) -framework AVFoundation -framework AudioToolbox -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox',
   }
 end


### PR DESCRIPTION
## Summary
- add a real iOS AudioQueue output backend using Kuroko's shared PCM ring buffer and audio clock snapshot
- route iOS presenter audio through the new backend instead of the buffered placeholder
- expose iOS plugin parity for volume, danmaku config snapshots, and patch-based danmaku config updates
- link iOS plugin/Rust builds with AudioToolbox and AVFoundation

## Checks
- cargo check -p kuroko
- cargo check -p kuroko_capi
- cargo check -p kuroko --target aarch64-apple-ios
- cargo check -p kuroko_capi --target aarch64-apple-ios
- cargo check --workspace --exclude xtask
- flutter test (packages/kuroko_flutter)
- flutter analyze --no-fatal-warnings (packages/kuroko_flutter)
