### PR TITLE
fix(renderer): align HDR peak and PQ output handling

### DIFF
--- a/crates/erika/src/renderer/pipeline.rs
+++ b/crates/erika/src/renderer/pipeline.rs
@@ -18,11 +18,11 @@ impl HdrMetadata {
     }
 
     pub fn nominal_peak_nits(self) -> Option<f32> {
-        self.content_light
-            .and_then(|metadata| metadata.max_content_light_level_nits())
+        self.mastering_display
+            .and_then(|metadata| metadata.max_luminance_nits())
             .or_else(|| {
-                self.mastering_display
-                    .and_then(|metadata| metadata.max_luminance_nits())
+                self.content_light
+                    .and_then(|metadata| metadata.max_content_light_level_nits())
             })
     }
 }
@@ -762,7 +762,7 @@ mod tests {
     }
 
     #[test]
-    fn hdr_metadata_prefers_content_light_peak() {
+    fn hdr_metadata_prefers_mastering_display_peak() {
         let metadata = HdrMetadata::new(
             Some(MasteringDisplayMetadata {
                 display_primaries: None,
@@ -779,9 +779,31 @@ mod tests {
         let source = SourceColorState::new(ColorPrimaries::Bt2020, TransferFunction::Pq)
             .hdr_metadata(Some(metadata));
 
+        assert_eq!(metadata.nominal_peak_nits(), Some(1000.0));
+        assert_eq!(source.nominal_peak_nits, 1000.0);
+        assert_eq!(source.hdr_metadata, Some(metadata));
+    }
+
+    #[test]
+    fn hdr_metadata_falls_back_to_max_cll_when_mastering_peak_is_missing() {
+        let metadata = HdrMetadata::new(
+            Some(MasteringDisplayMetadata {
+                display_primaries: None,
+                white_point: None,
+                min_luminance_nits: Some(0.005),
+                max_luminance_nits: None,
+            }),
+            Some(ContentLightMetadata {
+                max_content_light_level_nits: 4000,
+                max_frame_average_light_level_nits: 450,
+            }),
+        );
+
+        let source = SourceColorState::new(ColorPrimaries::Bt2020, TransferFunction::Pq)
+            .hdr_metadata(Some(metadata));
+
         assert_eq!(metadata.nominal_peak_nits(), Some(4000.0));
         assert_eq!(source.nominal_peak_nits, 4000.0);
-        assert_eq!(source.hdr_metadata, Some(metadata));
     }
 
     #[test]

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -1763,6 +1763,16 @@ mod tests {
         (num / den).powf(1.0 / m1)
     }
 
+    fn ref_pq_inverse_eotf(normalized_nits: f32) -> f32 {
+        let m1 = 0.1593017578125;
+        let m2 = 78.84375;
+        let c1 = 0.8359375;
+        let c2 = 18.8515625;
+        let c3 = 18.6875;
+        let p = normalized_nits.clamp(0.0, 1.0).powf(m1);
+        ((c1 + c2 * p) / (1.0 + c3 * p).max(0.000001)).powf(m2)
+    }
+
     fn ref_transfer_to_source_linear(rgb: [f32; 3], u: &VideoUniforms) -> [f32; 3] {
         let rgb = rgb.map(|c| c.max(0.0));
         match u.source_transfer {
@@ -1810,6 +1820,12 @@ mod tests {
     }
 
     fn ref_output(rgb: [f32; 3], u: &VideoUniforms) -> [f32; 3] {
+        if u.target_transfer == 3 {
+            let pq_absolute_peak_nits = 10000.0;
+            let target_white = u.nits[3].max(1.0);
+            return rgb
+                .map(|c| ref_pq_inverse_eotf(c.max(0.0) * target_white / pq_absolute_peak_nits));
+        }
         if u.edr_output != 0 {
             return rgb.map(|c| c.max(0.0));
         }
@@ -1821,6 +1837,9 @@ mod tests {
     }
 
     fn ref_final(rgb: [f32; 3], u: &VideoUniforms) -> [f32; 3] {
+        if u.target_transfer == 3 {
+            return rgb.map(|c| c.clamp(0.0, 1.0));
+        }
         if u.edr_output != 0 {
             let headroom = (u.nits[1].max(1.0) / u.nits[3].max(1.0)).max(1.0);
             rgb.map(|c| c.clamp(0.0, headroom))
@@ -1901,6 +1920,10 @@ mod tests {
             [0.0, 0.0, 1.0, 0.0],
         ];
 
+        let mut pq_target = identity;
+        pq_target.target_transfer = 3;
+        pq_target.nits = [1000.0, 10000.0, 203.0, 203.0];
+
         let samples = [
             (16u8, 128u8, 128u8),
             (128, 128, 128),
@@ -1909,7 +1932,7 @@ mod tests {
             (235, 128, 128),
         ];
 
-        for uniforms in [sdr, identity] {
+        for uniforms in [sdr, identity, pq_target] {
             for (y, cb, cr) in samples {
                 let (luma, chroma) = build_solid_nv12(4, 4, y, cb, cr);
                 let out = renderer

--- a/crates/erika/src/renderer/wgpu_video.wgsl
+++ b/crates/erika/src/renderer/wgpu_video.wgsl
@@ -54,6 +54,16 @@ fn pq_eotf(encoded: f32) -> f32 {
     return pow(num / den, 1.0 / m1);
 }
 
+fn pq_inverse_eotf(normalized_nits: f32) -> f32 {
+    let m1 = 0.1593017578125;
+    let m2 = 78.84375;
+    let c1 = 0.8359375;
+    let c2 = 18.8515625;
+    let c3 = 18.6875;
+    let p = pow(clamp(normalized_nits, 0.0, 1.0), m1);
+    return pow((c1 + c2 * p) / max(1.0 + c3 * p, 0.000001), m2);
+}
+
 fn transfer_to_source_reference_linear(rgb_in: vec3<f32>) -> vec3<f32> {
     let rgb = max(rgb_in, vec3<f32>(0.0));
     if (uniforms.source_transfer == 3u) {
@@ -106,6 +116,15 @@ fn target_nits_to_reference_linear(nits: vec3<f32>) -> vec3<f32> {
 }
 
 fn target_reference_linear_to_output(rgb: vec3<f32>) -> vec3<f32> {
+    if (uniforms.target_transfer == 3u) {
+        let pq_absolute_peak_nits = 10000.0;
+        let nits = max(rgb, vec3<f32>(0.0)) * target_reference_white_nits();
+        return vec3<f32>(
+            pq_inverse_eotf(nits.r / pq_absolute_peak_nits),
+            pq_inverse_eotf(nits.g / pq_absolute_peak_nits),
+            pq_inverse_eotf(nits.b / pq_absolute_peak_nits)
+        );
+    }
     if (uniforms.edr_output != 0u) {
         return max(rgb, vec3<f32>(0.0));
     }
@@ -119,6 +138,9 @@ fn target_reference_linear_to_output(rgb: vec3<f32>) -> vec3<f32> {
 }
 
 fn final_output(rgb: vec3<f32>) -> vec4<f32> {
+    if (uniforms.target_transfer == 3u) {
+        return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+    }
     if (uniforms.edr_output != 0u) {
         let headroom = max(target_peak_nits() / target_reference_white_nits(), 1.0);
         return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(headroom)), 1.0);


### PR DESCRIPTION
Align HDR10 static metadata peak selection with libplacebo-style mastering-display preference and add PQ target output handling for the wgpu video path.