### PR TITLE
Fix HTTP playback and startup danmaku stutter

### DIFF
--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use thiserror::Error;
 
 use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
+use crate::trace;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AudioError {
@@ -238,6 +239,34 @@ impl AudioRingBuffer {
         self.stats.dropped_frames +=
             (dropped_frames + incoming_frames.saturating_sub(accepted_frames)) as u64;
 
+        if trace::enabled()
+            && (dropped_frames > 0
+                || accepted_frames < incoming_frames
+                || self.queued_frames() >= self.config.capacity_frames.saturating_sub(256))
+        {
+            trace::log(format!(
+                "[erika-audio-trace] stage=push pts={} incoming_frames={} accepted_frames={} dropped_frames={} queued_frames={} queued_duration={} written_frames={} dropped_total={} sample_rate={} channels={} capacity_frames={} drop_oldest={}",
+                frame_pts.map_or_else(
+                    || "-".to_string(),
+                    |pts| format!("{:.3}", pts.as_secs_f64())
+                ),
+                incoming_frames,
+                accepted_frames,
+                dropped_frames + incoming_frames.saturating_sub(accepted_frames),
+                self.queued_frames(),
+                self.queued_duration().map_or_else(
+                    || "-".to_string(),
+                    |duration| format!("{:.3}", duration.as_secs_f64())
+                ),
+                self.stats.written_frames,
+                self.stats.dropped_frames,
+                format!("{}", format.sample_rate),
+                channels,
+                self.config.capacity_frames,
+                self.config.drop_oldest_on_overflow,
+            ));
+        }
+
         Ok(AudioPushResult {
             accepted_frames,
             dropped_frames: dropped_frames + incoming_frames.saturating_sub(accepted_frames),
@@ -271,6 +300,24 @@ impl AudioRingBuffer {
         self.advance_timeline(read_frames, format.sample_rate);
         self.stats.read_frames += read_frames as u64;
         self.stats.underflow_frames += underflow_frames as u64;
+
+        if trace::enabled() && (underflow_frames > 0 || read_frames == 0 && requested_frames > 0) {
+            trace::log(format!(
+                "[erika-audio-trace] stage=read requested_frames={} read_frames={} underflow_frames={} queued_frames={} queued_duration={} read_total={} underflow_total={} sample_rate={} channels={} state=buffered",
+                requested_frames,
+                read_frames,
+                underflow_frames,
+                self.queued_frames(),
+                self.queued_duration().map_or_else(
+                    || "-".to_string(),
+                    |duration| format!("{:.3}", duration.as_secs_f64())
+                ),
+                self.stats.read_frames,
+                self.stats.underflow_frames,
+                format.sample_rate,
+                channels,
+            ));
+        }
 
         Ok(AudioReadResult {
             frames: read_frames,

--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -18,7 +18,10 @@ use crate::trace;
 static NEXT_PLAYER_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_EXTERNAL_SUBTITLE_TRACK_ID: AtomicU64 = AtomicU64::new(1);
 const EXTERNAL_SUBTITLE_TRACK_ID_BASE: i64 = 1_000_000;
-const AUDIO_PREFILL_BURST_LIMIT: usize = 64;
+const AUDIO_PREFILL_AFTER_VIDEO_LIMIT: usize = 4;
+const AUDIO_PREFILL_PACKET_BUDGET: usize = 4;
+const AUDIO_PREFILL_TIME_BUDGET: Duration = Duration::from_millis(3);
+const AUDIO_PREFILL_LOW_WATER: Duration = Duration::from_millis(350);
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum PlayerError {
@@ -884,12 +887,27 @@ fn run_playback_worker(
     inner: Arc<Mutex<PlayerInner>>,
     commands: Receiver<PlaybackCommand>,
 ) {
+    let worker_started = std::time::Instant::now();
     let mut last_position_event = None;
     let mut playback_generation = 1u64;
     let mut last_worker_clock = None;
+    let mut last_audio_snapshot = None;
+    let mut loop_count = 0u64;
+    trace::log(format!(
+        "[erika-playback-trace] stage=worker_start state={:?} generation={} poll_ms={} uptime_ms={:.3}",
+        engine.state(),
+        playback_generation,
+        playback_poll_interval(engine.state()).as_millis(),
+        worker_started.elapsed().as_secs_f64() * 1000.0,
+    ));
     loop {
+        loop_count = loop_count.saturating_add(1);
+        let loop_started = std::time::Instant::now();
+        let mut command_count = 0usize;
         match commands.recv_timeout(playback_poll_interval(engine.state())) {
             Ok(command) => {
+                command_count += 1;
+                observe_audio_pump_command(&mut last_audio_snapshot, &command);
                 if !handle_playback_command(engine, &inner, command, &mut playback_generation) {
                     return;
                 }
@@ -899,14 +917,13 @@ fn run_playback_worker(
         }
 
         while let Ok(command) = commands.try_recv() {
+            command_count += 1;
+            observe_audio_pump_command(&mut last_audio_snapshot, &command);
             if !handle_playback_command(engine, &inner, command, &mut playback_generation) {
                 return;
             }
         }
-
-        if engine.should_prefill_audio() {
-            pump_audio_from_worker(engine, &inner, playback_generation, "before_video_tick");
-        }
+        let after_commands = std::time::Instant::now();
 
         sync_playback_clock_from_worker(
             engine,
@@ -915,11 +932,25 @@ fn run_playback_worker(
             "before_video_tick",
             &mut last_worker_clock,
         );
+        let after_clock_sync = std::time::Instant::now();
 
         match engine.tick() {
             Ok(Some(frame)) => {
                 let position = frame.pts.unwrap_or(frame.media_time);
                 last_position_event = Some(position);
+                trace::log(format!(
+                    "[erika-playback-trace] stage=video_frame gen={} pts={} media={} late={} loop={} commands={} state={:?}",
+                    playback_generation,
+                    trace::duration_label(frame.pts),
+                    trace::duration_label(Some(frame.media_time)),
+                    frame
+                        .late_by
+                        .map(|duration| format!("{:.3}", duration.as_secs_f64()))
+                        .unwrap_or_else(|| "-".to_string()),
+                    loop_count,
+                    command_count,
+                    engine.state(),
+                ));
                 emit_video_frame_from_worker(
                     &inner,
                     PlayerVideoFrame {
@@ -933,6 +964,10 @@ fn run_playback_worker(
             }
             Ok(None) => {}
             Err(error) => {
+                trace::log(format!(
+                    "[erika-playback-trace] stage=video_tick_error gen={} loop={} commands={} error={}",
+                    playback_generation, loop_count, command_count, error,
+                ));
                 emit_from_worker(
                     &inner,
                     PlayerEvent::Error(PlayerError::Playback(error.to_string())),
@@ -948,9 +983,18 @@ fn run_playback_worker(
             "after_video_tick",
             &mut last_worker_clock,
         );
+        let after_video = std::time::Instant::now();
 
         if engine.state() == PlaybackRunState::Playing {
-            pump_audio_from_worker(engine, &inner, playback_generation, "after_video_tick");
+            if should_prefill_audio_from_worker(engine, last_audio_snapshot) {
+                pump_audio_from_worker(
+                    engine,
+                    &inner,
+                    playback_generation,
+                    "after_video_tick",
+                    AUDIO_PREFILL_AFTER_VIDEO_LIMIT,
+                );
+            }
 
             match engine.tick_subtitle() {
                 Ok(Some(frame)) => emit_subtitle_frame_from_worker(
@@ -981,6 +1025,7 @@ fn run_playback_worker(
             "after_av_tick",
             &mut last_worker_clock,
         );
+        let after_av = std::time::Instant::now();
 
         if engine.state() == PlaybackRunState::Ended {
             set_state_from_worker(&inner, PlayerState::Stopped);
@@ -988,6 +1033,25 @@ fn run_playback_worker(
 
         if let Some(position) = last_position_event.take() {
             emit_from_worker(&inner, PlayerEvent::PositionChanged(position));
+        }
+
+        let loop_duration = loop_started.elapsed();
+        if trace::enabled() && (loop_duration > Duration::from_millis(4) || command_count > 0) {
+            trace::log(format!(
+                "[erika-playback-trace] stage=worker_loop gen={} loop={} commands={} total_ms={:.3} commands_ms={:.3} clock_ms={:.3} video_ms={:.3} av_ms={:.3} state={:?}",
+                playback_generation,
+                loop_count,
+                command_count,
+                loop_duration.as_secs_f64() * 1000.0,
+                after_commands.duration_since(loop_started).as_secs_f64() * 1000.0,
+                after_clock_sync
+                    .duration_since(after_commands)
+                    .as_secs_f64()
+                    * 1000.0,
+                after_video.duration_since(after_clock_sync).as_secs_f64() * 1000.0,
+                after_av.duration_since(after_video).as_secs_f64() * 1000.0,
+                engine.state(),
+            ));
         }
     }
 }
@@ -997,14 +1061,24 @@ fn pump_audio_from_worker(
     inner: &Arc<Mutex<PlayerInner>>,
     playback_generation: u64,
     stage: &'static str,
+    burst_limit: usize,
 ) {
     let started = Instant::now();
     let mut emitted = 0usize;
-    for _ in 0..AUDIO_PREFILL_BURST_LIMIT {
+    let mut budget_exhausted = false;
+    for _ in 0..burst_limit {
+        let elapsed = started.elapsed();
+        if elapsed >= AUDIO_PREFILL_TIME_BUDGET {
+            budget_exhausted = true;
+            break;
+        }
         if audio_frame_sender_is_full(inner) {
             break;
         }
-        match engine.tick_audio() {
+        match engine.tick_audio_bounded(
+            AUDIO_PREFILL_PACKET_BUDGET,
+            AUDIO_PREFILL_TIME_BUDGET.saturating_sub(elapsed),
+        ) {
             Ok(Some(frame)) => {
                 emitted += 1;
                 if !emit_audio_frame_from_worker(
@@ -1028,12 +1102,40 @@ fn pump_audio_from_worker(
             }
         }
     }
-    if emitted > 0 {
+    if emitted > 0 || budget_exhausted {
         trace::log(format!(
-            "[erika-clock-trace] stage=worker_audio_prefill:{stage} emitted={} elapsed_ms={:.3}",
+            "[erika-clock-trace] stage=worker_audio_prefill:{stage} emitted={} frame_limit={} packet_budget={} budget_exhausted={} elapsed_ms={:.3}",
             emitted,
+            burst_limit,
+            AUDIO_PREFILL_PACKET_BUDGET,
+            budget_exhausted,
             started.elapsed().as_secs_f64() * 1000.0,
         ));
+    }
+}
+
+fn should_prefill_audio_from_worker(
+    engine: &VideoPlaybackEngine,
+    snapshot: Option<AudioClockSnapshot>,
+) -> bool {
+    if !engine.should_prefill_audio() {
+        return false;
+    }
+    snapshot
+        .and_then(|snapshot| snapshot.queued_duration)
+        .is_none_or(|queued| queued < AUDIO_PREFILL_LOW_WATER)
+}
+
+fn observe_audio_pump_command(
+    last_audio_snapshot: &mut Option<AudioClockSnapshot>,
+    command: &PlaybackCommand,
+) {
+    match command {
+        PlaybackCommand::AudioClock(snapshot) => *last_audio_snapshot = Some(*snapshot),
+        PlaybackCommand::Seek(_) | PlaybackCommand::Stop | PlaybackCommand::SelectAudioTrack(_) => {
+            *last_audio_snapshot = None;
+        }
+        _ => {}
     }
 }
 

--- a/crates/erika/src/danmaku.rs
+++ b/crates/erika/src/danmaku.rs
@@ -377,6 +377,19 @@ impl DanmakuTimeline {
         &self.items
     }
 
+    pub fn window(&self, start: Duration, end: Duration) -> Self {
+        if end < start || self.items.is_empty() {
+            return Self::default();
+        }
+        let items = self
+            .items
+            .iter()
+            .filter(|item| item.pts >= start && item.pts <= end)
+            .cloned()
+            .collect();
+        Self { items }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
@@ -1796,6 +1809,16 @@ impl DfmLayoutEngine {
             .as_ref()
             .expect("prepared layout exists")
             .frame_layout(media_time, generation)
+    }
+
+    pub fn render_prepared_plan(
+        &self,
+        prepared: &DfmPreparedLayout,
+        media_time: Duration,
+        generation: u64,
+    ) -> DanmakuRenderPlan {
+        let layout = prepared.frame_layout(media_time, generation);
+        self.rasterizer.render_plan(&layout)
     }
 
     pub fn render_plan(

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -231,6 +231,8 @@ pub struct Demuxer {
     selection: StreamSelection,
 }
 
+unsafe impl Send for Demuxer {}
+
 impl Demuxer {
     pub fn open_path(path: impl AsRef<Path>) -> Result<Self> {
         Self::open_uri(&path.as_ref().to_string_lossy())
@@ -319,6 +321,11 @@ impl Demuxer {
         })
     }
 
+    pub fn owned_codec_parameters(&self, stream_index: i32) -> Result<OwnedCodecParameters> {
+        let parameters = self.codec_parameters(stream_index)?;
+        OwnedCodecParameters::copy_from(parameters)
+    }
+
     pub fn open_decoder(&self, stream_index: i32) -> Result<Decoder> {
         Decoder::open(self.codec_parameters(stream_index)?)
     }
@@ -401,6 +408,54 @@ impl CodecParameters<'_> {
     }
 }
 
+pub struct OwnedCodecParameters {
+    ptr: *mut sys::AVCodecParameters,
+    stream_index: i32,
+    time_base: TimeBase,
+}
+
+unsafe impl Send for OwnedCodecParameters {}
+
+impl OwnedCodecParameters {
+    fn copy_from(parameters: CodecParameters<'_>) -> Result<Self> {
+        let ptr = unsafe { sys::avcodec_parameters_alloc() };
+        if ptr.is_null() {
+            return Err(FfmpegError::NullPointer("avcodec_parameters_alloc"));
+        }
+        check(
+            unsafe { sys::avcodec_parameters_copy(ptr, parameters.ptr) },
+            "avcodec_parameters_copy",
+        )?;
+        Ok(Self {
+            ptr,
+            stream_index: parameters.stream_index,
+            time_base: parameters.time_base,
+        })
+    }
+
+    pub fn stream_index(&self) -> i32 {
+        self.stream_index
+    }
+
+    pub fn time_base(&self) -> TimeBase {
+        self.time_base
+    }
+
+    pub fn codec_name(&self) -> Option<String> {
+        unsafe { codec_name((*self.ptr).codec_id) }
+    }
+
+    pub fn kind(&self) -> Option<TrackKind> {
+        unsafe { track_kind((*self.ptr).codec_type) }
+    }
+}
+
+impl Drop for OwnedCodecParameters {
+    fn drop(&mut self) {
+        unsafe { sys::avcodec_parameters_free(&mut self.ptr) };
+    }
+}
+
 pub struct SubtitleDecoder {
     context: *mut sys::AVCodecContext,
     stream_index: i32,
@@ -412,11 +467,31 @@ unsafe impl Send for SubtitleDecoder {}
 
 impl SubtitleDecoder {
     pub fn open(parameters: CodecParameters<'_>) -> Result<Self> {
-        if parameters.kind() != Some(TrackKind::Subtitle) {
+        Self::open_raw(
+            parameters.ptr,
+            parameters.stream_index,
+            parameters.time_base,
+        )
+    }
+
+    pub fn open_owned(parameters: &OwnedCodecParameters) -> Result<Self> {
+        Self::open_raw(
+            parameters.ptr,
+            parameters.stream_index,
+            parameters.time_base,
+        )
+    }
+
+    fn open_raw(
+        parameters_ptr: *const sys::AVCodecParameters,
+        stream_index: i32,
+        time_base: TimeBase,
+    ) -> Result<Self> {
+        if unsafe { track_kind((*parameters_ptr).codec_type) } != Some(TrackKind::Subtitle) {
             return Err(FfmpegError::ExpectedSubtitleStream);
         }
 
-        let codec_id = unsafe { (*parameters.ptr).codec_id };
+        let codec_id = unsafe { (*parameters_ptr).codec_id };
         let codec = unsafe { sys::avcodec_find_decoder(codec_id) };
         if codec.is_null() {
             return Err(FfmpegError::NullPointer("avcodec_find_decoder(subtitle)"));
@@ -427,19 +502,16 @@ impl SubtitleDecoder {
         }
         let decoder = Self {
             context,
-            stream_index: parameters.stream_index,
-            time_base: parameters.time_base,
-            track: SubtitleTrackConfig::embedded(
-                i64::from(parameters.stream_index),
-                i64::from(parameters.stream_index),
-            ),
+            stream_index,
+            time_base,
+            track: SubtitleTrackConfig::embedded(i64::from(stream_index), i64::from(stream_index)),
         };
         check(
-            unsafe { sys::avcodec_parameters_to_context(decoder.context, parameters.ptr) },
+            unsafe { sys::avcodec_parameters_to_context(decoder.context, parameters_ptr) },
             "avcodec_parameters_to_context(subtitle)",
         )?;
         unsafe {
-            (*decoder.context).pkt_timebase = parameters.time_base.to_av_rational();
+            (*decoder.context).pkt_timebase = time_base.to_av_rational();
         }
         check(
             unsafe { sys::avcodec_open2(decoder.context, codec, ptr::null_mut()) },
@@ -568,11 +640,41 @@ impl Decoder {
         Self::open_with_config(parameters, DecoderConfig::default())
     }
 
+    pub fn open_owned(parameters: &OwnedCodecParameters) -> Result<Self> {
+        Self::open_owned_with_config(parameters, DecoderConfig::default())
+    }
+
+    pub fn open_owned_with_config(
+        parameters: &OwnedCodecParameters,
+        config: DecoderConfig,
+    ) -> Result<Self> {
+        Self::open_raw(
+            parameters.ptr,
+            parameters.stream_index,
+            parameters.time_base,
+            config,
+        )
+    }
+
     pub fn open_with_config(
         parameters: CodecParameters<'_>,
         config: DecoderConfig,
     ) -> Result<Self> {
-        let codec_id = unsafe { (*parameters.ptr).codec_id };
+        Self::open_raw(
+            parameters.ptr,
+            parameters.stream_index,
+            parameters.time_base,
+            config,
+        )
+    }
+
+    fn open_raw(
+        parameters_ptr: *const sys::AVCodecParameters,
+        stream_index: i32,
+        time_base: TimeBase,
+        config: DecoderConfig,
+    ) -> Result<Self> {
+        let codec_id = unsafe { (*parameters_ptr).codec_id };
         let codec = unsafe { sys::avcodec_find_decoder(codec_id) };
         if codec.is_null() {
             return Err(FfmpegError::NullPointer("avcodec_find_decoder"));
@@ -583,13 +685,13 @@ impl Decoder {
         }
         let decoder = Self {
             context,
-            stream_index: parameters.stream_index,
-            time_base: parameters.time_base,
+            stream_index,
+            time_base,
             backend: config.backend,
             hw_state: None,
         };
         check(
-            unsafe { sys::avcodec_parameters_to_context(decoder.context, parameters.ptr) },
+            unsafe { sys::avcodec_parameters_to_context(decoder.context, parameters_ptr) },
             "avcodec_parameters_to_context",
         )?;
         let mut decoder = decoder;

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
+use std::thread;
 use std::time::{Duration, Instant};
 
+use crossbeam_channel::{Receiver, Sender, TryRecvError, bounded, unbounded};
 use thiserror::Error;
 
 use crate::audio::AudioClockSnapshot;
@@ -9,7 +11,7 @@ use crate::core::{
 };
 use crate::ffmpeg::{
     self, AudioResampler, Decoder, DecoderBackend, DecoderConfig, DecoderOutputFrame, Demuxer,
-    Frame, PcmAudioFrame, PcmFormat, StreamSelection, SubtitleDecoder,
+    Frame, OwnedCodecParameters, PcmAudioFrame, PcmFormat, StreamSelection, SubtitleDecoder,
 };
 use crate::source::{self, source_from_uri_with_hint};
 use crate::subtitle::{DecodedSubtitleFrame, SubtitleTrackConfig, SubtitleTrackSource};
@@ -31,6 +33,8 @@ pub enum PlaybackError {
     TrackNotFound { kind: TrackKind, track_id: i64 },
     #[error("subtitle track is not removable: {0}")]
     SubtitleTrackNotRemovable(i64),
+    #[error("demux worker error: {0}")]
+    DemuxWorker(String),
 }
 
 pub type Result<T> = std::result::Result<T, PlaybackError>;
@@ -43,6 +47,7 @@ const SUBTITLE_FRAME_QUEUE_LIMIT: usize = 32;
 const EXTERNAL_SUBTITLE_LOOKAHEAD: Duration = Duration::from_secs(5);
 const DEFAULT_AUDIO_LEAD_TIME: Duration = Duration::from_millis(120);
 const STREAMING_AUDIO_LEAD_TIME: Duration = Duration::from_millis(1500);
+const DEMUX_PACKET_QUEUE_LIMIT: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PlaybackQueueLimits {
@@ -72,6 +77,266 @@ impl Default for PlaybackQueueLimits {
             audio_frames: DEFAULT_AUDIO_FRAME_QUEUE_LIMIT,
             subtitle_frames: SUBTITLE_FRAME_QUEUE_LIMIT,
         }
+    }
+}
+
+enum DemuxMessage {
+    Packet {
+        generation: u64,
+        packet: ffmpeg::Packet,
+    },
+    Eof {
+        generation: u64,
+    },
+    Error {
+        generation: u64,
+        message: String,
+    },
+}
+
+enum DemuxCommand {
+    Start {
+        generation: u64,
+    },
+    SetSelection {
+        generation: u64,
+        selection: StreamSelection,
+    },
+    Seek {
+        generation: u64,
+        position: Duration,
+    },
+    Stop,
+}
+
+enum PumpInput {
+    Packet(ffmpeg::Packet),
+    Eof,
+    Empty,
+}
+
+struct AsyncDemuxer {
+    packets: Receiver<DemuxMessage>,
+    commands: Sender<DemuxCommand>,
+    generation: u64,
+    active: bool,
+}
+
+impl AsyncDemuxer {
+    fn spawn(demuxer: Demuxer) -> Self {
+        let (packet_sender, packets) = bounded(DEMUX_PACKET_QUEUE_LIMIT);
+        let (commands, command_receiver) = unbounded();
+        thread::Builder::new()
+            .name("erika-demux".to_string())
+            .spawn(move || run_demux_worker(demuxer, packet_sender, command_receiver))
+            .expect("spawn erika demux worker");
+        Self {
+            packets,
+            commands,
+            generation: 1,
+            active: false,
+        }
+    }
+
+    fn start(&mut self) -> Result<()> {
+        if self.active {
+            return Ok(());
+        }
+        self.commands
+            .send(DemuxCommand::Start {
+                generation: self.generation,
+            })
+            .map_err(|_| PlaybackError::DemuxWorker("demux command channel closed".to_string()))?;
+        self.active = true;
+        Ok(())
+    }
+
+    fn set_stream_selection(&mut self, selection: StreamSelection) -> Result<()> {
+        self.generation = self.generation.saturating_add(1).max(1);
+        self.active = false;
+        self.drain_stale_packets();
+        self.commands
+            .send(DemuxCommand::SetSelection {
+                generation: self.generation,
+                selection,
+            })
+            .map_err(|_| PlaybackError::DemuxWorker("demux command channel closed".to_string()))
+    }
+
+    fn seek(&mut self, position: Duration) -> Result<()> {
+        self.generation = self.generation.saturating_add(1).max(1);
+        self.active = false;
+        self.drain_stale_packets();
+        self.commands
+            .send(DemuxCommand::Seek {
+                generation: self.generation,
+                position,
+            })
+            .map_err(|_| PlaybackError::DemuxWorker("demux command channel closed".to_string()))
+    }
+
+    fn poll(&mut self) -> Result<PumpInput> {
+        self.start()?;
+        loop {
+            match self.packets.try_recv() {
+                Ok(DemuxMessage::Packet { generation, packet })
+                    if generation == self.generation =>
+                {
+                    return Ok(PumpInput::Packet(packet));
+                }
+                Ok(DemuxMessage::Eof { generation }) if generation == self.generation => {
+                    return Ok(PumpInput::Eof);
+                }
+                Ok(DemuxMessage::Error {
+                    generation,
+                    message,
+                }) if generation == self.generation => {
+                    return Err(PlaybackError::DemuxWorker(message));
+                }
+                Ok(_) => continue,
+                Err(TryRecvError::Empty) => return Ok(PumpInput::Empty),
+                Err(TryRecvError::Disconnected) => {
+                    return Err(PlaybackError::DemuxWorker(
+                        "demux packet channel closed".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn drain_stale_packets(&mut self) {
+        while self.packets.try_recv().is_ok() {}
+    }
+}
+
+impl Drop for AsyncDemuxer {
+    fn drop(&mut self) {
+        let _ = self.commands.send(DemuxCommand::Stop);
+    }
+}
+
+fn run_demux_worker(
+    mut demuxer: Demuxer,
+    packets: Sender<DemuxMessage>,
+    commands: Receiver<DemuxCommand>,
+) {
+    let mut generation = 1u64;
+    let mut eof = false;
+    let mut active = false;
+    let mut pending_seek = None;
+    loop {
+        while let Ok(command) = commands.try_recv() {
+            if !handle_demux_command(
+                &mut demuxer,
+                &packets,
+                command,
+                &mut generation,
+                &mut eof,
+                &mut active,
+                &mut pending_seek,
+            ) {
+                return;
+            }
+        }
+
+        if eof || !active {
+            match commands.recv() {
+                Ok(command) => {
+                    if !handle_demux_command(
+                        &mut demuxer,
+                        &packets,
+                        command,
+                        &mut generation,
+                        &mut eof,
+                        &mut active,
+                        &mut pending_seek,
+                    ) {
+                        return;
+                    }
+                }
+                Err(_) => return,
+            }
+            continue;
+        }
+
+        let message = match demuxer.read_packet() {
+            Ok(Some(packet)) => DemuxMessage::Packet { generation, packet },
+            Ok(None) => {
+                eof = true;
+                DemuxMessage::Eof { generation }
+            }
+            Err(error) => {
+                eof = true;
+                DemuxMessage::Error {
+                    generation,
+                    message: error.to_string(),
+                }
+            }
+        };
+        if packets.send(message).is_err() {
+            return;
+        }
+    }
+}
+
+fn handle_demux_command(
+    demuxer: &mut Demuxer,
+    packets: &Sender<DemuxMessage>,
+    command: DemuxCommand,
+    generation: &mut u64,
+    eof: &mut bool,
+    active: &mut bool,
+    pending_seek: &mut Option<(u64, Duration)>,
+) -> bool {
+    match command {
+        DemuxCommand::Start {
+            generation: next_generation,
+        } => {
+            *generation = next_generation;
+            if let Some((seek_generation, position)) = pending_seek.take() {
+                *generation = seek_generation;
+                *eof = false;
+                if let Err(error) = demuxer.seek(position) {
+                    let _ = packets.send(DemuxMessage::Error {
+                        generation: *generation,
+                        message: error.to_string(),
+                    });
+                    *eof = true;
+                    *active = false;
+                    return true;
+                }
+            }
+            *active = true;
+            true
+        }
+        DemuxCommand::SetSelection {
+            generation: next_generation,
+            selection,
+        } => {
+            *generation = next_generation;
+            *eof = false;
+            *active = false;
+            *pending_seek = None;
+            if let Err(error) = demuxer.set_stream_selection(selection) {
+                let _ = packets.send(DemuxMessage::Error {
+                    generation: *generation,
+                    message: error.to_string(),
+                });
+                *eof = true;
+            }
+            true
+        }
+        DemuxCommand::Seek {
+            generation: next_generation,
+            position,
+        } => {
+            *generation = next_generation;
+            *eof = false;
+            *active = false;
+            *pending_seek = Some((*generation, position));
+            true
+        }
+        DemuxCommand::Stop => false,
     }
 }
 
@@ -146,7 +411,8 @@ impl OpenedMediaInfo {
 }
 
 pub struct PlaybackSession {
-    demuxer: Demuxer,
+    demuxer: AsyncDemuxer,
+    codec_parameters: Vec<OwnedCodecParameters>,
     video_decoder: Option<Decoder>,
     audio_decoder: Option<Decoder>,
     subtitle_decoder: Option<SubtitleDecoder>,
@@ -168,6 +434,12 @@ impl PlaybackSession {
         let queue_limits = PlaybackQueueLimits::for_request(request);
         let source = source_from_uri_with_hint(&request.uri, request.source_hint)?;
         let mut demuxer = Demuxer::open_source(source)?;
+        let mut probe = demuxer.probe().clone();
+        let codec_parameters = probe
+            .tracks
+            .iter()
+            .map(|track| demuxer.owned_codec_parameters(track.id as i32))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
         let selected_video_track = demuxer
             .probe()
             .tracks
@@ -191,8 +463,8 @@ impl PlaybackSession {
         let mut selected_streams = Vec::new();
         if let Some(stream_index) = selected_video_track {
             selected_streams.push(stream_index);
-            let parameters = demuxer.codec_parameters(stream_index)?;
-            video_decoder = Some(Decoder::open_with_config(
+            let parameters = codec_parameters_for(&codec_parameters, stream_index)?;
+            video_decoder = Some(Decoder::open_owned_with_config(
                 parameters,
                 config.video_decode.decoder_config(),
             )?);
@@ -200,13 +472,15 @@ impl PlaybackSession {
         let mut audio_decoder = None;
         if let Some(stream_index) = selected_audio_track {
             selected_streams.push(stream_index);
-            let parameters = demuxer.codec_parameters(stream_index)?;
-            audio_decoder = Some(Decoder::open(parameters)?);
+            let parameters = codec_parameters_for(&codec_parameters, stream_index)?;
+            audio_decoder = Some(Decoder::open_owned(parameters)?);
         }
         let mut subtitle_decoder = None;
         let mut opened_subtitle_track = None;
         if let Some(stream_index) = selected_subtitle_track {
-            match demuxer.open_subtitle_decoder(stream_index) {
+            match codec_parameters_for(&codec_parameters, stream_index)
+                .and_then(|parameters| SubtitleDecoder::open_owned(parameters).map_err(Into::into))
+            {
                 Ok(decoder) => {
                     selected_streams.push(stream_index);
                     opened_subtitle_track = Some(stream_index);
@@ -221,7 +495,6 @@ impl PlaybackSession {
             demuxer.set_stream_selection(StreamSelection::only(selected_streams))?;
         }
 
-        let mut probe = demuxer.probe().clone();
         let video_params = selected_video_track.and_then(|stream_index| {
             probe
                 .video
@@ -249,7 +522,8 @@ impl PlaybackSession {
         };
 
         Ok(Self {
-            demuxer,
+            demuxer: AsyncDemuxer::spawn(demuxer),
+            codec_parameters,
             video_decoder,
             audio_decoder,
             subtitle_decoder,
@@ -273,12 +547,18 @@ impl PlaybackSession {
         self.info.track_selection()
     }
 
+    pub fn is_eof(&self) -> bool {
+        self.eof
+    }
+
     pub fn next_video_frame(&mut self) -> Result<Option<Frame>> {
         if self.video_decoder.is_none() {
             return Ok(None);
         }
         while self.video_frames.is_empty() && !self.eof {
-            self.pump_once()?;
+            if !self.pump_once()? {
+                break;
+            }
         }
         Ok(self.video_frames.pop_front())
     }
@@ -288,9 +568,48 @@ impl PlaybackSession {
             return Ok(None);
         }
         while self.audio_frames.is_empty() && !self.eof {
-            self.pump_once()?;
+            if !self.pump_once()? {
+                break;
+            }
         }
         Ok(self.audio_frames.pop_front())
+    }
+
+    pub fn next_audio_frame_bounded(
+        &mut self,
+        max_packets: usize,
+        max_duration: Duration,
+    ) -> Result<Option<PcmAudioFrame>> {
+        if self.audio_decoder.is_none() {
+            return Ok(None);
+        }
+
+        let started = Instant::now();
+        let mut pumped_packets = 0usize;
+        while self.audio_frames.is_empty() && !self.eof && pumped_packets < max_packets {
+            if started.elapsed() >= max_duration {
+                break;
+            }
+            if self.pump_once()? {
+                pumped_packets = pumped_packets.saturating_add(1);
+            } else {
+                break;
+            }
+        }
+
+        let frame = self.audio_frames.pop_front();
+        if trace::enabled() && (pumped_packets > 0 || started.elapsed() >= max_duration) {
+            trace::log(format!(
+                "[erika-playback-trace] stage=session_audio_pump packets={} max_packets={} produced={} queued_audio={} eof={} elapsed_ms={:.3}",
+                pumped_packets,
+                max_packets,
+                frame.is_some(),
+                self.audio_frames.len(),
+                self.eof,
+                started.elapsed().as_secs_f64() * 1000.0,
+            ));
+        }
+        Ok(frame)
     }
 
     pub fn next_subtitle_frame(
@@ -374,8 +693,8 @@ impl PlaybackSession {
         match track_id {
             Some(id) => {
                 let stream_index = self.embedded_track_stream_index(id, TrackKind::Audio)?;
-                let parameters = self.demuxer.codec_parameters(stream_index)?;
-                let decoder = Decoder::open(parameters)?;
+                let parameters = self.codec_parameters(stream_index)?;
+                let decoder = Decoder::open_owned(parameters)?;
                 self.audio_decoder = Some(decoder);
                 self.info.selected_audio_track = Some(id);
                 self.info.audio_output = Some(self.audio_output);
@@ -408,7 +727,8 @@ impl PlaybackSession {
             Some(id) => match self.subtitle_track_source(id)? {
                 SubtitleTrackSource::Embedded { stream_index } => {
                     let stream_index = stream_index_i32(stream_index, TrackKind::Subtitle, id)?;
-                    let decoder = self.demuxer.open_subtitle_decoder(stream_index)?;
+                    let decoder =
+                        SubtitleDecoder::open_owned(self.codec_parameters(stream_index)?)?;
                     self.subtitle_decoder = Some(decoder);
                     self.info.selected_subtitle_track = Some(id);
                 }
@@ -497,6 +817,10 @@ impl PlaybackSession {
         stream_index_i32(track.id, kind, track_id)
     }
 
+    fn codec_parameters(&self, stream_index: i32) -> Result<&OwnedCodecParameters> {
+        codec_parameters_for(&self.codec_parameters, stream_index)
+    }
+
     fn subtitle_track_source(&self, track_id: i64) -> Result<SubtitleTrackSource> {
         self.info
             .subtitle_tracks
@@ -546,10 +870,17 @@ impl PlaybackSession {
         );
     }
 
-    fn pump_once(&mut self) -> Result<()> {
-        match self.demuxer.read_packet()? {
-            Some(packet) => self.route_packet(packet),
-            None => self.finish_decoders(),
+    fn pump_once(&mut self) -> Result<bool> {
+        match self.demuxer.poll()? {
+            PumpInput::Packet(packet) => {
+                self.route_packet(packet)?;
+                Ok(true)
+            }
+            PumpInput::Eof => {
+                self.finish_decoders()?;
+                Ok(true)
+            }
+            PumpInput::Empty => Ok(false),
         }
     }
 
@@ -787,6 +1118,19 @@ fn external_subtitle_title(uri: &str) -> Option<String> {
         .unwrap_or(uri)
         .trim();
     (!leaf.is_empty()).then_some(leaf.to_string())
+}
+
+fn codec_parameters_for(
+    parameters: &[OwnedCodecParameters],
+    stream_index: i32,
+) -> Result<&OwnedCodecParameters> {
+    parameters
+        .iter()
+        .find(|parameters| parameters.stream_index() == stream_index)
+        .ok_or(PlaybackError::TrackNotFound {
+            kind: TrackKind::Video,
+            track_id: i64::from(stream_index),
+        })
 }
 
 fn mark_selected_tracks(
@@ -1545,6 +1889,36 @@ impl VideoPlaybackEngine {
         }))
     }
 
+    pub fn tick_audio_bounded(
+        &mut self,
+        max_packets: usize,
+        max_decode_duration: Duration,
+    ) -> Result<Option<TimedAudioFrame>> {
+        if self.state != PlaybackRunState::Playing {
+            return Ok(None);
+        }
+        self.ensure_pending_audio_bounded(max_packets, max_decode_duration)?;
+        let Some(frame) = self.pending_audio.as_ref() else {
+            return Ok(None);
+        };
+
+        let pts = frame.pts;
+        let now = Instant::now();
+        let media_time = self.clock.media_time_at(now);
+        if pts.is_some_and(|pts| pts > media_time + self.timing.audio_lead_time) {
+            return Ok(None);
+        }
+
+        let frame = self.pending_audio.take().expect("pending audio exists");
+        let late_by = pts.and_then(|pts| media_time.checked_sub(pts));
+        Ok(Some(TimedAudioFrame {
+            frame,
+            pts,
+            media_time,
+            late_by,
+        }))
+    }
+
     pub fn tick_subtitle(&mut self) -> Result<Option<TimedSubtitleFrame>> {
         if self.state != PlaybackRunState::Playing {
             return Ok(None);
@@ -1657,7 +2031,7 @@ impl VideoPlaybackEngine {
             return Ok(());
         }
         self.pending_frame = self.session.next_video_frame()?;
-        if self.pending_frame.is_none() {
+        if self.pending_frame.is_none() && self.session.is_eof() {
             self.eof = true;
             self.state = PlaybackRunState::Ended;
             let now = Instant::now();
@@ -1674,6 +2048,20 @@ impl VideoPlaybackEngine {
             return Ok(());
         }
         self.pending_audio = self.session.next_audio_frame()?;
+        Ok(())
+    }
+
+    fn ensure_pending_audio_bounded(
+        &mut self,
+        max_packets: usize,
+        max_decode_duration: Duration,
+    ) -> Result<()> {
+        if self.pending_audio.is_some() || self.eof {
+            return Ok(());
+        }
+        self.pending_audio = self
+            .session
+            .next_audio_frame_bounded(max_packets, max_decode_duration)?;
         Ok(())
     }
 

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -3,10 +3,12 @@ use std::{
     fs::OpenOptions,
     io::Write,
     path::PathBuf,
+    sync::{Arc, Condvar, Mutex},
+    thread,
     time::{Duration, Instant},
 };
 
-use crossbeam_channel::Receiver;
+use crossbeam_channel::{Receiver, Sender};
 
 #[cfg(target_os = "macos")]
 use crate::apple::coreaudio::{CoreAudioOutput, CoreAudioOutputConfig};
@@ -23,7 +25,7 @@ use crate::core::{
 use crate::danmaku::{
     DANMAKU_DEBUG_BUCKETS, DanmakuDebugBucket, DanmakuLayoutConfig, DanmakuPreparedStats,
     DanmakuRenderPlan, DanmakuSession, DanmakuTimeline, DanmakuTrackInfo, DanmakuTrackSource,
-    DanmakuViewport, DfmLayoutEngine,
+    DanmakuViewport, DfmLayoutEngine, DfmPreparedLayout,
 };
 use crate::overlay::{OverlayFrame, OverlayTimeline, OverlayViewport};
 use crate::renderer::metal::{MetalRenderer, MetalRendererConfig};
@@ -41,6 +43,14 @@ use crate::trace;
 use crate::{PlayerError, Result};
 
 const AUDIO_START_BUFFER: Duration = Duration::from_millis(250);
+const AUDIO_PUMP_FRAME_LIMIT: usize = 16;
+const AUDIO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+const VIDEO_PUMP_FRAME_LIMIT: usize = 8;
+const VIDEO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+const DANMAKU_PLAN_REQUEST_QUANTUM: Duration = Duration::from_millis(250);
+const DANMAKU_PREPARE_REFRESH_MARGIN: Duration = Duration::from_secs(4);
+const DANMAKU_PLAN_LOOKAHEAD: Duration = Duration::from_secs(8);
+const DANMAKU_PLAN_LOOKBACK_PADDING: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone)]
 pub struct PresenterConfig {
@@ -168,6 +178,7 @@ pub struct PresenterRuntime {
     last_audio_clock_sync: Option<AudioClockSyncState>,
     current_overlay: Option<OverlayFrame>,
     current_danmaku: Option<DanmakuRenderPlan>,
+    current_danmaku_prepared: Option<CurrentDanmakuPrepared>,
     current_media_time: Duration,
     current_generation: u64,
     current_output_viewport: Option<DanmakuViewport>,
@@ -177,6 +188,7 @@ pub struct PresenterRuntime {
     render_test_pattern_when_idle: bool,
     danmaku_session: DanmakuSession,
     danmaku: DfmLayoutEngine,
+    danmaku_planner: AsyncDanmakuPlanner,
     danmaku_generation: u64,
     danmaku_trace: DanmakuTimeTrace,
     stats: PresenterStats,
@@ -196,6 +208,146 @@ pub struct PresenterRuntime {
 struct AudioClockSyncState {
     media_time: Duration,
     read_frames: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct DanmakuPlanKey {
+    media_time: Duration,
+    viewport: DanmakuViewport,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AsyncDanmakuPlanRequest {
+    key: DanmakuPlanKey,
+}
+
+#[derive(Debug)]
+struct AsyncDanmakuPlanResult {
+    request: AsyncDanmakuPlanRequest,
+    prepared: DfmPreparedLayout,
+    window_start: Duration,
+    window_end: Duration,
+    elapsed: Duration,
+}
+
+#[derive(Debug)]
+struct AsyncDanmakuPlannerState {
+    revision: u64,
+    config_revision: u64,
+    timeline: DanmakuTimeline,
+    config: DanmakuLayoutConfig,
+    latest_request: Option<AsyncDanmakuPlanRequest>,
+    shutdown: bool,
+}
+
+struct AsyncDanmakuPlanner {
+    shared: Arc<(Mutex<AsyncDanmakuPlannerState>, Condvar)>,
+    results: Receiver<AsyncDanmakuPlanResult>,
+    last_requested: Option<DanmakuPlanKey>,
+}
+
+#[derive(Debug, Clone)]
+struct CurrentDanmakuPrepared {
+    request: AsyncDanmakuPlanRequest,
+    prepared: DfmPreparedLayout,
+    window_start: Duration,
+    window_end: Duration,
+}
+
+impl AsyncDanmakuPlanner {
+    fn new(
+        engine: DfmLayoutEngine,
+        timeline: DanmakuTimeline,
+        config: DanmakuLayoutConfig,
+    ) -> Self {
+        let state = AsyncDanmakuPlannerState {
+            revision: 0,
+            config_revision: 1,
+            timeline,
+            config,
+            latest_request: None,
+            shutdown: false,
+        };
+        let shared = Arc::new((Mutex::new(state), Condvar::new()));
+        let (result_tx, results) = crossbeam_channel::unbounded();
+        let worker_shared = Arc::clone(&shared);
+        thread::Builder::new()
+            .name("erika-danmaku".to_string())
+            .spawn(move || run_async_danmaku_planner(worker_shared, result_tx, engine))
+            .expect("spawn erika danmaku planner");
+        Self {
+            shared,
+            results,
+            last_requested: None,
+        }
+    }
+
+    fn set_timeline(&mut self, timeline: DanmakuTimeline) {
+        self.update_configuration(Some(timeline), None);
+    }
+
+    fn clear_timeline(&mut self) {
+        self.update_configuration(Some(DanmakuTimeline::default()), None);
+    }
+
+    fn set_config(&mut self, config: DanmakuLayoutConfig) {
+        self.update_configuration(None, Some(config));
+    }
+
+    fn invalidate_requests(&mut self) {
+        self.last_requested = None;
+        let (lock, _) = &*self.shared;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.latest_request = None;
+    }
+
+    fn request_plan(&mut self, key: DanmakuPlanKey) {
+        if self.last_requested == Some(key) {
+            return;
+        }
+        self.last_requested = Some(key);
+        let request = AsyncDanmakuPlanRequest { key };
+        let (lock, cvar) = &*self.shared;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.latest_request = Some(request);
+        state.revision = state.revision.saturating_add(1);
+        cvar.notify_one();
+    }
+
+    fn try_recv(&self) -> Option<AsyncDanmakuPlanResult> {
+        self.results.try_recv().ok()
+    }
+
+    fn update_configuration(
+        &mut self,
+        timeline: Option<DanmakuTimeline>,
+        config: Option<DanmakuLayoutConfig>,
+    ) {
+        self.last_requested = None;
+        let (lock, cvar) = &*self.shared;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(timeline) = timeline {
+            state.timeline = timeline;
+        }
+        if let Some(config) = config {
+            state.config = config;
+        }
+        state.latest_request = None;
+        state.config_revision = state.config_revision.saturating_add(1);
+        state.revision = state.revision.saturating_add(1);
+        cvar.notify_one();
+    }
+}
+
+impl Drop for AsyncDanmakuPlanner {
+    fn drop(&mut self) {
+        let (lock, cvar) = &*self.shared;
+        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.shutdown = true;
+        state.revision = state.revision.saturating_add(1);
+        cvar.notify_one();
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -266,6 +418,10 @@ impl PresenterRuntime {
             .map(DanmakuSession::from_timeline)
             .unwrap_or_default();
         let danmaku_timeline = danmaku_session.active_timeline_clone();
+        let danmaku_config = config.danmaku_config;
+        let danmaku = DfmLayoutEngine::new(danmaku_timeline.clone(), danmaku_config.clone());
+        let danmaku_planner =
+            AsyncDanmakuPlanner::new(danmaku.clone(), danmaku_timeline, danmaku_config);
         Ok(Self {
             player,
             renderer,
@@ -278,6 +434,7 @@ impl PresenterRuntime {
             last_audio_clock_sync: None,
             current_overlay: None,
             current_danmaku: None,
+            current_danmaku_prepared: None,
             current_media_time: Duration::ZERO,
             current_generation: 1,
             current_output_viewport: None,
@@ -286,7 +443,8 @@ impl PresenterRuntime {
             overlay: config.overlay,
             render_test_pattern_when_idle: config.render_test_pattern_when_idle,
             danmaku_session,
-            danmaku: DfmLayoutEngine::new(danmaku_timeline, config.danmaku_config),
+            danmaku,
+            danmaku_planner,
             danmaku_generation: 1,
             danmaku_trace: DanmakuTimeTrace::from_env(),
             stats: PresenterStats::default(),
@@ -309,24 +467,21 @@ impl PresenterRuntime {
 
     pub fn attach_surface(&mut self, surface: PlatformSurface) -> Result<()> {
         self.current_output_viewport = surface_danmaku_viewport(surface);
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.player.attach_surface(surface)?;
         self.renderer.attach_surface(surface)
     }
 
     pub fn detach_surface(&mut self) -> Result<()> {
         self.current_output_viewport = None;
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.player.detach_surface()?;
         self.renderer.detach_surface()
     }
 
     pub fn resize_surface(&mut self, width: u32, height: u32, scale: f64) -> Result<()> {
         self.current_output_viewport = Some(surface_dimensions_to_viewport(width, height, scale));
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.last_audio_clock_sync = None;
         self.renderer.resize_surface(width, height, scale)
     }
@@ -335,8 +490,7 @@ impl PresenterRuntime {
         self.reset_audio_output();
         self.drain_pending_player_frames();
         self.current_overlay = None;
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.current_media_time = Duration::ZERO;
         self.current_generation = self.current_generation.saturating_add(1).max(1);
         self.last_audio_clock_sync = None;
@@ -375,8 +529,7 @@ impl PresenterRuntime {
         self.reset_audio_output();
         self.drain_pending_player_frames();
         self.current_overlay = None;
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
         result
@@ -387,8 +540,7 @@ impl PresenterRuntime {
         self.reset_audio_output();
         self.drain_pending_player_frames();
         self.current_overlay = None;
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
         result
@@ -399,8 +551,7 @@ impl PresenterRuntime {
         self.reset_audio_output();
         self.drain_pending_player_frames();
         self.current_overlay = None;
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.clear_current_danmaku_state();
         self.current_media_time = position;
         self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
@@ -486,8 +637,8 @@ impl PresenterRuntime {
     pub fn clear_danmaku(&mut self) {
         self.danmaku_session.clear();
         self.danmaku.clear_timeline();
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.danmaku_planner.clear_timeline();
+        self.clear_current_danmaku_state();
         self.bump_danmaku_generation();
     }
 
@@ -505,11 +656,11 @@ impl PresenterRuntime {
     }
 
     pub fn set_danmaku_config(&mut self, config: DanmakuLayoutConfig) {
-        if !self.danmaku.set_config(config) {
+        if !self.danmaku.set_config(config.clone()) {
             return;
         }
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.danmaku_planner.set_config(config);
+        self.clear_current_danmaku_state();
         self.bump_danmaku_generation();
     }
 
@@ -554,10 +705,6 @@ impl PresenterRuntime {
         let tick_started = Instant::now();
         let pump_started = Instant::now();
 
-        let audio_started = Instant::now();
-        self.pump_audio();
-        self.last_audio_pump_duration = audio_started.elapsed();
-
         let subtitle_started = Instant::now();
         self.pump_subtitles();
         self.last_subtitle_pump_duration = subtitle_started.elapsed();
@@ -565,6 +712,10 @@ impl PresenterRuntime {
         let video_started = Instant::now();
         self.pump_video();
         self.last_video_pump_duration = video_started.elapsed();
+
+        let audio_started = Instant::now();
+        self.pump_audio();
+        self.last_audio_pump_duration = audio_started.elapsed();
 
         let sync_started = Instant::now();
         self.sync_media_time_from_player();
@@ -623,6 +774,53 @@ impl PresenterRuntime {
         }
 
         self.last_tick_duration = tick_started.elapsed();
+        if trace::enabled() {
+            let renderer = self.renderer.runtime_stats();
+            trace::log(format!(
+                "[erika-presenter-trace] stage=render_tick media={} player={} gen={} playing={} tick_ms={:.3} pump_ms={:.3} audio_ms={:.3} subtitle_ms={:.3} video_ms={:.3} clock_ms={:.3} plan_ms={:.3} render_ms={:.3} render_current_ms={:.3} render_test_ms={:.3} stats_video={} stats_audio={} stats_subtitle={} stats_overlay={} renderer_rendered={} renderer_offscreen={} renderer_gpu_ms={:.3} audio_queued={} audio_queued_ms={} audio_underflow={} output={}x{} danmaku_items={}",
+                duration_label(Some(self.current_media_time)),
+                duration_label(Some(self.player.current_media_time())),
+                self.current_generation,
+                self.is_playing(),
+                self.last_tick_duration.as_secs_f64() * 1000.0,
+                self.last_pump_duration.as_secs_f64() * 1000.0,
+                self.last_audio_pump_duration.as_secs_f64() * 1000.0,
+                self.last_subtitle_pump_duration.as_secs_f64() * 1000.0,
+                self.last_video_pump_duration.as_secs_f64() * 1000.0,
+                self.last_clock_sync_duration.as_secs_f64() * 1000.0,
+                self.last_danmaku_plan_duration.as_secs_f64() * 1000.0,
+                self.last_render_duration.as_secs_f64() * 1000.0,
+                self.last_render_current_duration.as_secs_f64() * 1000.0,
+                self.last_render_test_duration.as_secs_f64() * 1000.0,
+                self.stats.decoded_video_frames,
+                self.stats.pushed_audio_frames,
+                self.stats.decoded_subtitle_frames,
+                self.stats.overlay_frames,
+                renderer.rendered_frames,
+                renderer.offscreen_frames,
+                renderer.last_gpu_duration.as_secs_f64() * 1000.0,
+                self.audio_output
+                    .clock_snapshot()
+                    .map(|snapshot| snapshot.queued_frames)
+                    .unwrap_or(0),
+                self.audio_output
+                    .clock_snapshot()
+                    .and_then(|snapshot| snapshot.queued_duration)
+                    .map(|duration| duration.as_secs_f64() * 1000.0)
+                    .unwrap_or(0.0),
+                self.audio_output
+                    .clock_snapshot()
+                    .map(|snapshot| snapshot.underflow_frames)
+                    .unwrap_or(0),
+                self.current_output_viewport
+                    .map_or(0, |viewport| viewport.width),
+                self.current_output_viewport
+                    .map_or(0, |viewport| viewport.height),
+                self.current_danmaku
+                    .as_ref()
+                    .map_or(0, |plan| plan.items.len()),
+            ));
+        }
         Ok(self.stats)
     }
 
@@ -695,7 +893,12 @@ impl PresenterRuntime {
     }
 
     fn pump_video(&mut self) {
+        let started = Instant::now();
+        let mut pumped = 0usize;
         loop {
+            if pumped >= VIDEO_PUMP_FRAME_LIMIT || started.elapsed() >= VIDEO_PUMP_TIME_BUDGET {
+                break;
+            }
             match self.video_frames.try_recv() {
                 Ok(frame) => {
                     if frame.generation < self.player.playback_generation() {
@@ -732,6 +935,7 @@ impl PresenterRuntime {
                                 plan_generation,
                                 plan_items,
                             );
+                            pumped += 1;
                         }
                         Err(error) => {
                             self.stats.import_failures += 1;
@@ -761,8 +965,7 @@ impl PresenterRuntime {
         let generation = generation.max(self.danmaku_generation).max(1);
         let danmaku_viewport = self.current_output_viewport.unwrap_or(viewport);
         self.current_danmaku_viewport = Some(danmaku_viewport);
-        self.current_danmaku = Some(self.danmaku.render_plan(pts, danmaku_viewport, generation));
-        self.record_current_danmaku_stats();
+        self.request_current_danmaku_plan(pts, danmaku_viewport, generation);
     }
 
     fn record_current_danmaku_stats(&mut self) {
@@ -775,39 +978,110 @@ impl PresenterRuntime {
     }
 
     fn refresh_stale_danmaku_plan(&mut self) {
-        let stale = self.current_danmaku.as_ref().is_none_or(|plan| {
-            plan.generation != self.current_generation || plan.media_time != self.current_media_time
-        });
-        if stale {
-            self.refresh_current_danmaku_plan();
+        self.apply_ready_danmaku_plans();
+        self.refresh_current_danmaku_plan_from_prepared();
+        self.request_current_danmaku_plan_for_current_time();
+    }
+
+    fn apply_ready_danmaku_plans(&mut self) {
+        while let Some(result) = self.danmaku_planner.try_recv() {
+            let accepted = self.danmaku_plan_result_is_current(&result);
+            let prepared_items = result.prepared.items().len();
+            if accepted {
+                self.current_danmaku_prepared = Some(CurrentDanmakuPrepared {
+                    request: result.request,
+                    prepared: result.prepared,
+                    window_start: result.window_start,
+                    window_end: result.window_end,
+                });
+                self.last_danmaku_plan_duration = result.elapsed;
+            }
+            if self.danmaku_trace.enabled {
+                self.trace_danmaku_time(
+                    if accepted {
+                        "prepared_async_ready"
+                    } else {
+                        "prepared_async_stale"
+                    },
+                    self.current_media_time,
+                    self.current_generation,
+                    None,
+                    None,
+                    Some(result.request.key.media_time),
+                    Some(result.request.key.generation),
+                    prepared_items,
+                );
+            }
         }
     }
 
-    fn refresh_current_danmaku_plan(&mut self) {
-        refresh_danmaku_plan(
-            &mut self.current_danmaku,
-            self.current_danmaku_viewport,
-            &mut self.danmaku,
+    fn refresh_current_danmaku_plan_from_prepared(&mut self) {
+        let Some(prepared) = &self.current_danmaku_prepared else {
+            self.current_danmaku = None;
+            return;
+        };
+        if !self.danmaku_prepared_covers_current_time(prepared) {
+            self.current_danmaku = None;
+            return;
+        }
+        let plan = self.danmaku.render_prepared_plan(
+            &prepared.prepared,
             self.current_media_time,
             self.current_generation,
         );
+        self.current_danmaku = Some(plan);
         self.record_current_danmaku_stats();
-        let plan_time = self.current_danmaku.as_ref().map(|plan| plan.media_time);
-        let plan_generation = self.current_danmaku.as_ref().map(|plan| plan.generation);
-        let plan_items = self
-            .current_danmaku
-            .as_ref()
-            .map_or(0, |plan| plan.items.len());
-        self.trace_danmaku_time(
-            "plan_refresh",
+    }
+
+    fn request_current_danmaku_plan_for_current_time(&mut self) {
+        let Some(viewport) = self.current_danmaku_viewport else {
+            return;
+        };
+        self.request_current_danmaku_plan(
             self.current_media_time,
+            viewport,
             self.current_generation,
-            None,
-            None,
-            plan_time,
-            plan_generation,
-            plan_items,
         );
+    }
+
+    fn request_current_danmaku_plan(
+        &mut self,
+        media_time: Duration,
+        viewport: DanmakuViewport,
+        generation: u64,
+    ) {
+        if self
+            .current_danmaku_prepared
+            .as_ref()
+            .is_some_and(|prepared| {
+                self.danmaku_prepared_covers_current_time(prepared)
+                    && prepared.window_end.saturating_sub(media_time)
+                        > DANMAKU_PREPARE_REFRESH_MARGIN
+            })
+        {
+            return;
+        }
+        let key = DanmakuPlanKey {
+            media_time: quantize_duration(media_time, DANMAKU_PLAN_REQUEST_QUANTUM),
+            viewport,
+            generation: generation.max(self.danmaku_generation).max(1),
+        };
+        self.danmaku_planner.request_plan(key);
+    }
+
+    fn danmaku_plan_result_is_current(&self, result: &AsyncDanmakuPlanResult) -> bool {
+        let key = result.request.key;
+        key.generation == self.current_generation
+            && Some(key.viewport) == self.current_danmaku_viewport
+            && result.window_start <= self.current_media_time
+            && self.current_media_time <= result.window_end
+    }
+
+    fn danmaku_prepared_covers_current_time(&self, prepared: &CurrentDanmakuPrepared) -> bool {
+        prepared.request.key.generation == self.current_generation
+            && Some(prepared.request.key.viewport) == self.current_danmaku_viewport
+            && prepared.window_start <= self.current_media_time
+            && self.current_media_time <= prepared.window_end
     }
 
     fn sync_media_time_from_player(&mut self) {
@@ -941,13 +1215,21 @@ impl PresenterRuntime {
 
     fn bump_danmaku_generation(&mut self) {
         bump_generation(&mut self.current_generation, &mut self.danmaku_generation);
+        self.danmaku_planner.invalidate_requests();
+        self.clear_current_danmaku_state();
+    }
+
+    fn clear_current_danmaku_state(&mut self) {
+        self.current_danmaku = None;
+        self.current_danmaku_prepared = None;
+        self.current_danmaku_viewport = None;
     }
 
     fn sync_danmaku_engine_timeline(&mut self) {
         let timeline = self.danmaku_session.active_timeline_clone();
         self.danmaku.sync_timeline(&timeline);
-        self.current_danmaku = None;
-        self.current_danmaku_viewport = None;
+        self.danmaku_planner.set_timeline(timeline);
+        self.clear_current_danmaku_state();
     }
 
     fn pump_subtitles(&mut self) {
@@ -967,18 +1249,25 @@ impl PresenterRuntime {
     }
 
     fn pump_audio(&mut self) {
+        let started = Instant::now();
+        let mut pumped = 0usize;
         loop {
+            if pumped >= AUDIO_PUMP_FRAME_LIMIT || started.elapsed() >= AUDIO_PUMP_TIME_BUDGET {
+                break;
+            }
             match self.audio_frames.try_recv() {
                 Ok(frame) => {
                     if frame.generation < self.player.playback_generation() {
                         continue;
                     }
                     self.push_audio(frame);
+                    pumped += 1;
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
                 Err(crossbeam_channel::TryRecvError::Disconnected) => break,
             }
         }
+        self.ensure_audio_started();
         if self.audio_started {
             self.sync_player_to_audio_output();
         }
@@ -1042,15 +1331,21 @@ impl PresenterRuntime {
             }
         }
 
-        if !self.audio_started && self.audio_output_ready_to_start() {
-            if let Err(error) = self.audio_output.start() {
-                self.stats.audio_failures += 1;
-                eprintln!("Erika presenter audio start failed: {error}");
-                return;
-            }
-            self.audio_started = true;
-            self.last_audio_clock_sync = None;
+        self.ensure_audio_started();
+    }
+
+    fn ensure_audio_started(&mut self) {
+        if self.audio_started || !self.audio_output_ready_to_start() || !self.audio_start_allowed()
+        {
+            return;
         }
+        if let Err(error) = self.audio_output.start() {
+            self.stats.audio_failures += 1;
+            eprintln!("Erika presenter audio start failed: {error}");
+            return;
+        }
+        self.audio_started = true;
+        self.last_audio_clock_sync = None;
     }
 
     fn audio_output_ready_to_start(&self) -> bool {
@@ -1058,6 +1353,10 @@ impl PresenterRuntime {
             .clock_snapshot()
             .and_then(|snapshot| snapshot.queued_duration)
             .is_some_and(|queued| queued >= AUDIO_START_BUFFER)
+    }
+
+    fn audio_start_allowed(&self) -> bool {
+        self.player.track_selection().video.is_none() || self.stats.rendered_video_frames > 0
     }
 
     fn reset_audio_output(&mut self) {
@@ -1077,6 +1376,7 @@ impl PresenterRuntime {
     }
 }
 
+#[cfg(test)]
 fn refresh_danmaku_plan(
     current_plan: &mut Option<DanmakuRenderPlan>,
     viewport: Option<DanmakuViewport>,
@@ -1088,6 +1388,91 @@ fn refresh_danmaku_plan(
         return;
     };
     *current_plan = Some(engine.render_plan(media_time, viewport, generation));
+}
+
+fn run_async_danmaku_planner(
+    shared: Arc<(Mutex<AsyncDanmakuPlannerState>, Condvar)>,
+    results: Sender<AsyncDanmakuPlanResult>,
+    mut engine: DfmLayoutEngine,
+) {
+    let (mut timeline, mut config, mut applied_config_revision) = {
+        let (lock, _) = &*shared;
+        let state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        (
+            state.timeline.clone(),
+            state.config.clone(),
+            state.config_revision,
+        )
+    };
+    let mut seen_revision = 0u64;
+
+    loop {
+        let (request, config_update) = {
+            let (lock, cvar) = &*shared;
+            let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            while !state.shutdown && state.revision == seen_revision {
+                state = cvar
+                    .wait(state)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+            if state.shutdown {
+                return;
+            }
+            seen_revision = state.revision;
+            let config_update = (state.config_revision != applied_config_revision).then(|| {
+                (
+                    state.config_revision,
+                    state.timeline.clone(),
+                    state.config.clone(),
+                )
+            });
+            (state.latest_request, config_update)
+        };
+
+        if let Some((revision, next_timeline, next_config)) = config_update {
+            timeline = next_timeline;
+            config = next_config;
+            engine.set_config(config.clone());
+            applied_config_revision = revision;
+        }
+
+        if let Some(request) = request {
+            let started = Instant::now();
+            let (window, window_start, window_end) =
+                danmaku_plan_window(&timeline, request.key.media_time, &config);
+            engine.sync_timeline(&window);
+            let prepared = engine.prepare(request.key.viewport, request.key.generation);
+            let elapsed = started.elapsed();
+            if results
+                .send(AsyncDanmakuPlanResult {
+                    request,
+                    prepared,
+                    window_start,
+                    window_end,
+                    elapsed,
+                })
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+}
+
+fn danmaku_plan_window(
+    timeline: &DanmakuTimeline,
+    media_time: Duration,
+    config: &DanmakuLayoutConfig,
+) -> (DanmakuTimeline, Duration, Duration) {
+    let scroll_duration = if config.scroll_duration_seconds.is_finite() {
+        config.scroll_duration_seconds.clamp(1.0, 60.0)
+    } else {
+        10.0
+    };
+    let lookback = Duration::from_secs_f32(scroll_duration) + DANMAKU_PLAN_LOOKBACK_PADDING;
+    let start = media_time.checked_sub(lookback).unwrap_or(Duration::ZERO);
+    let end = media_time + DANMAKU_PLAN_LOOKAHEAD;
+    (timeline.window(start, end), start, end)
 }
 
 fn surface_danmaku_viewport(surface: PlatformSurface) -> Option<DanmakuViewport> {
@@ -1134,6 +1519,15 @@ fn duration_regressed(next: Duration, previous: Duration) -> bool {
     previous
         .checked_sub(next)
         .is_some_and(|delta| delta > Duration::from_millis(5))
+}
+
+fn quantize_duration(value: Duration, quantum: Duration) -> Duration {
+    if quantum.is_zero() {
+        return value;
+    }
+    let quantum_micros = quantum.as_micros();
+    let quantized = (value.as_micros() / quantum_micros) * quantum_micros;
+    Duration::from_micros(quantized.min(u128::from(u64::MAX)) as u64)
 }
 
 fn duration_label(value: Option<Duration>) -> String {

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -55,6 +55,7 @@ use crate::renderer::metal::{
 };
 use crate::renderer::pipeline::{ColorRange, LumaUpscalerMode, ToneMapOperator};
 use crate::subtitle::{AssColor, SubtitleAlphaBitmap};
+use crate::trace;
 
 const CV_PIXEL_FORMAT_420_YP_CB_CR10_BI_PLANAR_VIDEO_RANGE: u32 =
     kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange;
@@ -291,6 +292,7 @@ impl MetalRendererImpl {
                 "no CAMetalLayer attached".to_string(),
             ));
         };
+        let started = Instant::now();
 
         unsafe {
             let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
@@ -334,6 +336,16 @@ impl MetalRendererImpl {
         }
 
         self.stats.rendered_frames += 1;
+        if trace::enabled() {
+            trace::log(format!(
+                "[erika-render-trace] stage=clear elapsed_ms={:.3} color={:.3},{:.3},{:.3},{:.3}",
+                started.elapsed().as_secs_f64() * 1000.0,
+                color.red,
+                color.green,
+                color.blue,
+                color.alpha,
+            ));
+        }
 
         Ok(())
     }
@@ -424,9 +436,12 @@ impl MetalRendererImpl {
         overlay: Option<OverlayRenderFrame<'_>>,
         danmaku: Option<DanmakuRenderFrame<'_>>,
     ) -> Result<()> {
+        let started = Instant::now();
         let danmaku_item_count = danmaku
             .as_ref()
             .map_or(0usize, |danmaku| danmaku.plan.items.len());
+        let mut upscaled_luma_used = false;
+        let has_overlay = overlay.is_some();
         self.stats.last_danmaku_atlas_duration = Duration::ZERO;
         self.stats.last_danmaku_vertex_build_duration = Duration::ZERO;
         self.stats.last_danmaku_vertex_copy_duration = Duration::ZERO;
@@ -536,6 +551,7 @@ impl MetalRendererImpl {
             if upscaled_luma.is_some() {
                 self.stats.upscaled_frames += 1;
                 frame.pipeline = frame.pipeline.with_luma_upscaler(self.upscaler.mode());
+                upscaled_luma_used = true;
             }
             let luma: &ProtocolObject<dyn MTLTexture> = upscaled_luma.as_deref().unwrap_or(luma);
 
@@ -632,6 +648,23 @@ impl MetalRendererImpl {
         if danmaku_item_count > 0 {
             self.stats.danmaku_passes += 1;
             self.stats.danmaku_items += danmaku_item_count as u64;
+        }
+        if trace::enabled() {
+            trace::log(format!(
+                "[erika-render-trace] stage=video_frame elapsed_ms={:.3} gen={} size={}x{} upscaled={} overlay={} danmaku_items={} gpu_ms={:.3} upscaler_ms={:.3}",
+                started.elapsed().as_secs_f64() * 1000.0,
+                frame
+                    .frame_token
+                    .map(|token| token.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                frame.frame.info.width,
+                frame.frame.info.height,
+                upscale_requested && upscaled_luma_used,
+                has_overlay,
+                danmaku_item_count,
+                self.stats.last_gpu_duration.as_secs_f64() * 1000.0,
+                self.stats.last_upscaler_encode_duration.as_secs_f64() * 1000.0,
+            ));
         }
 
         Ok(())

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -12,6 +12,7 @@ pub use crate::renderer::pipeline::LumaUpscalerMode;
 use crate::renderer::pipeline::{
     ColorRange, HdrMetadata, MatrixCoefficients, SourceColorState, VideoRenderPipeline,
 };
+use crate::trace;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple;
@@ -630,7 +631,18 @@ impl RendererBackend for MetalRenderer {
     fn render_test_frame(&mut self, time_seconds: f64) -> Result<()> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
+            let started = std::time::Instant::now();
             self.inner.render_clear(ClearColor::animated(time_seconds))
+                .map(|result| {
+                    if trace::enabled() {
+                        trace::log(format!(
+                            "[erika-render-trace] stage=test_frame time_seconds={:.3} elapsed_ms={:.3}",
+                            time_seconds,
+                            started.elapsed().as_secs_f64() * 1000.0,
+                        ));
+                    }
+                    result
+                })
         }
         #[cfg(not(any(target_os = "macos", target_os = "ios")))]
         {
@@ -642,21 +654,50 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn upload_player_frame(&mut self, frame: &PlayerVideoFrame) -> Result<()> {
+        let started = std::time::Instant::now();
         let imported = self.import_player_frame(&frame.frame)?;
         self.current_frame = Some(imported);
         self.current_media_time = frame.pts.unwrap_or(frame.media_time);
         self.current_generation = frame.generation.max(1);
         self.upload_counter = self.upload_counter.wrapping_add(1);
+        if trace::enabled() {
+            trace::log(format!(
+                "[erika-render-trace] stage=upload_frame gen={} pts={} media={} late={} frame_token={} elapsed_ms={:.3} size={}x{}",
+                frame.generation,
+                frame
+                    .pts
+                    .map(|pts| format!("{:.3}", pts.as_secs_f64()))
+                    .unwrap_or_else(|| "-".to_string()),
+                format!("{:.3}", frame.media_time.as_secs_f64()),
+                frame
+                    .late_by
+                    .map(|duration| format!("{:.3}", duration.as_secs_f64()))
+                    .unwrap_or_else(|| "-".to_string()),
+                self.upload_counter,
+                started.elapsed().as_secs_f64() * 1000.0,
+                frame.frame.width(),
+                frame.frame.height(),
+            ));
+        }
         Ok(())
     }
 
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {
         let Some(frame) = self.current_frame.take() else {
+            if trace::enabled() {
+                trace::log(format!(
+                    "[erika-render-trace] stage=render_current_frame empty gen={} media={} output={}x{}",
+                    context.generation,
+                    trace::duration_label(Some(context.media_time)),
+                    context.output_width,
+                    context.output_height,
+                ));
+            }
             return Ok(false);
         };
+        let started = std::time::Instant::now();
         let danmaku = context.danmaku.filter(|plan| {
             plan.generation == context.generation
-                && plan.media_time == context.media_time
                 && (context.output_width == 0 || plan.viewport.width == context.output_width)
                 && (context.output_height == 0 || plan.viewport.height == context.output_height)
         });
@@ -666,6 +707,18 @@ impl RendererBackend for MetalRenderer {
             danmaku.map(DanmakuRenderFrame::new),
         );
         self.current_frame = Some(frame);
+        if trace::enabled() {
+            trace::log(format!(
+                "[erika-render-trace] stage=render_current_frame gen={} media={} output={}x{} danmaku={} elapsed_ms={:.3} result={}",
+                context.generation,
+                trace::duration_label(Some(context.media_time)),
+                context.output_width,
+                context.output_height,
+                danmaku.as_ref().map_or(0, |plan| plan.items.len()),
+                started.elapsed().as_secs_f64() * 1000.0,
+                result.is_ok(),
+            ));
+        }
         result.map(|()| true)
     }
 

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -1564,7 +1564,6 @@ impl RendererBackend for WgpuRenderer {
         self.ensure_video_pipeline(format);
         let danmaku = context.danmaku.filter(|plan| {
             plan.generation == context.generation
-                && plan.media_time == context.media_time
                 && (context.output_width == 0 || plan.viewport.width == context.output_width)
                 && (context.output_height == 0 || plan.viewport.height == context.output_height)
         });

--- a/crates/erika/src/source.rs
+++ b/crates/erika/src/source.rs
@@ -1,6 +1,6 @@
 use std::env;
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 use crate::core::MediaSourceHint;
+use crate::trace;
 
 #[derive(Debug, Error)]
 pub enum SourceError {
@@ -310,6 +311,13 @@ impl MediaSource for HttpRangeSource {
             return Ok(self.content_length);
         }
         let started = Instant::now();
+        http_trace_log(format!(
+            "[erika-http-trace] stage=head_request uri={} cache_start={} cache_end={} read_ahead={}",
+            redacted_uri(&self.uri),
+            self.cache_start,
+            self.cache_end(),
+            self.read_ahead_bytes,
+        ));
         let response = self
             .agent
             .head(&self.uri)
@@ -323,7 +331,7 @@ impl MediaSource for HttpRangeSource {
             .and_then(|value| value.parse::<u64>().ok());
         self.content_length = length;
         http_trace_log(format!(
-            "{{\"event\":\"http_head\",\"status\":{},\"length\":{},\"elapsed_ms\":{:.3}}}",
+            "[erika-http-trace] stage=head_response status={} length={} elapsed_ms={:.3}",
             status,
             length.map_or_else(|| "null".to_string(), |length| length.to_string()),
             started.elapsed().as_secs_f64() * 1000.0,
@@ -459,19 +467,13 @@ fn http_read_ahead_bytes() -> u64 {
 }
 
 fn http_trace_log(line: impl AsRef<str>) {
-    if !crate::trace::env_flag("ERIKA_HTTP_TRACE") {
+    if !trace::env_flag("ERIKA_HTTP_TRACE") {
         return;
     }
-    let line = line.as_ref();
-    eprintln!("{line}");
     let path = env::var_os("ERIKA_HTTP_TRACE_FILE")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp/erika_http_trace.jsonl"));
-    let _ = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .and_then(|mut file| writeln!(file, "{line}"));
+    trace::append_line(line.as_ref(), path);
 }
 
 fn redacted_uri(uri: &str) -> String {

--- a/crates/erika/src/trace.rs
+++ b/crates/erika/src/trace.rs
@@ -1,23 +1,64 @@
-use std::{env, fs::OpenOptions, io::Write, path::PathBuf, time::Duration};
+use std::{
+    env,
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 pub(crate) fn enabled() -> bool {
-    env_flag("ERIKA_CLOCK_TRACE") || env_flag("ERIKA_DANMAKU_TRACE")
+    env_flag("ERIKA_CLOCK_TRACE")
+        || env_flag("ERIKA_DANMAKU_TRACE")
+        || env_flag("ERIKA_PLAYBACK_TRACE")
 }
 
 pub(crate) fn log(line: impl AsRef<str>) {
     if !enabled() {
         return;
     }
+    append_line(line.as_ref(), default_trace_path());
+}
+
+pub(crate) fn append_line(line: impl AsRef<str>, path: impl AsRef<Path>) {
     let line = line.as_ref();
+    let path = path.as_ref();
     eprintln!("{line}");
-    let path = env::var_os("ERIKA_DANMAKU_TRACE_FILE")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/tmp/erika_danmaku_trace.log"));
-    let _ = OpenOptions::new()
+    if let Err(error) = append_line_to_path(line, path) {
+        let fallback = fallback_trace_path(path);
+        if fallback.as_path() != path {
+            let _ = append_line_to_path(line, &fallback);
+        }
+        let _ = error;
+    }
+}
+
+fn append_line_to_path(line: &str, path: &Path) -> std::io::Result<()> {
+    OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
-        .and_then(|mut file| writeln!(file, "{line}"));
+        .and_then(|mut file| writeln!(file, "{line}"))
+}
+
+fn fallback_trace_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_owned())
+        .unwrap_or_else(|| "erika_playback_trace.log".into());
+    env::temp_dir().join(file_name)
+}
+
+pub(crate) fn default_trace_path() -> PathBuf {
+    if env_flag("ERIKA_PLAYBACK_TRACE") {
+        env::var_os("ERIKA_PLAYBACK_TRACE_FILE")
+            .or_else(|| env::var_os("ERIKA_DANMAKU_TRACE_FILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp/erika_playback_trace.log"))
+    } else {
+        env::var_os("ERIKA_DANMAKU_TRACE_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp/erika_danmaku_trace.log"))
+    }
 }
 
 pub(crate) fn duration_label(value: Option<Duration>) -> String {


### PR DESCRIPTION
## Summary
- decouple HTTP demuxing from the presentation path with an async demux worker and bounded packet delivery
- bound audio decode/pump work so network reads and decode bursts cannot monopolize playback progress
- move playback state pumping onto a worker path while keeping renderer-facing event delivery bounded
- fix startup black-screen/UI stalls by preparing DFM danmaku layout windows asynchronously
- keep danmaku clock-correct by generating render plans from the current playback clock every frame instead of reusing stale async plans
- restart audio output correctly after pause/resume when no new audio frame is pushed immediately
- keep playback, danmaku, clock, and HTTP diagnostics gated behind ERIKA_*_TRACE environment flags

## Why
NipaPlay HTTP playback was not simply dropping frames. The visible stall came from blocking work on the presentation/render path: HTTP demux/audio work could consume the hot path, and startup could synchronously perform expensive danmaku layout/raster preparation before the first stable frames. Parameter tuning alone would only hide the symptom. This change separates those responsibilities while preserving the key requirement that native danmaku remains driven by the same playback clock as video.

## Testing
- cargo fmt --all --check
- ERIKA_FFMPEG_DIR=/opt/homebrew/Cellar/ffmpeg/7.1.1_2 cargo check -p erika --no-default-features --lib

## Manual verification
- verified through NipaPlay with Erika HTTP playback that the long startup black-screen/UI stall is gone
- verified danmaku remains visible and smooth after startup, with render plans generated from the live player clock
- verified pause/resume recovers audio output