### PR TITLE
fix(ios): keep CAMetalLayer backing layer at the view's frame

### DIFF
--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -1023,7 +1023,10 @@ private final class ErikaMetalUIView: UIView, ErikaMetalSurfaceView {
     let scale = CGFloat(currentScale)
     contentScaleFactor = scale
     metalLayer.contentsScale = scale
-    metalLayer.frame = bounds
+    // metalLayer is this view's *backing* layer (layerClass == CAMetalLayer);
+    // UIKit already syncs its frame to the view. Setting it to `bounds` would
+    // move the backing layer to the superlayer origin, rendering the video at
+    // (0,0) instead of the view's frame (visible once the view isn't full-screen).
     metalLayer.drawableSize = CGSize(
       width: max(1.0, bounds.width * scale),
       height: max(1.0, bounds.height * scale)
@@ -1144,7 +1147,10 @@ private final class ErikaWindowOverlayView: UIView, ErikaMetalSurfaceView {
     let scale = CGFloat(currentScale)
     contentScaleFactor = scale
     metalLayer.contentsScale = scale
-    metalLayer.frame = bounds
+    // metalLayer is this view's *backing* layer (layerClass == CAMetalLayer);
+    // UIKit already syncs its frame to the view. Setting it to `bounds` would
+    // move the backing layer to the superlayer origin, rendering the video at
+    // (0,0) instead of the view's frame (visible once the view isn't full-screen).
     metalLayer.drawableSize = CGSize(
       width: max(1.0, bounds.width * scale),
       height: max(1.0, bounds.height * scale)


### PR DESCRIPTION
## Summary
- Fix iOS window-overlay video rendering at the wrong on-screen position when the surface is not full-screen.
- `updateDrawableSize()` set `metalLayer.frame = bounds` on both iOS metal views. Since these views use `layerClass == CAMetalLayer`, `metalLayer` is the view's **backing layer**, whose frame UIKit manages automatically. Forcing it to `bounds` moved the backing layer to the superlayer origin, so the video rendered at `(0,0)` instead of the view's frame.
- Removed the manual assignment on both views; `drawableSize`/`contentsScale` are still set explicitly.

## Symptom
With a host that centers `ErikaWindowOverlayVideoView` in a sub-rect (e.g. a 21:9 video letterboxed inside the safe area), the picture rendered at the correct **size** but snapped into a **corner**. It was invisible while the overlay filled the whole screen (origin already `(0,0)`).

## Root cause
iOS: `CAMetalLayer` is the view's backing layer → setting its `frame` overrides UIKit's positioning. macOS was unaffected because there the metal layer is a sibling **sublayer**, where setting `frame = bounds` is correct.

## Verification
- `swiftc -parse -target arm64-apple-ios16.0-simulator` on the plugin.
- On device (iPhone 16e simulator): the centered 21:9 overlay now renders centered with symmetric letterbox bars instead of corner-anchored; full-screen playback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)