### PR TITLE
Fix SDR brightness on Apple EDR output

### DIFF
--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -128,6 +128,9 @@ impl MetalOutputMode {
                         target.transfer = TransferFunction::Pq;
                         target.peak_nits = 10_000.0;
                         target.reference_white_nits = 203.0;
+                    } else {
+                        target.peak_nits = 100.0 * headroom.max(1.0);
+                        target.reference_white_nits = 100.0;
                     }
                     target
                 }
@@ -903,8 +906,8 @@ mod tests {
         let target = output.target_color();
         assert_eq!(target.primaries, ColorPrimaries::Bt709);
         assert_eq!(target.transfer, TransferFunction::Srgb);
-        assert_eq!(target.peak_nits, 812.0);
-        assert_eq!(target.reference_white_nits, 203.0);
+        assert_eq!(target.peak_nits, 400.0);
+        assert_eq!(target.reference_white_nits, 100.0);
         assert_eq!(target.edr_headroom, 4.0);
     }
 
@@ -927,7 +930,8 @@ mod tests {
     fn metal_output_mode_clamps_edr_headroom_to_one() {
         let target = MetalOutputMode::apple_edr(0.25).target_color();
 
-        assert_eq!(target.peak_nits, 203.0);
+        assert_eq!(target.peak_nits, 100.0);
+        assert_eq!(target.reference_white_nits, 100.0);
         assert_eq!(target.edr_headroom, 1.0);
     }
 


### PR DESCRIPTION
## Summary
- Preserve 100-nit reference white for SDR/unknown sources when rendering through Apple EDR output.
- Keep PQ/HDR sources on the 203-nit reference white EDR path.
- Update Metal output mode tests for SDR EDR headroom behavior.

## Validation
- cargo fmt --all
- cargo test -p erika metal_output_mode --lib
- cargo check -p erika_capi

## Manual check
- Verified from Nipa using the macOS Metal/VideoToolbox path against the SDR Lycoris Recoil sample; the Erika pause-frame luminance matched the reference after the fix instead of rendering visibly darker.