### PR TITLE
docs: add trilingual developer docs

### DIFF
--- a/crates/erika/assets/artcnn/README.ja.md
+++ b/crates/erika/assets/artcnn/README.ja.md
@@ -1,0 +1,22 @@
+# ArtCNN weights
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+`artcnn_c4f16.bin` / `artcnn_c4f32.bin` は [ArtCNN](https://github.com/Artoriuz/ArtCNN) の upstream ONNX release から変換したものです（MIT、`LICENSE.ArtCNN` を参照）。取得元は 2026-06-11 の `main` branch です。
+
+C-series モデルは luma doubler です（1 channel input、2x resolution output）。anime / line-art 向けに Manga109 で学習されています。
+
+| Blob | Architecture | Parameters |
+|------|--------------|------------|
+| `artcnn_c4f16.bin` | 7 convs, 16 features, residual, DepthToSpace 2x | ~12K |
+| `artcnn_c4f32.bin` | 7 convs, 32 features, residual, DepthToSpace 2x | ~48K |
+
+`export_artcnn.py` で再生成できます（`onnx`、`onnxruntime`、`numpy` が必要です）。
+
+```sh
+python3 export_artcnn.py ArtCNN_C4F16.onnx artcnn_c4f16.bin \
+    --test-vector ../../tests/data/artcnn/c4f16
+```
+
+blob layout はスクリプトの header に記載されており、`src/renderer/metal/upscaler.rs` から利用されています。
+

--- a/crates/erika/assets/artcnn/README.zh.md
+++ b/crates/erika/assets/artcnn/README.zh.md
@@ -1,0 +1,22 @@
+# ArtCNN 权重
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+`artcnn_c4f16.bin` / `artcnn_c4f32.bin` 是从 [ArtCNN](https://github.com/Artoriuz/ArtCNN) 的上游 ONNX release 转换而来（MIT，见 `LICENSE.ArtCNN`），来源是 2026-06-11 抓取的 `main` 分支。
+
+C 系列模型是亮度 doubler（1 通道输入，2x 分辨率输出），针对动漫/线稿内容在 Manga109 上训练：
+
+| Blob | Architecture | Parameters |
+|------|--------------|------------|
+| `artcnn_c4f16.bin` | 7 convs, 16 features, residual, DepthToSpace 2x | ~12K |
+| `artcnn_c4f32.bin` | 7 convs, 32 features, residual, DepthToSpace 2x | ~48K |
+
+使用 `export_artcnn.py` 可重新生成（需要 `onnx`、`onnxruntime`、`numpy`）：
+
+```sh
+python3 export_artcnn.py ArtCNN_C4F16.onnx artcnn_c4f16.bin \
+    --test-vector ../../tests/data/artcnn/c4f16
+```
+
+blob 布局记录在脚本头部，并由 `src/renderer/metal/upscaler.rs` 消费。
+

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -1,0 +1,159 @@
+# Erika Architecture
+
+[中文](architecture.zh.md) | [English](architecture.md) | [日本語](architecture.ja.md)
+
+Erika は埋め込み可能な Rust メディア再生ライブラリです。ホストアプリは Rust API、C ABI (`erika_capi`)、または Flutter バインディング (`erika_flutter`) から呼び出せます。動画フレーム、字幕、弾幕はすべてエンジン内部に留まり、レンダラー内で合成され、ホストの描画パイプラインは経由しません。
+
+## システム概要
+
+```text
+Rust Player Core
+  source abstraction ─── file + HTTP range
+  FFmpeg wrappers ────── custom AVIO, probe, demux, decode, seek, audio resample
+  playback engine ────── video/audio tick, clock, frame scheduler
+  video decode ───────── VideoToolbox (macOS/iOS), software fallback
+  audio output ───────── CoreAudio (macOS), AudioQueue (iOS), ring buffer
+  overlay timeline ───── subtitle + danmaku composition
+  renderer core ──────── color state, render graph, tone map, scaler policy
+  Metal renderer ─────── zero-copy NV12/P010, HDR/EDR, subtitle/danmaku pass
+  wgpu renderer ──────── cross-platform video + danmaku rendering
+  presenter runtime ──── ties player + renderer + audio + overlays
+  C ABI ──────────────── 63 exported functions, two handle families
+  Flutter plugin ─────── macOS + iOS native view embedding
+```
+
+## ネイティブ依存関係
+
+`xtask` は固定の upstream からネイティブ依存関係をダウンロード・ビルド・インストールし、`third_party/` に配置します。既定 profile は `lgpl` です。
+
+| 依存関係 | バージョン | 目的 |
+|----------|-----------|------|
+| FFmpeg | 7.1.1 | Demux、decode、audio resample、VideoToolbox |
+| libass | 0.17.3 | ASS 字幕描画 |
+| FreeType | 2.13.3 | フォントラスタライズ（libass 依存） |
+| HarfBuzz | 10.4.0 | テキストシェーピング（libass 依存） |
+| FriBidi | 1.0.16 | 双方向テキスト処理（libass 依存） |
+
+すべて静的リンクです。libass とその依存関係は既定で有効です（`features = ["libass"]`）。
+
+```sh
+cargo run -p xtask -- deps build --all --profile lgpl
+cargo run -p xtask -- deps status
+```
+
+## FFmpeg 統合
+
+`erika_ffmpeg_sys` は build 時に bindgen で低レベルバインディングを生成します。`erika::ffmpeg` は安全な Rust ラッパーを提供します。
+
+- **Demuxer**: `AVFormatContext` を保持し、`MediaSource` 由来の Rust-backed custom `AVIOContext` を使うこともできます。stream selection、reference-counted packets、timestamp-based seek をサポートします。
+- **Decoder**: software と VideoToolbox hardware backend を持ちます。hardware frames は BT.2020/PQ metadata を保持し、`CVPixelBufferRef` を通じて Metal に zero-copy で渡せます。
+- **AudioResampler**: `libswresample` を包み、interleaved f32 PCM（既定 48 kHz stereo）へ変換します。
+- **SubtitleDecoder**: 埋め込みテキスト字幕と bitmap 字幕ストリームをデコードします。
+
+## 再生エンジン
+
+`PlaybackSession` は media を開き、track を選び、decode backend を設定し、video frame と PCM audio block を生成します。
+
+`VideoPlaybackEngine` は clocked playback を追加します。
+
+- Play / pause / stop / seek / playback rate control / EOF detection。
+- `PlaybackClock`: audio-master clock discipline を持つ media-time anchor。
+- `VideoFrameScheduler`: decoded video frame の present / wait / drop を決定します。
+- `DisplaySyncState`: residual frame-duration error を持ち回る vsync quantizer です。
+
+## 音声出力
+
+- **macOS**: ring buffer と PTS-tracking clock snapshot を持つ CoreAudio 出力。presenter は snapshot を player worker に返し、audio-master clock discipline を維持します。
+- **iOS**: 同じ ring buffer / clock snapshot model を持つ AudioQueue 出力。
+- Ring buffer: interleaved f32、容量可変、overflow は oldest drop、volume control 対応。
+
+## 字幕システム
+
+- **Parsing**: SRT、WebVTT、ASS timeline parsing。embedded / external subtitle track を扱い、external track は runtime で追加・削除できます。
+- **libass renderer**: static link で既定有効。ASS script を受け取り、`ass_render_frame` を呼び、alpha plane を Erika の overlay system に取り込みます。Apple platform では CoreText font provider を使います。
+- **SubtitleRendererCore**: changed / unchanged frame を追跡し、不要な GPU upload を避ける renderer-facing boundary です。
+
+## 弾幕システム
+
+弾幕サブシステムは NipaPlay DFM+ の layout algorithm を Rust で native 実装しています。完全な設計は `docs/danmaku_architecture.md` を参照してください。
+
+- **入力**: Bilibili XML、JSON、JSON-lines parsing。
+- **DanmakuSession**: multi-track 管理、track ごとの enable/disable、track offset、global offset。
+- **DFM+ layout core**: prepare / frame-query 分離。prepare は measurement、filtering、duplicate merge、collision avoidance、lane allocation を一括で処理します。frame query は指定 media time の positioned items を返します。
+- **Text rasterizer**: fill / outline alpha mask を持つ glyph atlas と、GPU texture reuse 用の version tracking。
+- **Render plan**: `DanmakuRenderPlan` は screen rect、atlas tex rect、色、outline、shadow を持つ glyph instances を運びます。Metal と wgpu は atlas から instanced quad を描画します。
+
+## レンダラー
+
+### Metal Renderer（macOS/iOS）
+
+Apple platform の主 renderer です。
+
+- `CVMetalTextureCache` 経由で CVPixelBuffer → MTLTexture を zero-copy import。
+- YCbCr sampling、transfer decode、gamut mapping（BT.2020→BT.709、Display P3→BT.709）。
+- Tone mapping: Mobius、Reinhard、clip with absolute nits。
+- SDR output（`BGRA8Unorm`）と Apple EDR output（`RGBA16Float` + EDR headroom）。
+- Neural luma upscaler（`LumaUpscalerMode`）: ArtCNN C4F16/C4F32 2x doubler を Metal compute pass として decoded Y plane に適用し、render pass と同じ command buffer で実行します（`renderer/metal/upscaler.rs`）。Chroma は source resolution のままです。動画が source resolution より大きく表示される場合のみ動作し、network output は decoded frame ごとに cache されるため、同じ frame の繰り返し vsync tick では compute を再実行しません。weights は upstream ONNX release（`assets/artcnn/`）から変換し、`tests/artcnn_upscaler.rs` の onnxruntime reference で検証しています。backend は `simdgroup_matrix` matmul（Apple Silicon default）と scalar texture fallback の 2 つで、どちらも background thread で compile され、準備完了までは未拡大で再生を続けます。
+- Subtitle overlay: RGBA plane upload と alpha blending。
+- Danmaku: atlas からの instanced glyph quad drawing（shadow → outline → fill）。
+- Presentation layout は source aspect ratio を保ちます。
+
+### wgpu Renderer（cross-platform）
+
+移植性向けの第二 backend です。
+
+- `wgpu` dependency と device / surface / pipeline creation。
+- NV12/P010 video frame upload と WGSL YCbCr conversion shader。
+- 色空間変換と tone mapping（Metal と同じ pipeline model）。
+- Danmaku glyph atlas rendering。
+- headless testing 用 offscreen render target。
+- surface handle model は macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window をカバーします。
+- VideoToolbox zero-copy import と HDR/EDR output は未実装です。
+
+### Render Pipeline
+
+`renderer::pipeline` は backend が消費する前に、Rust 側で描画判断を記述します。
+
+- `SourceColorState` / `TargetColorState`: primaries、transfer、range。
+- `VideoRenderPipeline`: gamut matrix、tone map operator、transfer functions。
+- HDR metadata: mastering display、content light level、nominal peak nits。
+
+## Presenter Runtime
+
+`PresenterRuntime` は Player、MetalRenderer、OverlayTimeline、DanmakuEngine、audio output をつなぎます。host は native surface を提供し、display timer から `render_tick` を呼びます。
+
+- video frame を pump し、overlay（subtitle + danmaku）を更新し、render して present します。
+- danmaku plan generation は generation + media_time gate で video frame と同期します。
+- playback rate、volume、track selection、subtitle/danmaku configuration を runtime で変更できます。
+
+## C ABI
+
+`erika_capi` は 2 つの handle family で 63 関数を export します。
+
+- **`ErikaHandle`**: player control と event polling。rendering は host 管理です。
+- **`ErikaPresenterHandle`**: Erika が full stack を所有します。host は surface を渡して `render_tick` を呼びます。
+
+create/destroy、open/play/pause/stop/seek、track selection、subtitle track add/remove、danmaku track management（add/remove/enable/offset/config）、surface attach/detach/resize、event polling、volume、playback rate、neural luma upscaler switching、upscaler backend status diagnostics を含みます。
+
+Header: `crates/erika_capi/include/erika.h`
+
+## Flutter Plugin
+
+`packages/erika_flutter` は macOS / iOS の Flutter embedding を提供します。
+
+- **Dart**: `ErikaPlayer`（commands + events）、`ErikaWindowOverlayVideoView`（推奨の window-hosted native Metal surface）、`ErikaVideoView`（compatibility platform view）。
+- **macOS Swift plugin**: `liberika_capi.dylib` を読み込み、`NSWindow` overlay または `NSView`/`CAMetalLayer` platform view surface を作成し、display link から `render_tick` を駆動します。
+- **iOS Swift plugin**: `liberika_capi.a` を static link し、`UIWindow` overlay または `UIView`/`CAMetalLayer` platform view surface を作成し、同じ presenter model を使います。
+
+embedding model と HDR strategy は `docs/flutter_embedding.md` を参照してください。
+
+## Platform Support
+
+| Platform | Decode | Render | Audio | Status |
+|----------|--------|--------|-------|--------|
+| macOS 14+ | VideoToolbox | Metal | CoreAudio | Available |
+| iOS 16+ | VideoToolbox | Metal | AudioQueue | Available |
+| Windows | — | wgpu (planned) | — | Planned |
+| Linux | — | wgpu (planned) | — | Planned |
+| Android | — | wgpu (planned) | — | Planned |
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Erika Architecture
 
+[中文](architecture.zh.md) | [English](architecture.md) | [日本語](architecture.ja.md)
+
 Erika is an embeddable Rust media playback library. Host applications call into
 the engine through the Rust API, a C ABI (`erika_capi`), or Flutter bindings
 (`erika_flutter`). Video frames, subtitles, and danmaku stay inside the engine

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -1,0 +1,159 @@
+# Erika Architecture
+
+[中文](architecture.zh.md) | [English](architecture.md) | [日本語](architecture.ja.md)
+
+Erika 是一个可嵌入的 Rust 媒体播放库。宿主应用可以通过 Rust API、C ABI (`erika_capi`) 或 Flutter 绑定 (`erika_flutter`) 调用它。视频帧、字幕和弹幕都留在引擎内部，并在渲染器里合成，不会流经宿主渲染管线。
+
+## 系统概览
+
+```text
+Rust Player Core
+  source abstraction ─── file + HTTP range
+  FFmpeg wrappers ────── custom AVIO, probe, demux, decode, seek, audio resample
+  playback engine ────── video/audio tick, clock, frame scheduler
+  video decode ───────── VideoToolbox (macOS/iOS), software fallback
+  audio output ───────── CoreAudio (macOS), AudioQueue (iOS), ring buffer
+  overlay timeline ───── subtitle + danmaku composition
+  renderer core ──────── color state, render graph, tone map, scaler policy
+  Metal renderer ─────── zero-copy NV12/P010, HDR/EDR, subtitle/danmaku pass
+  wgpu renderer ──────── cross-platform video + danmaku rendering
+  presenter runtime ──── ties player + renderer + audio + overlays
+  C ABI ──────────────── 63 exported functions, two handle families
+  Flutter plugin ─────── macOS + iOS native view embedding
+```
+
+## 原生依赖
+
+`xtask` 会从固定上游源下载、构建并安装原生依赖到 `third_party/`。默认 profile 是 `lgpl`。
+
+| 依赖 | 版本 | 作用 |
+|------|------|------|
+| FFmpeg | 7.1.1 | Demux、decode、audio resample、VideoToolbox |
+| libass | 0.17.3 | ASS 字幕渲染 |
+| FreeType | 2.13.3 | 字体栅格化（libass 依赖） |
+| HarfBuzz | 10.4.0 | 文本 shaping（libass 依赖） |
+| FriBidi | 1.0.16 | 双向文本处理（libass 依赖） |
+
+所有依赖都静态链接。libass 及其依赖默认启用（`features = ["libass"]`）。
+
+```sh
+cargo run -p xtask -- deps build --all --profile lgpl
+cargo run -p xtask -- deps status
+```
+
+## FFmpeg 集成
+
+`erika_ffmpeg_sys` 在构建时通过 bindgen 生成底层绑定。`erika::ffmpeg` 提供安全的 Rust 封装：
+
+- **Demuxer**：持有 `AVFormatContext`，可选使用来自 `MediaSource` 的 Rust 后端自定义 `AVIOContext`。支持流选择、引用计数 packet 和基于时间戳的 seek。
+- **Decoder**：软件和 VideoToolbox 硬件后端。硬件帧保留 BT.2020/PQ 元数据，并携带 `CVPixelBufferRef` 供 Metal 零拷贝导入。
+- **AudioResampler**：封装 `libswresample`，输出 interleaved f32 PCM（默认 48 kHz stereo）。
+- **SubtitleDecoder**：解码内嵌文本和位图字幕流。
+
+## 播放引擎
+
+`PlaybackSession` 负责打开媒体、选择轨道、配置解码后端，并产出视频帧和 PCM 音频块。
+
+`VideoPlaybackEngine` 增加时钟驱动播放：
+
+- 播放、暂停、停止、seek、倍速控制、EOF 检测。
+- `PlaybackClock`：带音频主时钟约束的 media-time 锚点（deadband 校正、逐帧有界调整、大漂移 snap）。
+- `VideoFrameScheduler`：为解码后的视频帧决定 present / wait / drop。
+- `DisplaySyncState`：携带残余帧时长误差的 vsync 量化器。
+
+## 音频输出
+
+- **macOS**：CoreAudio 输出，带 ring buffer 和 PTS 跟踪的 clock snapshot。presenter 会把输出快照回传给 player worker 做音频主时钟约束。
+- **iOS**：AudioQueue 输出，使用同样的 ring buffer 和 clock snapshot 模型。
+- Ring buffer：interleaved f32、容量可配、溢出丢最旧、支持音量控制。
+
+## 字幕系统
+
+- **Parsing**：SRT、WebVTT、ASS 时间线解析。支持内嵌和外部字幕轨，外部轨可在运行时增删。
+- **libass renderer**：静态链接且默认启用。接收 ASS 脚本，调用 `ass_render_frame`，把 alpha plane 导入 Erika 的 overlay 系统。Apple 平台使用 CoreText 字体提供者。
+- **SubtitleRendererCore**：面向 renderer 的边界层，用 changed/unchanged frame 跟踪避免重复 GPU 上传。
+
+## 弹幕系统
+
+弹幕子系统用 Rust 原生实现了 NipaPlay DFM+ 的布局算法。完整设计见 `docs/danmaku_architecture.md`。
+
+- **输入**：Bilibili XML、JSON、JSON-lines 解析。
+- **DanmakuSession**：多轨管理，支持按轨启用/禁用、按轨 offset、全局 offset。
+- **DFM+ layout core**：prepare / frame-query 分离。prepare 一次性处理整条轨道（测量、过滤、重复合并、碰撞避让、轨道分配），frame query 返回某一 media time 下的位置结果。
+- **Text rasterizer**：带 fill/outline alpha mask 的 glyph atlas，并通过 version 跟踪 GPU 纹理复用。
+- **Render plan**：`DanmakuRenderPlan` 携带 glyph instances，包含屏幕 rect、atlas tex rect、颜色、outline、shadow。Metal 和 wgpu 渲染器从 atlas 画实例化 quad。
+
+## 渲染器
+
+### Metal Renderer（macOS/iOS）
+
+Apple 平台的主渲染器：
+
+- 通过 `CVMetalTextureCache` 零拷贝导入 CVPixelBuffer → MTLTexture。
+- YCbCr 采样、transfer decode、gamut mapping（BT.2020→BT.709、Display P3→BT.709）。
+- Tone mapping：Mobius、Reinhard、clip，支持绝对 nits。
+- SDR 输出（`BGRA8Unorm`）与 Apple EDR 输出（`RGBA16Float` + EDR headroom）。
+- 神经亮度超分（`LumaUpscalerMode`）：ArtCNN C4F16/C4F32 2x doubler，以 Metal compute pass 跑在解码后的 Y plane 上，并与 render pass 使用同一 command buffer（`renderer/metal/upscaler.rs`）。色度保持原分辨率。仅在视频显示尺寸大于源分辨率时启用；网络输出会按解码帧缓存，重复 vsync tick 直接复用结果。权重来自上游 ONNX 发布（`assets/artcnn/`），并用 `tests/artcnn_upscaler.rs` 中的 onnxruntime 参考验证。提供 `simdgroup_matrix` matmul 后端（Apple Silicon 默认）和 scalar texture fallback；两者都在后台线程编译，编译完成前播放会先以未放大状态继续。
+- 字幕 overlay：RGBA plane 上传与 alpha blending。
+- 弹幕：来自 atlas 的 instanced glyph quad 绘制（shadow → outline → fill）。
+- 呈现布局保持源宽高比。
+
+### wgpu Renderer（跨平台）
+
+面向可移植性的第二渲染后端：
+
+- 真正的 `wgpu` 依赖与设备/表面/pipeline 创建。
+- NV12/P010 视频帧上传和 WGSL YCbCr 转换 shader。
+- 色彩空间转换、tone mapping（与 Metal 保持同一流水线模型）。
+- 弹幕 glyph atlas 渲染。
+- 可用于无头测试的离屏 render target。
+- 表面句柄模型覆盖 macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window。
+- 目前尚未实现 VideoToolbox 零拷贝导入和 HDR/EDR 输出。
+
+### Render Pipeline
+
+`renderer::pipeline` 会在任何后端消费之前，先在 Rust 里描述渲染决策：
+
+- `SourceColorState` / `TargetColorState`：primaries、transfer、range。
+- `VideoRenderPipeline`：gamut matrix、tone map operator、transfer functions。
+- HDR metadata：mastering display、content light level、nominal peak nits。
+
+## Presenter Runtime
+
+`PresenterRuntime` 把 Player、MetalRenderer、OverlayTimeline、DanmakuEngine 和音频输出串起来。宿主提供原生 surface，并从显示定时器驱动 `render_tick`。
+
+- 推送视频帧，更新 overlay（字幕 + 弹幕），渲染并 present。
+- 弹幕 plan 生成与视频帧通过 generation + media_time gate 保持同步。
+- 运行时支持倍速、音量、轨道选择、字幕/弹幕配置。
+
+## C ABI
+
+`erika_capi` 通过两组 handle family 导出 63 个函数：
+
+- **`ErikaHandle`**：播放器控制与事件轮询，渲染由宿主管理。
+- **`ErikaPresenterHandle`**：Erika 持有完整栈，宿主只需提供 surface 并调用 `render_tick`。
+
+覆盖范围包括：create/destroy、open/play/pause/stop/seek、轨道选择、字幕轨增删、弹幕轨管理（add/remove/enable/offset/config）、surface attach/detach/resize、事件轮询、音量、播放速率、神经亮度超分切换、超分后端状态诊断。
+
+Header：`crates/erika_capi/include/erika.h`
+
+## Flutter Plugin
+
+`packages/erika_flutter` 提供 macOS 和 iOS 的 Flutter embedding：
+
+- **Dart**：`ErikaPlayer`（命令 + 事件）、`ErikaWindowOverlayVideoView`（推荐的 window-hosted native Metal surface）、`ErikaVideoView`（兼容 platform view）。
+- **macOS Swift plugin**：加载 `liberika_capi.dylib`，创建 `NSWindow` overlay 或 `NSView`/`CAMetalLayer` platform view，并通过 display link 驱动 `render_tick`。
+- **iOS Swift plugin**：静态链接 `liberika_capi.a`，创建 `UIWindow` overlay 或 `UIView`/`CAMetalLayer` platform view，并沿用同一 presenter 模型。
+
+Embedding 模型和 HDR 策略见 `docs/flutter_embedding.md`。
+
+## Platform Support
+
+| Platform | Decode | Render | Audio | Status |
+|----------|--------|--------|-------|--------|
+| macOS 14+ | VideoToolbox | Metal | CoreAudio | Available |
+| iOS 16+ | VideoToolbox | Metal | AudioQueue | Available |
+| Windows | — | wgpu (planned) | — | Planned |
+| Linux | — | wgpu (planned) | — | Planned |
+| Android | — | wgpu (planned) | — | Planned |
+

--- a/docs/danmaku_architecture.en.md
+++ b/docs/danmaku_architecture.en.md
@@ -1,0 +1,173 @@
+# Erika Danmaku Subsystem Architecture
+
+[中文](danmaku_architecture.md) | [English](danmaku_architecture.en.md) | [日本語](danmaku_architecture.ja.md)
+
+This document describes the current Erika danmaku subsystem, how it maps to NipaPlay's DFM+ danmaku system, and which boundaries should be replaced or preserved. The core idea is simple: Erika should treat itself as a native host for a NipaPlay-style danmaku system. Inputs remain danmaku files and user configuration; the layout core should preserve DFM+ input/output semantics; the final result is rendered together with the video frame inside Erika's native renderer.
+
+## Current Goal
+
+Danmaku is not an external UI layer or a separate display system. It is part of the playback core: the player provides the current video frame and its media time, the danmaku layout queries only that media time for what should be visible, and the renderer composites video, subtitles, and danmaku in the same render tick.
+
+The target flow is:
+
+```text
+Danmaku file / JSON / XML / user config
+  -> DanmakuSession / track manager
+  -> active DanmakuTimeline
+  -> DFM+ layout core
+  -> per-media-time positioned danmaku
+  -> Erika render plan
+  -> Metal / WGPU native danmaku pass
+```
+
+DFM+ owns layout and filtering. Erika owns session management, timing, lifecycle, C ABI, font/glyph resources, and native GPU composition. The boundary should not blur: Erika should not reinvent a “DFM-like algorithm”; it should make DFM+ semantics hold inside Erika's core.
+
+## NipaPlay Danmaku Structure
+
+NipaPlay's danmaku system has four layers.
+
+The first layer is input normalization. Danmaku may come from local JSON, local Bilibili XML, manual track selection, or cache. Flutter normalizes them into a list of maps. Each item contains at least time, text, type, color, and self-danmaku flags; user settings include font size, display area, scroll duration, density, max lines, duplicate merge, block words, outline, shadow, and font.
+
+The second layer is DFM+ preparation. `DfmPlusLayoutBridge.configure` calls Rust `dfm_plus_prepare_layout_full` whenever the item list, viewport, font size, or config changes. This stage hands the full track and user settings to DFM+, which performs measurement, filtering, duplicate merge, lane allocation, and collision avoidance, then returns a prepared layout. A prepared layout is not “the current frame”; it is the stable layout result for this track under the current viewport/config.
+
+The third layer is per-frame querying. During playback, only the current playback time is passed to the prepared layout. NipaPlay performs the same logic on the Dart side as Rust's `build_dfm_plus_frame`: binary-search the visible window, then compute x for scrolling items from elapsed time, while fixed items use the centered x/y computed during preparation.
+
+The fourth layer is presentation. NipaPlay currently uses its own Flutter/Texture path to draw positioned danmaku; that is not the DFM+ layout core. Erika replaces that presentation layer: keep DFM+ layout input/output, convert positioned danmaku into Erika glyph atlas / quad instances, and composite them in Metal/WGPU together with video.
+
+## NipaPlay DFM+ I/O Contract
+
+The key NipaPlay DFM+ Rust API lives in `/Users/sakiko/Desktop/NipaPlay-Reload/rust/src/api/dfm_plus.rs`. It exposes a prepare + frame-query contract.
+
+Prepare takes normalized danmaku items plus viewport and user config. Key fields include `time_seconds`, `text`, `type_code`, `color_argb`, `is_me`, and collision-related `paint_width` / `paint_height`. Config includes `width`, `height`, `font_size`, `display_area`, `scroll_duration_seconds`, `allow_stacking`, `merge_danmaku`, `max_quantity`, `max_lines_per_type`, `track_gap_ratio`, `outline_width`, `block_words`.
+
+Prepare returns a prepared layout. It stores viewport, scroll/fixed durations, sorted prepared items, item times, and lane statistics. Prepared items keep text, time, type, color, self flag, font size multiplier, merge count, y position, width, scroll speed, duration, whether the item scrolls, and centered_x for fixed items. This output is the source of truth for later frame queries.
+
+Frame query takes only the prepared layout handle and `current_time_seconds`. It returns positioned items for the current frame, each with `item_index`, `x`, `y`, and `offstage_x`. Text, colors, and other style data are not repeated in the frame item; they are resolved through `item_index` back into the prepared item.
+
+This contract matters because DFM+'s power comes from preparing the full track once, not deciding every item position on every frame. Erika should keep this model, but move the handle store into Erika's internal object lifetime and turn the output into an Erika render plan.
+
+## Current Erika Danmaku Path
+
+Erika already has a native danmaku path in these files:
+
+- `crates/erika/src/danmaku.rs`: public data model, parser, timeline, DFM adapter, frame layout, render plan, text rasterizer, glyph atlas.
+- `crates/erika/src/danmaku/dfm.rs`: adapter between Erika and the NipaPlay DFM+ prepare/frame-query contract.
+- `crates/erika/src/danmaku/dfm_core/*`: model, retainer, filters, measure, factory, timer, types migrated from NipaPlay DFM+.
+- `crates/erika/src/presenter.rs`: connects player media time, generation, viewport, and the danmaku engine.
+- `crates/erika/src/core.rs`: `RenderFrameContext` merges video frames, subtitle overlay, and danmaku render plan into one renderer call.
+- `crates/erika/src/renderer/metal/*` and `crates/erika/src/renderer/wgpu.rs`: native danmaku passes.
+- `crates/erika_capi/include/erika.h` / `crates/erika_capi/src/lib.rs`: C ABI for loading, clearing, enabling, configuring, and blocking danmaku.
+- `packages/erika_flutter/lib/src/erika_player.dart` and `packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift`: the Flutter wrapper only talks to the Erika C API.
+
+The current data flow is:
+
+```mermaid
+flowchart LR
+  A["JSON / JSONL / Bilibili XML"] --> B["DanmakuTimeline per track"]
+  B --> C["DanmakuSession tracks + offsets + enable state"]
+  C --> D["Active DanmakuTimeline"]
+  D --> E["DfmLayoutEngine"]
+  E --> F["dfm.rs adapter"]
+  F --> G["dfm_core retainer + filters"]
+  G --> H["DfmPreparedLayout"]
+  H --> I["DanmakuFrameLayout(media_time, generation)"]
+  I --> J["DanmakuRenderPlan glyph atlas + instances"]
+  J --> K["RenderFrameContext"]
+  K --> L["Metal / WGPU video + subtitle + danmaku composition"]
+```
+
+`dfm_core` is already a migrated version of NipaPlay DFM+ core, not a new algorithm written from scratch. The important boundary is that `DanmakuSession` is Erika's input session layer, while `dfm.rs` is the adapter that maps active timelines and `DanmakuLayoutConfig` into a DFM+ prepare request and back into Erika's `DanmakuFrameLayout`.
+
+## Replacement Boundary
+
+The part that should be replaced “as close as possible to the original DFM+ core” is `crates/erika/src/danmaku/dfm.rs` plus `crates/erika/src/danmaku/dfm_core/*`.
+
+Its input should stay aligned with NipaPlay DFM+: normalized items, viewport, font metrics, and user config. Erika may use its own Rust types, but field semantics should match NipaPlay: time, text, type_code, color, is_me, paint_width/paint_height, display_area, scroll_duration, allow_stacking, merge, max_quantity, max_lines, track_gap, outline, block_words, and so on.
+
+Before DFM+, Erika adds `DanmakuSession`. It does not participate in layout; it only prepares an active timeline that DFM+ can consume. Multiple tracks may be enabled at once; per-track and global offsets are applied when building the active timeline; source item IDs are prefixed with the track ID to avoid collisions after multi-track merging. Seek should not force a re-prepare because generation changes; prepare should only be invalidated by timeline/session content, viewport, or config changes. Generation only gates current-frame output for the renderer.
+
+The output should also stay close to NipaPlay DFM+: prepared layout stores stable results, and frame query returns only the visible items and their positions for the current media time. Erika can then map `item_index` to text, colors, font size, outline, and so on to build `DanmakuFrameLayout` and `DanmakuRenderPlan`.
+
+In other words, Erika may change the shell and the final drawing path, but not the semantic behavior of the DFM+ core. The C ABI exposed to player/Flutter should cover the NipaPlay-style input surface: danmaku files, JSON/JSONL/XML, display area, font size, scroll duration, density, max lines, duplicate merge, block words, outline/shadow, enable state, and track switching.
+
+## Public API Today
+
+The Rust presenter already exposes the danmaku session surface: load/replace default danmaku, append multiple tracks, remove a track, enable/disable per track, per-track offsets, global offset, clear, enable, and configure danmaku. The older `load_danmaku_file` / `load_danmaku_json` remain as “replace the default track” for compatibility with the old single-track call pattern.
+
+Current C ABI entry points include:
+
+```c
+ErikaStatus erika_presenter_load_danmaku_file(ErikaPresenterHandle *handle, const char *uri);
+ErikaStatus erika_presenter_load_danmaku_json(ErikaPresenterHandle *handle, const char *json);
+ErikaStatus erika_presenter_add_danmaku_track_file(ErikaPresenterHandle *handle, const char *uri, const char *name, int64_t offset_micros, uint64_t *out_track_id);
+ErikaStatus erika_presenter_add_danmaku_track_json(ErikaPresenterHandle *handle, const char *json, const char *name, int64_t offset_micros, uint64_t *out_track_id);
+ErikaStatus erika_presenter_remove_danmaku_track(ErikaPresenterHandle *handle, uint64_t track_id);
+ErikaStatus erika_presenter_set_danmaku_track_enabled(ErikaPresenterHandle *handle, uint64_t track_id, bool enabled);
+ErikaStatus erika_presenter_set_danmaku_track_offset(ErikaPresenterHandle *handle, uint64_t track_id, int64_t offset_micros);
+ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *handle, int64_t offset_micros);
+ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *handle, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
+ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *handle);
+ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *handle, bool enabled);
+ErikaStatus erika_presenter_set_danmaku_config(ErikaPresenterHandle *handle, ErikaDanmakuConfig config);
+ErikaStatus erika_presenter_set_danmaku_font(ErikaPresenterHandle *handle, const char *family, const char *file_path);
+ErikaStatus erika_presenter_set_danmaku_block_words_json(ErikaPresenterHandle *handle, const char *json);
+```
+
+`ErikaDanmakuConfig` currently includes `enabled`, `font_size`, `opacity`, `display_area`, `scroll_duration_seconds`, `scroll_speed_factor`, `track_gap_ratio`, `outline_width`, `shadow_offset`, `shadow_style`, `merge_duplicates`, `allow_stacking`, `allow_scroll_overwrite`, `max_quantity`, `max_lines_per_mode`, `block_top`, `block_bottom`, and `block_scroll`. Font family/file input is passed through `erika_presenter_set_danmaku_font` so temporary string pointers do not have to live inside the config struct.
+
+The Flutter wrapper exposes `addDanmakuTrackFile`, `addDanmakuTrackJson`, `removeDanmakuTrack`, `setDanmakuTrackEnabled`, `setDanmakuTrackOffset`, `setDanmakuGlobalOffset`, `danmakuTracks`, and the older `loadDanmakuFile` / `loadDanmakuJson` / `clearDanmaku` / `setDanmakuConfig`. `setDanmakuConfig` now also carries `customFontFamily`, `customFontFilePath`, and the DFM+ texture-path semantics of `shadowStyle`.
+
+That means the player side can now push NipaPlay-style “danmaku file + user config + track control” into Erika, while the output continues to flow with the video frame into the native view.
+
+The remaining work is to keep aligning remote/cache sources, structured block rules, config persistence, the NipaPlay multi-kernel selection abstraction, and a few behavior switches that are not fully forwarded yet in the DFM+ adapter.
+
+## Timing Contract
+
+Danmaku timing is owned by Erika's playback core, not by a separate danmaku timer.
+
+`PlayerVideoFrame` carries `pts`, `media_time`, and `generation`. After the presenter uploads a frame in `pump_video`, it uses `frame.pts.unwrap_or(frame.media_time)` as the current danmaku query time. `update_overlay` then uses the same PTS to generate subtitle overlay and danmaku render plan. The renderer receives `RenderFrameContext { media_time, generation, overlay, danmaku }`.
+
+The renderer gates out mismatched danmaku plans. Both Metal and WGPU require the plan `generation` to equal the context generation, the plan `media_time` to equal the context media time, and the viewport to match the current output size. That way old plans do not keep rendering after seek, stop, close, danmaku-track switches, or config changes.
+
+This means danmaku position is not just “frozen while paused.” At any moment it is driven by the video media timeline. While playback advances, scrolling danmaku move continuously with media time; during pause, media time stays unchanged so positions stay fixed; after seek, the new media time is queried directly, and the old plan is discarded because the generation no longer matches.
+
+## Fonts, Measurement, and Glyph Atlas
+
+DFM+ collision results depend on text width and height. If measurement and actual drawing use different font metrics, lane allocation will diverge from the final image. For that reason Erika keeps `DanmakuTextRasterizer` inside the layout engine: prepare measures text with the same font set, and render-plan generation uses the same glyph rasterization / atlas data.
+
+Font size semantics are split into two layers. `size` in source files and the third field in Bilibili XML still follow the default Bilibili base of `25`; `ErikaDanmakuConfig.font_size` from the player and Flutter wrapper follows NipaPlay/Flutter logic-size semantics, with desktop defaulting to `30`. Erika embeds and prefers NipaPlay's `Droid Sans Fallback` danmaku font first, and converts only from logical size to glyph-atlas physical pixels using the surface backing scale. Callers do not need to multiply by any extra renderer compensation ratio.
+
+Erika's render plan does not pack the whole danmaku line into a single bitmap. It caches glyphs into a persistent atlas and emits `DanmakuGlyphInstance` records. Each instance contains screen rect, atlas tex rect, fill color, outline color, shadow color, and offset. Metal/WGPU only needs to bind the atlas texture and draw alpha-mask quads.
+
+The current atlas has fill alpha and outline alpha masks so shadow/outline/fill can be drawn in that order. The atlas carries a version, and the renderer uses version, size, and stride to decide whether a GPU texture can be reused, avoiding needless full-ատlas uploads every frame.
+
+## Renderer Composition Point
+
+The danmaku pass sits after video frame upload and before present. The renderer input is not an external window pointer or a separate danmaku render loop; it is the `DanmakuRenderPlan` inside `RenderFrameContext`.
+
+On Metal, `render_video_frame_inner` draws the video texture first, then the subtitle overlay, then the danmaku glyph instances. WGPU folds the danmaku draw into the current video draw flow and uses the same plan generation/media-time gate. Renderer statistics and presenter statistics record `danmaku_passes`, `danmaku_items`, and `danmaku_frames`.
+
+## Current Differences from NipaPlay
+
+Erika already keeps the main DFM+ advantages: prepare/frame-query separation, binary search over the time window, track retainer, scrolling collision avoidance, top/bottom fixed lanes, display area, track gap, density control, max lines, duplicate merge, block words, and the basic regex block structure. It also now has the danmaku session layer, which can normalize multiple tracks, per-track offsets, and a global offset into one active timeline before handing it to DFM+.
+
+It is still not a complete “drop-in NipaPlay danmaku system.” Main differences:
+
+- NipaPlay DFM+ API uses `DfmPlusPreparedLayout.handle` and `DfmPlusFrameRequest.layout_handle`; Erika uses an internal `DfmPreparedLayout` object instead of a global handle store. This is a lifecycle-shell difference and should not affect behavior.
+- NipaPlay prepared/frame output keeps `frame item -> item_index -> prepared item` very explicit; Erika currently maps further into `DanmakuPlacedItem` and carries text/style earlier. That works, but Erika must keep the `item_index` / source-ID semantics intact for behavior matching and tests.
+- NipaPlay's full settings surface comes from Flutter state, including tracks, offsets, custom font, display settings, and block configuration; Erika C ABI already covers tracks, offset control, custom font family/path, and DFM+ shadowStyle, but remote/cache sources, structured block rules, and config persistence still need to be filled in.
+- Erika's renderer output is already native, which is intentional and should not be compared against NipaPlay's final presentation form.
+- The current `dfm_core` is migrated, but the adapter still has Erika-specific mapping and config interpretation. Future work should compare against the NipaPlay DFM+ API field-by-field rather than continuing to hand-write “similar-looking” behavior.
+
+## Future Implementation Principles
+
+The future work is to make Erika's compute layer more like NipaPlay DFM+, and Erika's render layer more like Erika itself.
+
+The compute layer should preserve NipaPlay's inputs, outputs, and core behavior. The FRB generator layer, global handle store, and Flutter widget dependencies may be removed, but the DFM+ configuration fields and intermediate state should stay. Erika's adapter should do type conversion, lifecycle management, and renderer-facing projection only.
+
+The API layer should expose the NipaPlay danmaku input surface to the player and Flutter wrapper. The Flutter wrapper should only pass user settings, danmaku files, and track selection to Erika, not perform danmaku layout or drawing itself.
+
+The render layer should stay native to Erika. DFM+ outputs “where each danmaku item is at the current media time, and what style it has,” not GPU textures or Flutter resources. Erika's renderer turns that output into glyph atlases, quad instances, and Metal/WGPU composition together with video.
+
+The synchronization layer must keep the current generation + media_time contract. Seek, stop, close, track switch, and config change all invalidate the old plan; each frame query only looks at the video timeline; danmaku do not own a separate wall-clock timer. That contract is the real fix for “the video jumped but the danmaku didn't.”
+

--- a/docs/danmaku_architecture.ja.md
+++ b/docs/danmaku_architecture.ja.md
@@ -1,0 +1,173 @@
+# Erika 弾幕サブシステムアーキテクチャ
+
+[中文](danmaku_architecture.md) | [English](danmaku_architecture.en.md) | [日本語](danmaku_architecture.ja.md)
+
+この文書は、現在の Erika 弾幕サブシステム、その NipaPlay DFM+ 弾幕システムとの対応関係、そして今後置き換えるべき境界と維持すべき境界を記録します。核となる考え方は単純で、Erika 自身を NipaPlay 風の弾幕システムを native に受け持つホストとして扱うことです。入力は弾幕ファイルとユーザー設定のまま、layout core は DFM+ の input/output semantics を保ち、最終結果は Erika の native renderer で動画フレームと一緒に描画されます。
+
+## 現在の目標
+
+弾幕は外部 UI 層でも、別系統の表示システムでもありません。再生コアの一部です。player は現在の video frame と media time を渡し、弾幕 layout はその media time だけを使って表示対象を決め、renderer は video / subtitle / danmaku を同じ render tick で合成します。
+
+目標となる流れは次の通りです。
+
+```text
+Danmaku file / JSON / XML / user config
+  -> DanmakuSession / track manager
+  -> active DanmakuTimeline
+  -> DFM+ layout core
+  -> per-media-time positioned danmaku
+  -> Erika render plan
+  -> Metal / WGPU native danmaku pass
+```
+
+DFM+ が担うのは layout と filtering、Erika が担うのは session management、timing、lifecycle、C ABI、font/glyph resources、native GPU composition です。この境界は曖昧にしてはいけません。Erika は「DFM っぽい別アルゴリズム」を作るのではなく、Erika core の中で DFM+ semantics を成立させるべきです。
+
+## NipaPlay の弾幕構造
+
+NipaPlay の弾幕システムは 4 層に分かれます。
+
+第 1 層は input normalization です。弾幕は local JSON、local Bilibili XML、手動の track selection、cache から来る場合があり、Flutter 側で list of maps に正規化します。各 item には少なくとも time、text、type、color、self-danmaku flags が含まれ、user settings には font size、display area、scroll duration、density、max lines、duplicate merge、block words、outline、shadow、font が含まれます。
+
+第 2 層は DFM+ preparation です。`DfmPlusLayoutBridge.configure` は item list、viewport、font size、config が変わるたびに Rust の `dfm_plus_prepare_layout_full` を呼びます。この段階で全トラックと user settings を DFM+ に渡し、measurement、filtering、duplicate merge、lane allocation、collision avoidance を実行して prepared layout を返します。prepared layout は「現在の frame」ではなく、現在の viewport/config に対する安定した layout 結果です。
+
+第 3 層は per-frame querying です。再生中は current playback time だけを prepared layout に渡します。NipaPlay の Dart 側には Rust の `build_dfm_plus_frame` と等価な処理があり、表示 window を binary search で取り、scrolling item の x を elapsed から計算し、fixed item は preparation 時に計算した centered x/y を使います。
+
+第 4 層は presentation です。NipaPlay は現在、positioned danmaku を Flutter/Texture path で描画していますが、これは DFM+ layout core ではありません。Erika が置き換えるのはこの層で、DFM+ の input/output は維持したまま、positioned danmaku を Erika の glyph atlas / quad instances に変換して Metal/WGPU で動画と一緒に合成します。
+
+## NipaPlay DFM+ の入出力契約
+
+NipaPlay DFM+ Rust API の中心は `/Users/sakiko/Desktop/NipaPlay-Reload/rust/src/api/dfm_plus.rs` にあります。これは prepare + frame-query の契約を公開しています。
+
+Prepare には正規化済み item、viewport、user config が入ります。重要な field は `time_seconds`、`text`、`type_code`、`color_argb`、`is_me`、collision 用の `paint_width` / `paint_height` です。config には `width`、`height`、`font_size`、`display_area`、`scroll_duration_seconds`、`allow_stacking`、`merge_danmaku`、`max_quantity`、`max_lines_per_type`、`track_gap_ratio`、`outline_width`、`block_words` があります。
+
+Prepare は prepared layout を返します。そこには viewport、scroll/fixed duration、sorted prepared items、item_times、lane statistics が保持されます。prepared item には text、time、type、color、self flag、font size multiplier、merge count、y position、width、scroll speed、duration、scroll item かどうか、fixed item 用の centered_x が入ります。この出力が後続 frame query の source of truth です。
+
+Frame query には prepared layout handle と `current_time_seconds` だけを渡します。返るのは現在 frame の positioned items で、各 item には `item_index`、`x`、`y`、`offstage_x` が含まれます。text や color などの style は frame item に重複して載せず、`item_index` から prepared item を引きます。
+
+この契約が重要なのは、DFM+ の強みが毎 frame 位置を決めることではなく、track 全体を一度 prepare することにあるからです。Erika もこの model を維持しつつ、handle store を Erika 内部の lifetime に移し、出力を Erika render plan に変えるべきです。
+
+## 現在の Erika の弾幕経路
+
+Erika には既に native 弾幕経路があります。
+
+- `crates/erika/src/danmaku.rs`: public data model、parser、timeline、DFM adapter、frame layout、render plan、text rasterizer、glyph atlas。
+- `crates/erika/src/danmaku/dfm.rs`: Erika と NipaPlay DFM+ の prepare/frame-query contract をつなぐ adapter。
+- `crates/erika/src/danmaku/dfm_core/*`: NipaPlay DFM+ から移植された model、retainer、filters、measure、factory、timer、types。
+- `crates/erika/src/presenter.rs`: player の media time、generation、viewport と弾幕 engine を接続。
+- `crates/erika/src/core.rs`: `RenderFrameContext` が video frame、subtitle overlay、danmaku render plan を 1 回の renderer call にまとめる。
+- `crates/erika/src/renderer/metal/*` と `crates/erika/src/renderer/wgpu.rs`: native danmaku pass。
+- `crates/erika_capi/include/erika.h` / `crates/erika_capi/src/lib.rs`: 弾幕の load、clear、enable、config、block の C ABI。
+- `packages/erika_flutter/lib/src/erika_player.dart` と `packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift`: Flutter wrapper は Erika C API だけを呼ぶ。
+
+現在の data flow は次の通りです。
+
+```mermaid
+flowchart LR
+  A["JSON / JSONL / Bilibili XML"] --> B["DanmakuTimeline per track"]
+  B --> C["DanmakuSession tracks + offsets + enable state"]
+  C --> D["Active DanmakuTimeline"]
+  D --> E["DfmLayoutEngine"]
+  E --> F["dfm.rs adapter"]
+  F --> G["dfm_core retainer + filters"]
+  G --> H["DfmPreparedLayout"]
+  H --> I["DanmakuFrameLayout(media_time, generation)"]
+  I --> J["DanmakuRenderPlan glyph atlas + instances"]
+  J --> K["RenderFrameContext"]
+  K --> L["Metal / WGPU video + subtitle + danmaku composition"]
+```
+
+`dfm_core` は NipaPlay DFM+ core を移植したもので、ゼロから書いた別アルゴリズムではありません。重要なのは、`DanmakuSession` が Erika の input session layer であり、`dfm.rs` が active timeline と `DanmakuLayoutConfig` を DFM+ の prepare request に変換し、さらに `DanmakuFrameLayout` に戻す adapter だという点です。
+
+## 置き換え境界
+
+できるだけ「元の DFM+ core をそのまま受け持つ」べき部分は、`crates/erika/src/danmaku/dfm.rs` と `crates/erika/src/danmaku/dfm_core/*` です。
+
+入力は NipaPlay DFM+ の抽象とそろえるべきです。つまり、正規化済み item、viewport、font metrics、user config です。Erika は独自の Rust 型を使っても構いませんが、field semantics は NipaPlay と一致していなければなりません。time、text、type_code、color、is_me、paint_width/paint_height、display_area、scroll_duration、allow_stacking、merge、max_quantity、max_lines、track_gap、outline、block_words などが DFM+ prepare に流れ込む必要があります。
+
+DFM+ の前段にある `DanmakuSession` は layout algorithm には参加しません。複数 track を同時に有効化でき、track ごとの offset と global offset は active timeline 構築時に適用され、source item id は track id で prefix されて multi-track merge 後の衝突を避けます。seek は generation が変わったという理由で prepare をやり直すべきではありません。prepare の失効条件は timeline/session の内容、viewport、config の変化です。generation は renderer の current-frame gate にだけ使います。
+
+出力側も NipaPlay DFM+ の抽象に近いままであるべきです。prepared layout は安定した結果を保持し、frame query は current media time に対する visible items と位置だけを返します。その後で Erika が `item_index` に対応する text、color、font size、outline などを `DanmakuFrameLayout` と `DanmakuRenderPlan` に変換します。
+
+要するに、Erika が変えてよいのは外側の shell と最終描画方法であり、DFM+ core の semantic behavior ではありません。player/Flutter に公開する C ABI も、NipaPlay 的な入力面をカバーすべきです。danmaku file、JSON/JSONL/XML、display area、font size、scroll duration、density、max lines、duplicate merge、block words、outline/shadow、enable state、track switching などです。
+
+## 公開 API
+
+Rust presenter はすでに弾幕 session の入力面を持っています。default danmaku の load/replace、複数 track の append、track の remove、track ごとの enable/disable、track offset、global offset、clear、enable、config が可能です。旧 `load_danmaku_file` / `load_danmaku_json` は single-track 互換用に「default track を置き換える」意味で残されています。
+
+現在の C ABI entry point は次の通りです。
+
+```c
+ErikaStatus erika_presenter_load_danmaku_file(ErikaPresenterHandle *handle, const char *uri);
+ErikaStatus erika_presenter_load_danmaku_json(ErikaPresenterHandle *handle, const char *json);
+ErikaStatus erika_presenter_add_danmaku_track_file(ErikaPresenterHandle *handle, const char *uri, const char *name, int64_t offset_micros, uint64_t *out_track_id);
+ErikaStatus erika_presenter_add_danmaku_track_json(ErikaPresenterHandle *handle, const char *json, const char *name, int64_t offset_micros, uint64_t *out_track_id);
+ErikaStatus erika_presenter_remove_danmaku_track(ErikaPresenterHandle *handle, uint64_t track_id);
+ErikaStatus erika_presenter_set_danmaku_track_enabled(ErikaPresenterHandle *handle, uint64_t track_id, bool enabled);
+ErikaStatus erika_presenter_set_danmaku_track_offset(ErikaPresenterHandle *handle, uint64_t track_id, int64_t offset_micros);
+ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *handle, int64_t offset_micros);
+ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *handle, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
+ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *handle);
+ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *handle, bool enabled);
+ErikaStatus erika_presenter_set_danmaku_config(ErikaPresenterHandle *handle, ErikaDanmakuConfig config);
+ErikaStatus erika_presenter_set_danmaku_font(ErikaPresenterHandle *handle, const char *family, const char *file_path);
+ErikaStatus erika_presenter_set_danmaku_block_words_json(ErikaPresenterHandle *handle, const char *json);
+```
+
+`ErikaDanmakuConfig` には `enabled`、`font_size`、`opacity`、`display_area`、`scroll_duration_seconds`、`scroll_speed_factor`、`track_gap_ratio`、`outline_width`、`shadow_offset`、`shadow_style`、`merge_duplicates`、`allow_stacking`、`allow_scroll_overwrite`、`max_quantity`、`max_lines_per_mode`、`block_top`、`block_bottom`、`block_scroll` が含まれます。font family / file input は `erika_presenter_set_danmaku_font` で渡すため、config struct に一時文字列ポインタを入れる必要がありません。
+
+Flutter wrapper は `addDanmakuTrackFile`、`addDanmakuTrackJson`、`removeDanmakuTrack`、`setDanmakuTrackEnabled`、`setDanmakuTrackOffset`、`setDanmakuGlobalOffset`、`danmakuTracks`、および旧 `loadDanmakuFile` / `loadDanmakuJson` / `clearDanmaku` / `setDanmakuConfig` を公開しています。`setDanmakuConfig` は `customFontFamily`、`customFontFilePath`、DFM+ texture path 的な `shadowStyle` も受け取れます。
+
+つまり、player 側は NipaPlay 風の「弾幕ファイル + ユーザー設定 + track control」を Erika に渡せるようになっており、出力はそのまま video frame と一緒に native view に流れます。
+
+残りの作業は、remote/cache source、structured block rules、config persistence、NipaPlay multi-kernel selection 抽象、そして DFM+ adapter にまだ完全に転送されていない挙動スイッチを埋めていくことです。
+
+## 時間同期契約
+
+弾幕の時間同期は、独立した弾幕タイマーではなく Erika の再生コアが担当します。
+
+`PlayerVideoFrame` は `pts`、`media_time`、`generation` を持ちます。presenter が `pump_video` で frame を upload した後、`frame.pts.unwrap_or(frame.media_time)` を現在の弾幕 query time として使います。その後 `update_overlay` が同じ PTS を使って subtitle overlay と danmaku render plan を生成します。最終的に renderer は `RenderFrameContext { media_time, generation, overlay, danmaku }` を受け取ります。
+
+renderer は不一致の danmaku plan を gate で落とします。Metal / WGPU ともに plan の `generation` が context generation と一致し、plan の `media_time` が context media time と一致し、viewport が現在の出力サイズに一致する必要があります。これにより seek、stop、close、track switch、config change の後に古い plan が描画され続けることを防ぎます。
+
+つまり、弾幕位置は「pause 中に止まる」だけではありません。常に video media timeline によって決まります。再生中は media time に合わせて scrolling 弾幕が流れ、pause 中は media time が変わらないので位置も変わらず、seek 後は新しい media time を直接 query し、古い plan は generation 不一致で破棄されます。
+
+## フォント、測定、glyph atlas
+
+DFM+ の collision 結果は text width と height に依存します。measurement と実描画で違う font metrics を使うと、lane allocation が最終画像とずれてしまいます。そのため Erika は `DanmakuTextRasterizer` を layout engine の内部に置き、prepare 時に同じ font set で測定し、render plan 生成でも同じ glyph rasterization / atlas data を使います。
+
+font size semantics は 2 層に分かれます。source file の `size` / Bilibili XML の 3 番目の field は引き続き Bilibili 既定の `25` を基準にし、player と Flutter wrapper から渡される `ErikaDanmakuConfig.font_size` は NipaPlay / Flutter の logic-size semantics に従います。desktop の既定は `30` です。Erika は NipaPlay の `Droid Sans Fallback` 弾幕フォントを優先的に埋め込み、surface backing scale を使って logical size から glyph atlas の physical pixel へ変換します。呼び出し側が renderer 補正比率をさらに掛ける必要はありません。
+
+Erika の render plan は弾幕全体を 1 枚の bitmap にしません。glyph を persistent atlas にキャッシュし、`DanmakuGlyphInstance` を出力します。各 instance には screen rect、atlas tex rect、fill color、outline color、shadow color、offset が含まれます。Metal / WGPU は atlas texture を bind して alpha mask quad を描くだけです。
+
+現在の atlas には fill alpha と outline alpha の 2 つの mask があり、shadow → outline → fill の順で描画します。atlas には version があり、renderer は version / size / stride を見て GPU texture を再利用できるか判断し、毎 frame の無意味な全面再送を避けます。
+
+## Renderer 合成位置
+
+弾幕 pass は video frame upload の後、present の前に入ります。renderer の input は外部 window pointer や別の弾幕 render loop ではなく、`RenderFrameContext` の中にある `DanmakuRenderPlan` です。
+
+Metal 側では `render_video_frame_inner` が video texture を先に描き、その後 subtitle overlay、最後に danmaku glyph instances を描画します。WGPU 側も同じ video draw flow に danmaku draw を組み込み、同じ plan generation/media-time gate を使います。renderer stats と presenter stats は `danmaku_passes`、`danmaku_items`、`danmaku_frames` を記録します。
+
+## NipaPlay との現在の差分
+
+Erika はすでに DFM+ の重要な利点を保持しています。prepare/frame-query 分離、time window の binary search、track retainer、scrolling collision avoidance、top/bottom fixed lanes、display area、track gap、density control、max lines、duplicate merge、block words、基本的な regex block 構造です。さらに、複数 track、track ごとの offset、global offset を 1 つの active timeline にまとめる danmaku session layer も備えています。
+
+ただし、まだ完全な「NipaPlay 弾幕システムそのもの」ではありません。主な差分は次の通りです。
+
+- NipaPlay DFM+ API は `DfmPlusPreparedLayout.handle` と `DfmPlusFrameRequest.layout_handle` を使いますが、Erika は global handle store ではなく内部の `DfmPreparedLayout` object を使います。これは lifecycle shell の違いで、挙動に影響すべきではありません。
+- NipaPlay の prepared/frame output は `frame item -> item_index -> prepared item` の関係が明確ですが、Erika はさらに `DanmakuPlacedItem` にマッピングし、text/style を早めに持ちます。これは動作しますが、behavior matching と test のために item_index / source id semantics を保つ必要があります。
+- NipaPlay の完全な設定面は Flutter state 由来で、track、offset、custom font、display settings、block configuration を含みます。Erika C ABI はすでに track、offset control、custom font family/path、DFM+ shadowStyle をカバーしていますが、remote/cache source、structured block rules、config persistence はまだ詰める必要があります。
+- Erika の renderer output はすでに native であり、これは意図した差分です。NipaPlay の最終的な presentation 形態と比べるべきではありません。
+- 現在の `dfm_core` は移植済みですが、adapter にはまだ Erika 固有の mapping と config interpretation があります。今後は「似た挙動」を手で増やすのではなく、NipaPlay DFM+ API と field 単位で照合していくべきです。
+
+## 今後の実装方針
+
+今後やるべきことは、Erika の compute layer をより NipaPlay DFM+ に近づけ、renderer layer をより Erika らしくすることです。
+
+compute layer は NipaPlay の input、output、core behavior を保つべきです。FRB 生成層、global handle store、Flutter widget 依存は削除しても構いませんが、DFM+ に必要な configuration fields と中間状態は残すべきです。Erika の adapter は type conversion、lifecycle management、renderer-facing projection だけを担当します。
+
+API layer は NipaPlay の弾幕 input surface を player と Flutter wrapper に公開すべきです。Flutter wrapper は user settings、弾幕ファイル、track selection を Erika に渡すだけで、自前で弾幕 layout や描画を行うべきではありません。
+
+render layer は Erika の native 実装として保つべきです。DFM+ が出力するのは「current media time で各弾幕がどこにあり、どんな style か」であって、GPU texture や Flutter resource ではありません。Erika renderer はその出力を glyph atlas、quad instances、Metal/WGPU 合成に変え、動画と一緒に描画します。
+
+synchronization layer は現在の generation + media_time 契約を維持しなければなりません。seek、stop、close、track switch、config change はすべて古い plan を無効化し、各 frame query は video timeline だけを見ます。弾幕は別の wall-clock timer を持ちません。この契約こそが「動画は跳んだのに弾幕が跳ばない」を解決する本体です。
+

--- a/docs/danmaku_architecture.md
+++ b/docs/danmaku_architecture.md
@@ -1,5 +1,7 @@
 # Erika 弹幕子系统架构
 
+[中文](danmaku_architecture.md) | [English](danmaku_architecture.en.md) | [日本語](danmaku_architecture.ja.md)
+
 本文记录当前 Erika 弹幕子系统的实际架构、它和 NipaPlay DFM+ 弹幕系统的对应关系，以及后续应替换/保持的边界。核心结论是：Erika 也应该把自己视为一个 NipaPlay 弹幕系统的原生化承载者。弹幕系统的输入仍然是弹幕文件和用户配置，布局内核应尽量保持 DFM+ 的输入输出语义，最终输出随视频帧一起进入 Erika 原生 renderer。
 
 ## 当前目标

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -1,0 +1,147 @@
+# Flutter Embedding
+
+[中文](flutter_embedding.zh.md) | [English](flutter_embedding.md) | [日本語](flutter_embedding.ja.md)
+
+Erika は Flutter の動画レンダラーではありません。Flutter はあくまで任意の host UI です。再生コアが decode、timing、native rendering、字幕、弾幕、音声、HDR presentation を担当します。
+
+## API Families
+
+C ABI の entrypoint family は 2 つあります。
+
+- `ErikaHandle`: control と event API。host が自前の presenter loop を持つ場合や、再生の probe / control だけを行いたい場合に使います。
+- `ErikaPresenterHandle`: presenter-owned API。Erika が `Player + MetalRenderer + audio output` を所有し、host は native surface と display tick callback だけを提供する場合に使います。
+
+どちらも `crates/erika_capi/include/erika.h` に定義されています。
+
+## Apple Surface Strategies
+
+Apple HDR path は Flutter Texture ではなく native Metal-backed surface を使います。Flutter plugin は macOS / iOS ともに 2 つの native surface strategy を公開し、host が UI に合う composition model を選べるようにしています。
+
+### ErikaVideoView (Platform View)
+
+標準的な Flutter platform view です。macOS では `NSView`/`CAMetalLayer`、iOS では `UIView`/`CAMetalLayer` で実装されます。plugin は `erika_flutter/video_view` として登録された native video view を作り、presenter に attach し、display link から描画を駆動します。
+
+simple embedder や診断用途には便利です。macOS では AppKit/Flutter platform view composition の都合で black flicker などの compositor artifact が出ることがあるため、production path としては推奨されません。
+
+### ErikaWindowOverlayVideoView (Window Overlay)
+
+HDR/EDR の推奨 path は、Flutter の platform-view compositor の外側に置かれる window-hosted native overlay です。
+
+1. Dart の `ErikaWindowOverlayVideoView` が widget tree 上の rectangle を確保します。
+2. platform plugin が window-level native view を作り、`CAMetalLayer` を Flutter host view の sibling / underlay として配置します。
+3. Flutter は該当 widget 領域を transparent に描画し、native video 用の hole を残します。
+4. widget は位置を追跡し、surface generation number 付きで geometry update を送るため、dispose 済み widget からの古い hide call が新しく attach された surface に影響しません。
+5. attach retry は exponential backoff で window readiness のタイミングを吸収します。
+
+この overlay path は NipaPlay や他の full-player UI に推奨です。video presentation は Erika/Metal が持ち、Flutter は control / layout layer に専念できます。iOS では `UIWindow` + sibling `UIView`/`CAMetalLayer`、macOS では host `NSWindow` + sibling `NSView`/`CAMetalLayer` を使います。
+
+touch events は両方の native video strategy を通過するので、Flutter controls を video surface の上や周囲に置けます。
+
+## iOS Build Path
+
+iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を app にリンクし、対象 iOS architecture 向けに Rust の `erika_capi` crate をビルドします。
+
+## Minimal Presenter Flow
+
+```c
+ErikaPresenterHandle *presenter = erika_presenter_create();
+erika_presenter_attach_metal_layer(
+    presenter,
+    (uint64_t)cametal_layer,
+    width,
+    height,
+    backing_scale);
+erika_presenter_open(presenter, "/path/to/media.mp4");
+erika_presenter_play(presenter);
+
+// On every display tick:
+ErikaPresenterStats stats;
+erika_presenter_render_tick(presenter, host_time_seconds, &stats);
+
+// On resize:
+erika_presenter_resize_surface(presenter, width, height, backing_scale);
+
+// On dispose:
+erika_presenter_detach_surface(presenter);
+erika_presenter_destroy(presenter);
+```
+
+## Flutter Texture Path
+
+Flutter Texture は機能が限定された compatibility path です。
+
+用途:
+- SDR fallback。
+- native view composition がまだ使えない platform。
+- test surface や制約の強い embedding 環境。
+
+HDR/EDR の推奨 path ではありません。video が Flutter compositor に入ってしまうためです。C ABI はこの path のために `erika_attach_flutter_texture` を確保しています。
+
+## wgpu Fallback
+
+Apple HDR path は引き続き native Metal です。`wgpu` は Windows、Linux、Android、および非 HDR path に向けた cross-platform fallback です。wgpu renderer は video frame rendering と danmaku compositing を実装済みですが、VideoToolbox zero-copy import や HDR/EDR output はまだ未対応です。
+
+## Dart API
+
+```dart
+final player = ErikaPlayer(
+  outputMode: ErikaOutputMode.appleEdr,  // optional: force EDR
+  edrHeadroom: 4.0,                      // optional: EDR headroom
+);
+
+await player.open('/path/to/video.mp4');
+await player.play();
+
+// Preferred for full-player UIs on macOS/iOS:
+ErikaWindowOverlayVideoView(player: player)
+
+// Compatibility/diagnostic platform-view path:
+ErikaVideoView(player: player)
+
+// Playback control
+await player.pause();
+await player.seek(Duration(seconds: 30));
+await player.setVolume(0.8);
+await player.setPlaybackRate(1.5);
+
+// Neural upscaler (anime luma 2x; macOS/iOS only)
+await player.setUpscaler(ErikaUpscalerMode.artCnnC4F16); // off / artCnnC4F16 / artCnnC4F32
+final status = await player.getUpscalerStatus();
+
+// Track management
+final tracks = await player.tracks();
+await player.selectAudioTrack(trackId);
+await player.selectSubtitleTrack(trackId);
+await player.addExternalSubtitle('/path/to/subtitle.srt');
+
+// Danmaku
+await player.loadDanmakuFile('/path/to/danmaku.xml');
+await player.addDanmakuTrackJson(jsonString, name: 'source', offset: Duration.zero);
+await player.setDanmakuConfig(fontSize: 30, displayArea: 0.5);
+
+// Events
+player.events.listen((event) {
+  // event.kind, event.state, event.position, event.duration, ...
+});
+
+await player.dispose();
+```
+
+## Neural Upscaler Status
+
+`setUpscaler` はモードを要求するだけで、kernel は background thread で compile されます。そのため host は `getUpscalerStatus` を poll して UI を更新する必要があります。
+
+| `activeBackend` | 意味 |
+|-----------------|------|
+| `off` | どの mode も要求されていない。 |
+| `building` | kernel を compile 中（その mode の初回使用）。準備完了まで frame は未拡大で描画される。 |
+| `inactive` | mode は要求されたが、この frame では適用されていない。たとえば video の表示サイズが source resolution を超えていない、または source が HDR（upscaler は SDR luma のみ処理）など。 |
+| `scalar` | portable scalar backend で動作中（非 Apple Silicon GPU）。 |
+| `simdgroupMatrix` | `simdgroup_matrix` backend で動作中（Apple Silicon の既定）。 |
+
+upscaler は drawable が source resolution より大きく video を表示している場合にのみ有効になります。そのため、1080p source を 1080p（またはそれ以下）の view に出している間は `inactive` のままです。C4F16 は realtime の推奨で、C4F32 はより高画質ですが、1080p input では M-Pro/Max クラスの GPU が必要です。renderer 側の設計は `docs/architecture.md` を参照してください。
+
+## Ownership Rule
+
+Flutter は layout と controls を担当し、Erika は video plane、subtitle plane、danmaku plane、audio、timing を担当します。plugin は `MethodChannel` を通じて command と event を橋渡しし、rendering は Dart を経由しません。
+

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -1,5 +1,7 @@
 # Flutter Embedding
 
+[中文](flutter_embedding.zh.md) | [English](flutter_embedding.md) | [日本語](flutter_embedding.ja.md)
+
 Erika is not a Flutter video renderer. Flutter is an optional host UI.
 The player owns decode, timing, native rendering, subtitles, danmaku, audio, and
 HDR presentation.

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -1,0 +1,147 @@
+# Flutter Embedding
+
+[中文](flutter_embedding.zh.md) | [English](flutter_embedding.md) | [日本語](flutter_embedding.ja.md)
+
+Erika 不是 Flutter 视频渲染器。Flutter 只是可选宿主 UI。播放器内部负责解码、时序、原生渲染、字幕、弹幕、音频和 HDR 呈现。
+
+## API Families
+
+有两组 C ABI 入口：
+
+- `ErikaHandle`：控制与事件 API。适合宿主管理自己的 presenter loop，或只想探测/控制播放的场景。
+- `ErikaPresenterHandle`：presenter-owned API。适合 Erika 自己持有 `Player + MetalRenderer + audio output`，宿主只提供 native surface 和 display tick callback 的场景。
+
+两组入口都声明在 `crates/erika_capi/include/erika.h`。
+
+## Apple Surface Strategies
+
+Apple HDR 路径使用 native Metal-backed surface，而不是 Flutter Texture。Flutter plugin 在 macOS 和 iOS 上都提供两种 native surface 策略，方便宿主按 UI 结构选择合适的合成模型。
+
+### ErikaVideoView (Platform View)
+
+标准 Flutter platform view，macOS 上由 `NSView`/`CAMetalLayer` 提供，iOS 上由 `UIView`/`CAMetalLayer` 提供。plugin 会创建注册为 `erika_flutter/video_view` 的 native video view，attach 到 presenter，并通过 display link 驱动渲染。
+
+这个路径适合简单嵌入和诊断。macOS 上它不是推荐的生产路径，因为 AppKit/Flutter platform view 合成可能出现黑屏闪烁或其他 compositor artifacts。
+
+### ErikaWindowOverlayVideoView (Window Overlay)
+
+这是推荐的 HDR/EDR 路径。plugin 会创建一个 window-hosted native overlay，位于 Flutter 的 platform-view compositor 之外：
+
+1. Dart `ErikaWindowOverlayVideoView` 在 widget tree 中预留一个矩形区域。
+2. platform plugin 创建一个 window-level native view，使用 `CAMetalLayer` 作为 Flutter host view 的 sibling/underlay。
+3. Flutter 将该 widget 区域绘制为透明，为 native video 留出空洞。
+4. widget 跟踪自身位置，并通过 surface generation number 发送几何更新，因此已销毁 widget 的旧 hide 调用不会影响新 attach 的 surface。
+5. attach retry 使用 exponential backoff 处理 window readiness 时机。
+
+这个 overlay 路径是 NipaPlay 和其他 full-player UI 的推荐方案。它让视频呈现由 Erika/Metal 持有，而 Flutter 继续承担控制层和布局层。iOS 上 native side 使用 `UIWindow` 加 sibling `UIView`/`CAMetalLayer`；macOS 上使用 host `NSWindow` 加 sibling `NSView`/`CAMetalLayer`。
+
+触摸事件会穿透两种 native video strategy，因此 Flutter controls 可以保持在视频 surface 上方或周围。
+
+## iOS Build Path
+
+iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进 app，并为目标 iOS architecture 构建 Rust `erika_capi` crate。
+
+## Minimal Presenter Flow
+
+```c
+ErikaPresenterHandle *presenter = erika_presenter_create();
+erika_presenter_attach_metal_layer(
+    presenter,
+    (uint64_t)cametal_layer,
+    width,
+    height,
+    backing_scale);
+erika_presenter_open(presenter, "/path/to/media.mp4");
+erika_presenter_play(presenter);
+
+// 每个 display tick：
+ErikaPresenterStats stats;
+erika_presenter_render_tick(presenter, host_time_seconds, &stats);
+
+// resize 时：
+erika_presenter_resize_surface(presenter, width, height, backing_scale);
+
+// dispose 时：
+erika_presenter_detach_surface(presenter);
+erika_presenter_destroy(presenter);
+```
+
+## Flutter Texture Path
+
+Flutter Texture 是一个能力更低的兼容路径。
+
+适合：
+- SDR fallback。
+- native view composition 尚未准备好的平台。
+- 测试 surface 或受限 embedding 环境。
+
+它不是首选 HDR/EDR 路径，因为视频会进入 Flutter compositor。C ABI 为此路径保留了 `erika_attach_flutter_texture`。
+
+## wgpu Fallback
+
+Apple HDR 路径仍然坚持 native Metal。`wgpu` 是面向 Windows、Linux、Android 以及非 HDR 路径的跨平台 fallback 方向。wgpu renderer 已实现视频帧渲染和弹幕合成，但尚未支持 VideoToolbox 零拷贝导入或 HDR/EDR 输出。
+
+## Dart API
+
+```dart
+final player = ErikaPlayer(
+  outputMode: ErikaOutputMode.appleEdr,  // optional: force EDR
+  edrHeadroom: 4.0,                      // optional: EDR headroom
+);
+
+await player.open('/path/to/video.mp4');
+await player.play();
+
+// Preferred for full-player UIs on macOS/iOS:
+ErikaWindowOverlayVideoView(player: player)
+
+// Compatibility / diagnostic platform-view path:
+ErikaVideoView(player: player)
+
+// Playback control
+await player.pause();
+await player.seek(Duration(seconds: 30));
+await player.setVolume(0.8);
+await player.setPlaybackRate(1.5);
+
+// Neural upscaler (anime luma 2x; macOS/iOS only)
+await player.setUpscaler(ErikaUpscalerMode.artCnnC4F16); // off / artCnnC4F16 / artCnnC4F32
+final status = await player.getUpscalerStatus();
+
+// Track management
+final tracks = await player.tracks();
+await player.selectAudioTrack(trackId);
+await player.selectSubtitleTrack(trackId);
+await player.addExternalSubtitle('/path/to/subtitle.srt');
+
+// Danmaku
+await player.loadDanmakuFile('/path/to/danmaku.xml');
+await player.addDanmakuTrackJson(jsonString, name: 'source', offset: Duration.zero);
+await player.setDanmakuConfig(fontSize: 30, displayArea: 0.5);
+
+// Events
+player.events.listen((event) {
+  // event.kind, event.state, event.position, event.duration, ...
+});
+
+await player.dispose();
+```
+
+## Neural Upscaler Status
+
+`setUpscaler` 只是在请求一个模式；kernel 会在后台线程编译，所以宿主应该轮询 `getUpscalerStatus` 来驱动 UI：
+
+| `activeBackend` | 含义 |
+|-----------------|------|
+| `off` | 没有请求任何模式。 |
+| `building` | kernel 正在编译（首次使用该模式）；在准备好之前视频会保持未放大。 |
+| `inactive` | 请求了模式，但这一帧没有生效，例如视频显示尺寸没有超过源分辨率，或源视频是 HDR（upscaler 只处理 SDR luma）。 |
+| `scalar` | 运行在可移植 scalar backend 上（非 Apple Silicon GPU）。 |
+| `simdgroupMatrix` | 运行在 `simdgroup_matrix` backend 上（Apple Silicon 默认）。 |
+
+只有当 drawable 显示的视频尺寸大于源分辨率时，upscaler 才会生效，所以 1080p 源在 1080p（或更小）视图里会保持 `inactive`。C4F16 是实时推荐；C4F32 质量更高，但在 1080p 输入下需要 M-Pro/Max 级别 GPU。渲染器侧设计见 `docs/architecture.md`。
+
+## Ownership Rule
+
+Flutter 负责布局和 controls。Erika 负责 video plane、subtitle plane、danmaku plane、audio 和 timing。plugin 通过 `MethodChannel` 传递命令和事件；渲染不会经过 Dart。
+

--- a/examples/danmaku_perf_lab/README.ja.md
+++ b/examples/danmaku_perf_lab/README.ja.md
@@ -1,0 +1,107 @@
+# Erika Danmaku Perf Lab
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+Erika の制御された弾幕パフォーマンス計測ハーネスです。NipaPlay から意図的に独立させてあり、弾幕密度、viewport size、media time、video decode、trace output を Flutter/UI のノイズなしで変えられます。
+
+## Synthetic danmaku load
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --size 1920x1080
+```
+
+## Video-driven media time
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --video /path/to/video.mp4 \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense
+```
+
+CPU decode 負荷だけを切り出したい場合は `--software` を使って software decode を強制します。
+
+## Native Metal window stress
+
+renderer profiling では release build を使ってください。debug Rust は GPU path の結論を出すには遅すぎます。
+
+```sh
+cargo run --release -p danmaku_perf_lab -- \
+  --window \
+  --fullscreen \
+  --target-fps 165 \
+  --video /path/to/video.mp4 \
+  --pattern scroll \
+  --rate 600 \
+  --duration 120 \
+  --font-size 16 \
+  --display-area 1.0 \
+  --scroll-duration 10 \
+  --stacking \
+  --window-size 1600x900 \
+  --hide-panel \
+  --surface-scale 1.0 \
+  --metrics-log /tmp/erika_lab_stress.jsonl \
+  --auto-exit 18
+```
+
+生の throughput を見たい場合は `--target-fps` の代わりに `--uncapped` を使います。uncapped mode では CAMetalLayer の display sync を無効化し、main run loop が出せる限り速く frame を回します。renderer stress には便利ですが、固定 refresh-rate の run よりノイズが多くなります。
+
+このモードは DFM collision avoidance が通常許すよりも多くの弾幕をあえて見えるようにするため、実運用の密度ではなく renderer stress case です。性能の真実は JSONL ログにあり、window は visual sanity check 用です。
+
+## Neural upscaler comparison
+
+`--upscaler off|artcnn-c4f16|artcnn-c4f32` で Metal の neural luma doubler を選びます。同じ clip を各 mode で走らせ、JSONL の `upscaler_backend`、`upscaler_fallbacks`、`upscaler_encode_ms`、`gpu_frame_ms`、`upscaled_frames`、`fps` を比較してください。
+
+```sh
+cargo run --release -p danmaku_perf_lab -- \
+  --window --hide-panel --items 1 \
+  --video /path/to/anime_720p.mp4 \
+  --target-fps 60 \
+  --upscaler artcnn-c4f16 \
+  --metrics-log /tmp/erika_sr.jsonl \
+  --auto-exit 25
+```
+
+upscaler は drawable が source resolution より大きく video を表示したときだけ動作します。つまり、window の物理ピクセルが source より大きい必要があります。`gpu_frame_ms` は完了済み command buffer をサンプルします。同じ frame の cached upscale を再利用する tick がサンプルを支配するので、ネットワーク自体の isolated GPU cost を知りたい場合は `cargo test --release -p erika --test artcnn_upscaler -- --ignored --nocapture bench` を使ってください。
+
+実験用 kernel の調整項目: `ERIKA_SR_BACKEND=scalar|matmul` で backend を固定（既定は Apple Silicon で matmul）、`ERIKA_SR_BLOCK=WxH` で scalar backend の per-thread output block、`ERIKA_SR_PXF=N` で matmul backend の pixels per simdgroup を設定します。
+
+## Atlas prewarm comparison
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --prewarm-frames 720
+```
+
+## Reading the output
+
+- `prepare_ms`: DFM+ prepare、measurement、filtering、track allocation、collision avoidance。
+- `standalone_frame_layout_ms`: prepared layout への直接 frame query。
+- `render_plan_total_ms`: frame query と glyph instance 展開、atlas snapshot access の合計。
+- `current_metal_draws`: glyph の shadow / outline / fill を考慮した現在の Metal 弾幕 draw call 推定値。
+- `batched_target_draws`: shadow / outline / fill を batch した場合の draw call 推定値。
+- `atlas_changes`: サンプル frame 中の atlas version change 数。
+- `draw_call_reduction_target`: 現在の draw call ÷ 期待 batch draw call。
+
+window JSONL で見るべき field:
+
+- `fps`、`tick_ms`、`pump_ms`、`render_ms`: 全体の frame health。
+- `video_pump_ms`、`danmaku_plan_ms`: presenter 側の decode/import と render-plan cost。
+- `danmaku_vertex_build_ms`、`danmaku_vertex_copy_ms`、`danmaku_encode_ms`: Metal 弾幕 pass の CPU cost。
+- `draw_items_per_new_pass`: 新しく描画した danmaku pass あたりの glyph instance 数。
+- `danmaku_vertex_bytes`: current frame で Metal instance buffer に書き込まれた byte 数。
+
+この lab は Metal/WGPU 弾幕 batching 作業の baseline です。
+

--- a/examples/danmaku_perf_lab/README.zh.md
+++ b/examples/danmaku_perf_lab/README.zh.md
@@ -1,0 +1,107 @@
+# Erika Danmaku Perf Lab
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+Erika 的受控弹幕性能测试工具。它刻意独立于 NipaPlay，这样弹幕密度、viewport 大小、media time、视频解码和 trace 输出都可以在没有 Flutter/UI 干扰的情况下自由变化。
+
+## Synthetic danmaku load
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --size 1920x1080
+```
+
+## Video-driven media time
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --video /path/to/video.mp4 \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense
+```
+
+使用 `--software` 可在隔离 CPU decode 负载时强制软件解码。
+
+## Native Metal window stress
+
+做 renderer profiling 时请使用 release build；debug Rust 对 GPU path 来说太慢，不适合做有意义的结论。
+
+```sh
+cargo run --release -p danmaku_perf_lab -- \
+  --window \
+  --fullscreen \
+  --target-fps 165 \
+  --video /path/to/video.mp4 \
+  --pattern scroll \
+  --rate 600 \
+  --duration 120 \
+  --font-size 16 \
+  --display-area 1.0 \
+  --scroll-duration 10 \
+  --stacking \
+  --window-size 1600x900 \
+  --hide-panel \
+  --surface-scale 1.0 \
+  --metrics-log /tmp/erika_lab_stress.jsonl \
+  --auto-exit 18
+```
+
+需要原始吞吐时，用 `--uncapped` 替代 `--target-fps`。在 uncapped 模式下，lab 会关闭 CAMetalLayer 的 display sync，并尽可能快地推进主 run loop；这适合 renderer stress，但比固定刷新率测试更嘈杂。
+
+这个模式会刻意制造比 DFM collision avoidance 通常允许的更多可见弹幕，因此它是 renderer stress case，而不是现实密度画像。JSONL 日志才是性能真相；窗口只用于肉眼检查。
+
+## Neural upscaler comparison
+
+`--upscaler off|artcnn-c4f16|artcnn-c4f32` 用来选择 Metal 神经亮度 doubler。用同一段视频分别跑不同模式，再比较 JSONL 字段 `upscaler_backend`、`upscaler_fallbacks`、`upscaler_encode_ms`、`gpu_frame_ms`、`upscaled_frames` 和 `fps`：
+
+```sh
+cargo run --release -p danmaku_perf_lab -- \
+  --window --hide-panel --items 1 \
+  --video /path/to/anime_720p.mp4 \
+  --target-fps 60 \
+  --upscaler artcnn-c4f16 \
+  --metrics-log /tmp/erika_sr.jsonl \
+  --auto-exit 25
+```
+
+只有当 drawable 显示的视频高于源分辨率时，upscaler 才会启动，所以窗口物理像素必须大于源视频。`gpu_frame_ms` 采样的是已完成 command buffer；那些复用缓存 upscaled 结果的 tick 会主导这些样本，因此如果要单独看网络本体的 GPU 成本，请用 `cargo test --release -p erika --test artcnn_upscaler -- --ignored --nocapture bench`。
+
+实验 kernel 的调参开关：`ERIKA_SR_BACKEND=scalar|matmul` 强制 kernel backend（默认：Apple Silicon 上用 matmul），`ERIKA_SR_BLOCK=WxH` 设置 scalar backend 的每线程输出块，`ERIKA_SR_PXF=N` 设置 matmul backend 的每个 simdgroup 像素片段数。
+
+## Atlas prewarm comparison
+
+```sh
+cargo run -p danmaku_perf_lab -- \
+  --frames 600 \
+  --rate 300 \
+  --duration 120 \
+  --pattern dense \
+  --prewarm-frames 720
+```
+
+## Reading the output
+
+- `prepare_ms`：DFM+ prepare、measurement、filtering、track allocation、collision avoidance。
+- `standalone_frame_layout_ms`：prepared layout 的直接 frame query。
+- `render_plan_total_ms`：frame query 加 glyph instance 扩展和 atlas snapshot access。
+- `current_metal_draws`：按 glyph shadow/outline/fill 计算的当前 Metal danmaku draw call 估计。
+- `batched_target_draws`：按 shadow/outline/fill 批处理后的 draw call 估计。
+- `atlas_changes`：采样帧期间 atlas version 改变次数。
+- `draw_call_reduction_target`：当前 draw call 除以预期批处理 draw call。
+
+窗口 JSONL 字段里值得关注的有：
+
+- `fps`、`tick_ms`、`pump_ms`、`render_ms`：整体 frame 健康度。
+- `video_pump_ms`、`danmaku_plan_ms`：presenter 侧的 decode/import 与 render-plan 成本。
+- `danmaku_vertex_build_ms`、`danmaku_vertex_copy_ms`、`danmaku_encode_ms`：Metal danmaku pass 的 CPU 成本。
+- `draw_items_per_new_pass`：新渲染的 danmaku pass 中 glyph instance 数量。
+- `danmaku_vertex_bytes`：当前 frame 写入 Metal instance buffer 的字节数。
+
+这个 lab 是 Metal/WGPU 弹幕 batching 工作的基线。
+

--- a/packages/erika_flutter/README.ja.md
+++ b/packages/erika_flutter/README.ja.md
@@ -1,0 +1,60 @@
+# erika_flutter
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+Erika メディア再生エンジン向けの Flutter plugin です。
+
+この plugin は Dart を hot path から外します。
+
+- Dart は低頻度の player command と event stream だけを公開します。
+- Apple plugin は 2 種類の native Metal surface を提供します。推奨は `ErikaWindowOverlayVideoView`、互換用は `ErikaVideoView` です。
+- macOS plugin は Erika の dynamic library を読み込みます。
+- iOS plugin は Erika の static library を link します。
+- Erika は `ErikaPresenterHandle` を通じて playback、rendering、audio、timing、overlay を担当します。
+
+## Video Surfaces
+
+フルプレイヤーの macOS/iOS UI では `ErikaWindowOverlayVideoView` を使うのが推奨です。Flutter の layout では矩形領域を予約しつつ、plugin が横に native `CAMetalLayer` を持ち、video を Flutter platform-view compositor の外に置きます。
+
+標準的な Flutter platform view が必要な場合は `ErikaVideoView` を使います。
+
+## macOS Setup
+
+ローカル開発では macOS plugin が `dlopen` で Erika を読み込みます。`ERIKA_CAPI_DYLIB` で dynamic library path を上書きできます。未設定時は app bundle、実行ファイルディレクトリ、`$WORKSPACE/target/debug/liberika_capi.dylib` の順で探します。
+
+dynamic library を build するには：
+
+```sh
+cargo run -p xtask -- deps build --all --profile lgpl
+cargo build -p erika_capi
+```
+
+## iOS Setup
+
+iOS の CocoaPod script phase が、Xcode build 中に Erika の native dependency と C ABI static library を自動 build します。対応する iOS target の Rust toolchain が必要です。
+
+- `rustup target add aarch64-apple-ios`
+
+## Output Mode
+
+`ErikaPlayer()` は macOS plugin に現在の screen と environment から SDR か Apple EDR を選ばせます。Dart から EDR を強制するには：
+
+```dart
+final player = ErikaPlayer(
+  outputMode: ErikaOutputMode.appleEdr,
+  edrHeadroom: 4.0,
+);
+```
+
+`ErikaOutputMode.sdr` で SDR 出力を強制できます。
+
+## Upscaler
+
+player 作成後に Dart から ArtCNN upscaling を有効にできます。
+
+```dart
+await player.setUpscaler(ErikaUpscalerMode.artCnnC4F16);
+```
+
+`ErikaUpscalerMode.off` で無効化します。`player.getUpscalerStatus()` では要求モード、実行 backend、fallback 回数、upscaled frame 数、最近の GPU timing を確認できます。
+

--- a/packages/erika_flutter/README.zh.md
+++ b/packages/erika_flutter/README.zh.md
@@ -1,0 +1,60 @@
+# erika_flutter
+
+[中文](README.zh.md) | [English](README.md) | [日本語](README.ja.md)
+
+Erika 媒体播放引擎的 Flutter plugin。
+
+插件让 Dart 不进入热路径：
+
+- Dart 只暴露低频播放器命令和事件流。
+- Apple 插件提供两种 native Metal surface：推荐的 `ErikaWindowOverlayVideoView`，以及兼容用的 `ErikaVideoView`。
+- macOS 插件加载 Erika 动态库。
+- iOS 插件链接 Erika 静态库。
+- Erika 通过 `ErikaPresenterHandle` 负责播放、渲染、音频、时序和 overlay。
+
+## Video Surfaces
+
+全播放器 macOS/iOS UI 推荐使用 `ErikaWindowOverlayVideoView`。它会在 Flutter 布局中预留矩形区域，同时插件在旁边托管一个原生 `CAMetalLayer`，让视频保持在 Flutter platform-view compositor 之外。
+
+需要标准 Flutter platform view 时则使用 `ErikaVideoView`。
+
+## macOS Setup
+
+本地开发时，macOS 插件通过 `dlopen` 加载 Erika。可设置 `ERIKA_CAPI_DYLIB` 覆盖动态库路径；若未设置，插件会按 app bundle、可执行文件目录、再到 `$WORKSPACE/target/debug/liberika_capi.dylib` 依次查找。
+
+构建动态库：
+
+```sh
+cargo run -p xtask -- deps build --all --profile lgpl
+cargo build -p erika_capi
+```
+
+## iOS Setup
+
+iOS CocoaPod script phase 会在 Xcode 构建期间自动构建 Erika 原生依赖和 C ABI static library。需要安装对应 iOS target 的 Rust toolchain：
+
+- `rustup target add aarch64-apple-ios`
+
+## Output Mode
+
+`ErikaPlayer()` 会让 macOS 插件根据当前屏幕和环境选择 SDR 或 Apple EDR。若要从 Dart 强制 EDR：
+
+```dart
+final player = ErikaPlayer(
+  outputMode: ErikaOutputMode.appleEdr,
+  edrHeadroom: 4.0,
+);
+```
+
+使用 `ErikaOutputMode.sdr` 可强制 SDR 输出。
+
+## Upscaler
+
+创建播放器后即可从 Dart 启用 ArtCNN 超分：
+
+```dart
+await player.setUpscaler(ErikaUpscalerMode.artCnnC4F16);
+```
+
+使用 `ErikaUpscalerMode.off` 关闭。`player.getUpscalerStatus()` 会返回请求模式、当前后端、fallback 次数、超分帧数和最近 GPU timing。
+


### PR DESCRIPTION
Adds zh/ja counterparts and language switchers for the developer-facing documentation set:\n\n- docs/architecture\n- docs/danmaku_architecture\n- docs/flutter_embedding\n- packages/erika_flutter README\n- examples/danmaku_perf_lab README\n- crates/erika/assets/artcnn README\n\nThe root README already had trilingual navigation, so it was left unchanged.