### PR TITLE
Add iOS window overlay video surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ final player = ErikaPlayer();
 await player.open('/path/to/video.mp4');
 await player.play();
 
-// Widget 树中:
+// 推荐：完整播放器 UI 在 macOS/iOS 使用原生 window overlay / 挖空路径
+ErikaWindowOverlayVideoView(player: player)
+
+// 兼容/诊断：Flutter platform view 路径
 ErikaVideoView(player: player)
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,12 +189,15 @@ Header: `crates/erika_capi/include/erika.h`
 
 `packages/erika_flutter` provides macOS and iOS Flutter embedding:
 
-- **Dart**: `ErikaPlayer` (commands + events), `ErikaVideoView` (platform view),
-  `ErikaWindowOverlayVideoView` (macOS HDR native layer path).
-- **macOS Swift plugin**: Loads `liberika_capi.dylib`, creates
-  `NSView`/`CAMetalLayer`, drives `render_tick` from display link.
-- **iOS Swift plugin**: Links `liberika_capi.a` statically, creates
-  `UIView`/`CAMetalLayer`, same presenter model.
+- **Dart**: `ErikaPlayer` (commands + events), `ErikaWindowOverlayVideoView`
+  (recommended window-hosted native Metal surface), and `ErikaVideoView`
+  (compatibility platform view).
+- **macOS Swift plugin**: Loads `liberika_capi.dylib`, creates either
+  `NSWindow`-hosted overlay or `NSView`/`CAMetalLayer` platform view surfaces,
+  and drives `render_tick` from a display link.
+- **iOS Swift plugin**: Links `liberika_capi.a` statically, creates either
+  `UIWindow`-hosted overlay or `UIView`/`CAMetalLayer` platform view surfaces,
+  and uses the same presenter model.
 
 See `docs/flutter_embedding.md` for the embedding model and HDR strategy.
 

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -16,41 +16,51 @@ There are two C ABI entrypoint families:
 
 Both families are declared in `crates/erika_capi/include/erika.h`.
 
-## macOS HDR Path
+## Apple Surface Strategies
 
-The macOS HDR path uses a native Metal-backed surface, not Flutter Texture.
-Flutter/AppKit view composition can show video but is vulnerable to black
-flicker, while a window-hosted native layer with a transparent Flutter region is
-the stable HDR direction.
-
-The plugin implements two view strategies:
+The Apple HDR path uses a native Metal-backed surface, not Flutter Texture.
+The Flutter plugin intentionally exposes two native surface strategies on both
+macOS and iOS so hosts can pick the composition model that matches their UI.
 
 ### ErikaVideoView (Platform View)
 
-Standard Flutter platform view backed by `NSView`/`CAMetalLayer`. The plugin
-creates a native video view registered as `erika_flutter/video_view`, attaches
-it to the presenter, and drives rendering from a display link.
+Standard Flutter platform view backed by `NSView`/`CAMetalLayer` on macOS and
+`UIView`/`CAMetalLayer` on iOS. The plugin creates a native video view
+registered as `erika_flutter/video_view`, attaches it to the presenter, and
+drives rendering from a display link.
+
+This path is useful for simple embedders and diagnostics. On macOS it is not the
+recommended production path because AppKit/Flutter platform view composition can
+show black flicker or other compositor artifacts.
 
 ### ErikaWindowOverlayVideoView (Window Overlay)
 
-For HDR/EDR on macOS, the plugin creates a window-hosted native overlay that
-sits outside Flutter's compositor:
+For the preferred HDR/EDR path, the plugin creates a window-hosted native
+overlay that sits outside Flutter's platform-view compositor:
 
 1. Dart `ErikaWindowOverlayVideoView` reserves a rectangle in the widget tree.
-2. The macOS plugin creates a window-level `CAMetalLayer` as a sibling/underlay.
+2. The platform plugin creates a window-level native view with a `CAMetalLayer`
+   as a sibling/underlay of the Flutter host view.
 3. Flutter paints the widget region transparent, leaving a hole for native video.
 4. The widget tracks its position and sends geometry updates with a surface
    generation number, so stale hide calls from disposed widgets cannot affect
    newly attached surfaces.
 5. Attach retry with exponential backoff handles window readiness timing.
 
-## iOS Path
+The overlay path is the recommended path for NipaPlay and other full-player
+UIs. It keeps video presentation owned by Erika/Metal while Flutter remains a
+control and layout layer. On iOS the native side uses `UIWindow` plus a sibling
+`UIView`/`CAMetalLayer`; on macOS it uses the host `NSWindow` plus a sibling
+`NSView`/`CAMetalLayer`.
 
-The iOS plugin uses `UiKitView` backed by `CAMetalLayer`. The Erika C ABI
-static library is linked into the app through a CocoaPod script phase that
-builds the Rust `erika_capi` crate for the target iOS architecture.
+Touch events pass through both native video strategies, so Flutter controls can
+remain above or around the video surface.
 
-Touch events pass through the video view (`hitTestBehavior: transparent`).
+## iOS Build Path
+
+The iOS plugin links the Erika C ABI static library into the app through a
+CocoaPod script phase that builds the Rust `erika_capi` crate for the target iOS
+architecture.
 
 ## Minimal Presenter Flow
 
@@ -106,6 +116,12 @@ final player = ErikaPlayer(
 
 await player.open('/path/to/video.mp4');
 await player.play();
+
+// Preferred for full-player UIs on macOS/iOS:
+ErikaWindowOverlayVideoView(player: player)
+
+// Compatibility/diagnostic platform-view path:
+ErikaVideoView(player: player)
 
 // Playback control
 await player.pause();

--- a/packages/erika_flutter/README.md
+++ b/packages/erika_flutter/README.md
@@ -5,12 +5,22 @@ Flutter plugin for the Erika media playback engine.
 The plugin keeps Dart out of the hot path:
 
 - Dart exposes low-frequency player commands and event streams.
-- The macOS plugin owns `NSView`/`CAMetalLayer` lifecycle and loads the Erika
-  dynamic library.
-- The iOS plugin owns `UIView`/`CAMetalLayer` lifecycle and links the Erika
-  static library.
+- The Apple plugins expose two native Metal surface strategies:
+  `ErikaWindowOverlayVideoView` for the recommended window-hosted overlay path,
+  and `ErikaVideoView` for compatibility platform-view embedding.
+- The macOS plugin loads the Erika dynamic library.
+- The iOS plugin links the Erika static library.
 - Erika owns playback, rendering, audio, timing, and overlays through
   `ErikaPresenterHandle`.
+
+## Video Surfaces
+
+Use `ErikaWindowOverlayVideoView` for full-player macOS/iOS UIs. It reserves a
+Flutter layout rect while the plugin hosts a sibling native `CAMetalLayer`, so
+video stays outside Flutter's platform-view compositor.
+
+Use `ErikaVideoView` when a standard Flutter platform view is required for a
+small embedder, compatibility path, or diagnostics.
 
 ## macOS Setup
 

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -2,8 +2,13 @@ import Darwin
 import AVFoundation
 import Flutter
 import Metal
+import ObjectiveC.runtime
 import QuartzCore
 import UIKit
+
+private let erikaWindowHostedVideoSurfaceId: Int64 = -1
+private let erikaDebugLabelsEnabled =
+  ProcessInfo.processInfo.environment["ERIKA_DEBUG_LABELS"] == "1"
 
 private func erikaHdrWrite(_ message: String) {
   fputs("ErikaHDR[iOS]: \(message)\n", stderr)
@@ -265,7 +270,7 @@ private enum ErikaPluginError: Error, CustomStringConvertible {
     case .viewNotFound(let viewId):
       return "Erika video view \(viewId) was not found."
     case .overlayNotAvailable:
-      return "Window overlay is not available on iOS. Use ErikaVideoView."
+      return "No window-hosted Erika overlay is available."
     case .presenterCreateFailed:
       return "erika_presenter_create returned null."
     case .erikaStatus(let operation, let status):
@@ -1030,6 +1035,144 @@ private final class ErikaMetalUIView: UIView, ErikaMetalSurfaceView {
   }
 }
 
+private final class ErikaWindowOverlayView: UIView, ErikaMetalSurfaceView {
+  let platformViewId: Int64 = erikaWindowHostedVideoSurfaceId
+  weak var plugin: ErikaFlutterPlugin?
+  var attachedPlayerId: Int64?
+
+  private var overlayFrameGeneration: Int64?
+  private var debugLabelView: UILabel?
+
+  override class var layerClass: AnyClass { CAMetalLayer.self }
+
+  var metalLayer: CAMetalLayer { layer as! CAMetalLayer }
+
+  var currentScale: Double {
+    Double(max(1.0, window?.screen.scale ?? UIScreen.main.scale))
+  }
+
+  init(plugin: ErikaFlutterPlugin?) {
+    self.plugin = plugin
+    super.init(frame: .zero)
+    isOpaque = true
+    isHidden = true
+    isUserInteractionEnabled = false
+    backgroundColor = .black
+    contentScaleFactor = CGFloat(currentScale)
+    autoresizingMask = []
+    metalLayer.pixelFormat = .bgra8Unorm
+    metalLayer.framebufferOnly = true
+    metalLayer.isOpaque = true
+    metalLayer.backgroundColor = UIColor.black.cgColor
+    layer.actions = [
+      "bounds": NSNull(),
+      "frame": NSNull(),
+      "position": NSNull(),
+    ]
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  deinit {
+    plugin?.detachOverlayView(self)
+  }
+
+  override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    false
+  }
+
+  override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+    nil
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    updateDrawableSize()
+    plugin?.resizePlayerAttachedToView(viewId: platformViewId)
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    updateDrawableSize()
+    plugin?.resizePlayerAttachedToView(viewId: platformViewId)
+  }
+
+  func updateOverlayFrame(
+    _ frame: CGRect?,
+    visible: Bool,
+    debugLabel: String?,
+    generation: Int64?
+  ) {
+    if visible {
+      overlayFrameGeneration = generation
+    } else if let generation,
+              let overlayFrameGeneration,
+              generation != overlayFrameGeneration {
+      return
+    }
+
+    updateDebugLabel(debugLabel)
+    let shouldShow = visible &&
+      (frame?.width ?? 0) > 0 &&
+      (frame?.height ?? 0) > 0
+
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    defer { CATransaction.commit() }
+
+    guard shouldShow, let frame else {
+      isHidden = true
+      return
+    }
+
+    let resolvedFrame = frame.integral
+    if self.frame != resolvedFrame {
+      self.frame = resolvedFrame
+    }
+    isHidden = false
+    updateDrawableSize()
+    plugin?.resizePlayerAttachedToView(viewId: platformViewId)
+  }
+
+  func updateDrawableSize() {
+    let scale = CGFloat(currentScale)
+    contentScaleFactor = scale
+    metalLayer.contentsScale = scale
+    metalLayer.frame = bounds
+    metalLayer.drawableSize = CGSize(
+      width: max(1.0, bounds.width * scale),
+      height: max(1.0, bounds.height * scale)
+    )
+  }
+
+  func pngSnapshotData() -> Data? {
+    snapshotPngData(of: self)
+  }
+
+  private func updateDebugLabel(_ text: String?) {
+    guard erikaDebugLabelsEnabled, let text, !text.isEmpty else {
+      debugLabelView?.removeFromSuperview()
+      debugLabelView = nil
+      return
+    }
+    let label = debugLabelView ?? UILabel()
+    if debugLabelView == nil {
+      label.textColor = UIColor(white: 1.0, alpha: 0.45)
+      label.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+      label.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(label)
+      NSLayoutConstraint.activate([
+        label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+        label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+      ])
+      debugLabelView = label
+    }
+    label.text = text
+  }
+}
+
 private func snapshotPngData(of view: UIView) -> Data? {
   guard view.bounds.width > 0, view.bounds.height > 0 else {
     return nil
@@ -1077,6 +1220,29 @@ private final class ErikaVideoViewFactory: NSObject, FlutterPlatformViewFactory 
     let platformView = ErikaVideoPlatformView(frame: frame, viewId: viewId, arguments: args, plugin: plugin)
     plugin?.registerView(platformView.metalView, viewId: viewId)
     return platformView
+  }
+}
+
+private enum ErikaAssociatedObjectKeys {
+  static var windowOverlayView: UInt8 = 0
+}
+
+private extension UIWindow {
+  var erikaWindowOverlayView: ErikaWindowOverlayView? {
+    get {
+      objc_getAssociatedObject(
+        self,
+        &ErikaAssociatedObjectKeys.windowOverlayView
+      ) as? ErikaWindowOverlayView
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &ErikaAssociatedObjectKeys.windowOverlayView,
+        newValue,
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
   }
 }
 
@@ -1284,8 +1450,37 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let viewId = try requiredInt64(args["viewId"], name: "viewId")
         host.detach(viewId: viewId)
         result(nil)
-      case "attachOverlay", "detachOverlay", "setOverlayFrame":
-        throw ErikaPluginError.overlayNotAvailable
+      case "attachOverlay":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        let overlay = try ensureWindowOverlayInstalled()
+        try host.attach(view: overlay)
+        result(erikaWindowHostedVideoSurfaceId)
+      case "detachOverlay":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        host.detach(viewId: erikaWindowHostedVideoSurfaceId)
+        if let overlay = resolveWindowOverlay() {
+          overlay.updateOverlayFrame(
+            nil,
+            visible: false,
+            debugLabel: nil,
+            generation: int64Value(args["generation"])
+          )
+        }
+        result(nil)
+      case "setOverlayFrame":
+        let args = try dictionaryArgs(call.arguments)
+        let overlay = try ensureWindowOverlayInstalled()
+        let visible = boolValue(args["visible"]) ?? true
+        let frame = convertedOverlayRect(from: args, targetView: overlay)
+        overlay.updateOverlayFrame(
+          frame,
+          visible: visible,
+          debugLabel: args["debugLabel"] as? String,
+          generation: int64Value(args["generation"])
+        )
+        result(nil)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -1325,6 +1520,158 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         host.resizeFromAttachedView()
       }
     }
+  }
+
+  fileprivate func detachOverlayView(_ view: ErikaWindowOverlayView) {
+    for host in players.values {
+      host.detach(viewId: view.platformViewId)
+    }
+    if views[view.platformViewId]?.view === view {
+      views.removeValue(forKey: view.platformViewId)
+    }
+    if view.window?.erikaWindowOverlayView === view {
+      view.window?.erikaWindowOverlayView = nil
+    }
+  }
+
+  private func ensureWindowOverlayInstalled() throws -> ErikaWindowOverlayView {
+    if let existing = resolveWindowOverlay(),
+       existing.superview != nil {
+      return existing
+    }
+
+    guard let flutterHostView = currentFlutterHostView() else {
+      throw ErikaPluginError.overlayNotAvailable
+    }
+    guard let hostWindow = flutterHostView.window else {
+      throw ErikaPluginError.overlayNotAvailable
+    }
+    let hostSuperview = flutterHostView.superview ?? hostWindow
+
+    prepareFlutterHostViewForWindowOverlay(flutterHostView)
+
+    let overlay = hostWindow.erikaWindowOverlayView ??
+      ErikaWindowOverlayView(plugin: self)
+    overlay.plugin = self
+
+    if overlay.superview !== hostSuperview {
+      overlay.removeFromSuperview()
+      overlay.frame = .zero
+    }
+    if flutterHostView.superview === hostSuperview,
+       shouldPlaceWindowOverlayAboveFlutter() {
+      hostSuperview.insertSubview(overlay, aboveSubview: flutterHostView)
+    } else if flutterHostView.superview === hostSuperview {
+      hostSuperview.insertSubview(overlay, belowSubview: flutterHostView)
+    } else if shouldPlaceWindowOverlayAboveFlutter() {
+      hostSuperview.addSubview(overlay)
+    } else {
+      hostSuperview.insertSubview(overlay, at: 0)
+    }
+
+    hostWindow.erikaWindowOverlayView = overlay
+    registerView(overlay, viewId: overlay.platformViewId)
+    return overlay
+  }
+
+  private func resolveWindowOverlay() -> ErikaWindowOverlayView? {
+    for window in activeWindows() {
+      if let overlay = window.erikaWindowOverlayView {
+        return overlay
+      }
+    }
+    return nil
+  }
+
+  private func currentFlutterHostView() -> UIView? {
+    for window in activeWindows() {
+      if let controller = findFlutterViewController(from: window.rootViewController) {
+        return controller.view
+      }
+    }
+    return activeWindows().first?.rootViewController?.view
+  }
+
+  private func activeWindows() -> [UIWindow] {
+    let scenes = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .filter {
+        $0.activationState == .foregroundActive ||
+          $0.activationState == .foregroundInactive
+      }
+    let windows = scenes.flatMap(\.windows).filter { !$0.isHidden }
+    return windows.sorted { lhs, rhs in
+      if lhs.isKeyWindow != rhs.isKeyWindow {
+        return lhs.isKeyWindow
+      }
+      return lhs.windowLevel.rawValue > rhs.windowLevel.rawValue
+    }
+  }
+
+  private func findFlutterViewController(from controller: UIViewController?) -> FlutterViewController? {
+    guard let controller else {
+      return nil
+    }
+    if let flutter = controller as? FlutterViewController {
+      return flutter
+    }
+    if let presented = findFlutterViewController(from: controller.presentedViewController) {
+      return presented
+    }
+    if let navigation = controller as? UINavigationController,
+       let visible = findFlutterViewController(from: navigation.visibleViewController) {
+      return visible
+    }
+    if let tab = controller as? UITabBarController,
+       let selected = findFlutterViewController(from: tab.selectedViewController) {
+      return selected
+    }
+    for child in controller.children {
+      if let flutter = findFlutterViewController(from: child) {
+        return flutter
+      }
+    }
+    return nil
+  }
+
+  private func prepareFlutterHostViewForWindowOverlay(_ view: UIView) {
+    if shouldPlaceWindowOverlayAboveFlutter() {
+      return
+    }
+    view.isOpaque = false
+    view.backgroundColor = .clear
+    view.layer.isOpaque = false
+    view.layer.backgroundColor = UIColor.clear.cgColor
+    view.window?.backgroundColor = .black
+  }
+
+  private func shouldPlaceWindowOverlayAboveFlutter() -> Bool {
+    let environment = ProcessInfo.processInfo.environment
+    if environment["ERIKA_WINDOW_OVERLAY_BELOW"] == "1" {
+      return false
+    }
+    return environment["ERIKA_WINDOW_OVERLAY_ABOVE"] == "1"
+  }
+
+  private func convertedOverlayRect(
+    from args: [String: Any],
+    targetView: UIView
+  ) -> CGRect? {
+    guard let x = doubleValue(args["x"]),
+          let y = doubleValue(args["y"]),
+          let width = doubleValue(args["width"]),
+          let height = doubleValue(args["height"]) else {
+      return nil
+    }
+    guard width > 0, height > 0 else {
+      return nil
+    }
+    guard let flutterHostView = currentFlutterHostView(),
+          let targetSuperview = targetView.superview else {
+      return CGRect(x: x, y: y, width: width, height: height)
+    }
+    let rect = CGRect(x: x, y: y, width: width, height: height)
+    return flutterHostView.convert(rect, to: targetSuperview)
   }
 
   private func createPlayer(arguments: Any?) throws -> Int64 {

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -1043,6 +1043,10 @@ private final class ErikaWindowOverlayView: UIView, ErikaMetalSurfaceView {
   private var overlayFrameGeneration: Int64?
   private var debugLabelView: UILabel?
 
+  /// Generation of the widget that currently owns this shared overlay surface.
+  /// Used to reject stale detach calls from disposed widgets.
+  var activeGeneration: Int64? { overlayFrameGeneration }
+
   override class var layerClass: AnyClass { CAMetalLayer.self }
 
   var metalLayer: CAMetalLayer { layer as! CAMetalLayer }
@@ -1459,15 +1463,25 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "detachOverlay":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
-        host.detach(viewId: erikaWindowHostedVideoSurfaceId)
-        if let overlay = resolveWindowOverlay() {
-          overlay.updateOverlayFrame(
-            nil,
-            visible: false,
-            debugLabel: nil,
-            generation: int64Value(args["generation"])
-          )
+        let generation = int64Value(args["generation"])
+        let overlay = resolveWindowOverlay()
+        // A disposing widget can fire detachOverlay after a newer widget has
+        // already re-attached the shared overlay surface. Skip the teardown so
+        // the stale detach cannot stop the live surface's display link and
+        // leave a frozen, non-rendering overlay on screen.
+        if let generation,
+           let activeGeneration = overlay?.activeGeneration,
+           generation != activeGeneration {
+          result(nil)
+          return
         }
+        host.detach(viewId: erikaWindowHostedVideoSurfaceId)
+        overlay?.updateOverlayFrame(
+          nil,
+          visible: false,
+          debugLabel: nil,
+          generation: generation
+        )
         result(nil)
       case "setOverlayFrame":
         let args = try dictionaryArgs(call.arguments)

--- a/packages/erika_flutter/lib/src/erika_video_view.dart
+++ b/packages/erika_flutter/lib/src/erika_video_view.dart
@@ -8,6 +8,16 @@ import 'package:flutter/widgets.dart';
 
 import 'erika_player.dart';
 
+bool get _supportsWindowOverlayVideoView =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS);
+
+/// Flutter platform-view video surface backed by AppKit/UIKit.
+///
+/// This is the compatibility surface. Full-player Apple hosts should usually
+/// prefer [ErikaWindowOverlayVideoView] so Erika owns the native Metal video
+/// plane outside Flutter's platform-view compositor.
 class ErikaVideoView extends StatefulWidget {
   const ErikaVideoView({
     super.key,
@@ -94,6 +104,10 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
   }
 }
 
+/// Window-hosted native Metal video surface for macOS and iOS.
+///
+/// The widget reserves a Flutter layout rect while the platform plugin hosts a
+/// sibling native view with a CAMetalLayer and keeps its frame in sync.
 class ErikaWindowOverlayVideoView extends StatefulWidget {
   const ErikaWindowOverlayVideoView({
     super.key,
@@ -185,10 +199,7 @@ class _ErikaWindowOverlayVideoViewState
   }
 
   Future<void> _attachOverlaySurface() async {
-    if (!mounted ||
-        _isBound ||
-        kIsWeb ||
-        defaultTargetPlatform != TargetPlatform.macOS) {
+    if (!mounted || _isBound || !_supportsWindowOverlayVideoView) {
       return;
     }
 
@@ -232,7 +243,7 @@ class _ErikaWindowOverlayVideoViewState
     required bool visible,
     bool force = false,
   }) async {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) {
+    if (!_supportsWindowOverlayVideoView) {
       return;
     }
 
@@ -295,7 +306,7 @@ class _ErikaWindowOverlayVideoViewState
 
   @override
   Widget build(BuildContext context) {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) {
+    if (!_supportsWindowOverlayVideoView) {
       return const SizedBox.shrink();
     }
     _scheduleFrameUpdate();

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -1036,6 +1036,10 @@ final class ErikaWindowOverlayView: NSView, ErikaMetalSurfaceView {
 
   private var overlayFrameGeneration: Int64?
 
+  /// Generation of the widget that currently owns this shared overlay surface.
+  /// Used to reject stale detach calls from disposed widgets.
+  var activeGeneration: Int64? { overlayFrameGeneration }
+
   var currentBackingScale: Double {
     let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
     return Double(max(1.0, scale))
@@ -1444,10 +1448,20 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "detachOverlay":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
-        host.detach(viewId: erikaWindowHostedVideoSurfaceId)
-        if let overlay = resolveWindowOverlay() {
-          overlay.updateOverlayFrame(nil, visible: false, debugLabel: nil, generation: int64Value(args["generation"]))
+        let generation = int64Value(args["generation"])
+        let overlay = resolveWindowOverlay()
+        // A disposing widget can fire detachOverlay after a newer widget has
+        // already re-attached the shared overlay surface. Skip the teardown so
+        // the stale detach cannot stop the live surface's display link and
+        // leave a frozen, non-rendering overlay on screen.
+        if let generation,
+           let activeGeneration = overlay?.activeGeneration,
+           generation != activeGeneration {
+          result(nil)
+          return
         }
+        host.detach(viewId: erikaWindowHostedVideoSurfaceId)
+        overlay?.updateOverlayFrame(nil, visible: false, debugLabel: nil, generation: generation)
         result(nil)
       case "setOverlayFrame":
         let args = try dictionaryArgs(call.arguments)

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -164,6 +164,60 @@ void main() {
     await player.dispose();
   });
 
+  test('window overlay methods forward surface geometry', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(playerChannel, (MethodCall call) async {
+      playerCalls.add(call);
+      return switch (call.method) {
+        'create' => 7,
+        'attachOverlay' => ErikaPlayer.windowOverlayViewId,
+        'dispose' => null,
+        _ => null,
+      };
+    });
+    final player = ErikaPlayer();
+
+    final viewId = await player.attachWindowOverlay();
+    await player.setWindowOverlayFrame(
+      frame: const Rect.fromLTWH(10, 20, 320, 180),
+      visible: true,
+      generation: 42,
+      debugLabel: 'episode.mkv',
+    );
+    await player.detachWindowOverlay(generation: 42);
+
+    expect(viewId, ErikaPlayer.windowOverlayViewId);
+    expect(
+      playerCalls
+          .singleWhere((MethodCall call) => call.method == 'attachOverlay')
+          .arguments,
+      <String, Object?>{'playerId': 7},
+    );
+    expect(
+      playerCalls
+          .singleWhere((MethodCall call) => call.method == 'setOverlayFrame')
+          .arguments,
+      <String, Object?>{
+        'viewId': ErikaPlayer.windowOverlayViewId,
+        'generation': 42,
+        'x': 10.0,
+        'y': 20.0,
+        'width': 320.0,
+        'height': 180.0,
+        'visible': true,
+        'debugLabel': 'episode.mkv',
+      },
+    );
+    expect(
+      playerCalls
+          .singleWhere((MethodCall call) => call.method == 'detachOverlay')
+          .arguments,
+      <String, Object?>{'playerId': 7, 'generation': 42},
+    );
+
+    await player.dispose();
+  });
+
   test('upscaler mode is forwarded to native presenter', () async {
     final player = ErikaPlayer();
 

--- a/readme/README.en.md
+++ b/readme/README.en.md
@@ -59,7 +59,10 @@ final player = ErikaPlayer();
 await player.open('/path/to/video.mp4');
 await player.play();
 
-// In your widget tree:
+// Recommended for full-player UIs: keep video in Erika's native Metal layer.
+ErikaWindowOverlayVideoView(player: player)
+
+// Compatibility/diagnostics: Flutter platform-view embedding remains available.
 ErikaVideoView(player: player)
 ```
 

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -59,7 +59,10 @@ final player = ErikaPlayer();
 await player.open('/path/to/video.mp4');
 await player.play();
 
-// ウィジェットツリー内:
+// 推奨: フルプレイヤー UI では Erika のネイティブ Metal レイヤーを使います。
+ErikaWindowOverlayVideoView(player: player)
+
+// 互換/診断: Flutter platform view 埋め込みも引き続き利用できます。
 ErikaVideoView(player: player)
 ```
 


### PR DESCRIPTION
## Summary
- add a UIWindow-hosted native Metal overlay surface for iOS
- allow ErikaWindowOverlayVideoView on both iOS and macOS
- document the Apple surface choices and recommend window overlay for full-player hosts
- add Dart method-channel coverage for overlay attach/frame/detach calls

## Verification
- git diff --check
- swiftc -parse -target arm64-apple-ios16.0-simulator packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
- flutter analyze (packages/erika_flutter)
- flutter test (packages/erika_flutter)