### PR TITLE
Capture Metal frames for screenshots

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -266,6 +266,13 @@ pub struct RenderFrameContext<'a> {
     pub output_height: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RendererFrameCapture {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+}
+
 impl<'a> RenderFrameContext<'a> {
     pub fn new(media_time: Duration, generation: u64) -> Self {
         Self {
@@ -417,6 +424,16 @@ pub trait RendererBackend {
     /// surface. Returns `false` if there is no current frame to draw, letting the
     /// caller fall back to a test frame.
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool>;
+
+    /// Render the retained current frame into an offscreen RGBA buffer.
+    fn capture_current_frame(
+        &mut self,
+        _context: RenderFrameContext<'_>,
+        _width: u32,
+        _height: u32,
+    ) -> Result<Option<RendererFrameCapture>> {
+        Ok(None)
+    }
 
     fn runtime_stats(&self) -> RendererRuntimeStats {
         RendererRuntimeStats::default()

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -824,6 +824,27 @@ impl PresenterRuntime {
         Ok(self.stats)
     }
 
+    pub fn capture_frame_rgba(&mut self, width: u32, height: u32) -> Result<Option<Vec<u8>>> {
+        if width == 0 || height == 0 {
+            return Err(PlayerError::Renderer(
+                "capture size must be non-zero".to_string(),
+            ));
+        }
+
+        self.pump_subtitles();
+        self.pump_video();
+        self.sync_media_time_from_player();
+        self.refresh_stale_danmaku_plan();
+
+        let context = RenderFrameContext::new(self.current_media_time, self.current_generation)
+            .overlay(self.current_overlay.as_ref())
+            .danmaku(self.current_danmaku.as_ref())
+            .output_size(width, height);
+        self.renderer
+            .capture_current_frame(context, width, height)
+            .map(|capture| capture.map(|capture| capture.rgba))
+    }
+
     pub fn stats(&self) -> PresenterStats {
         self.stats
     }

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -30,12 +30,12 @@ use objc2_core_video::{
 use objc2_foundation::NSString;
 use objc2_metal::{
     MTLBlendFactor, MTLBlendOperation, MTLClearColor, MTLCreateSystemDefaultDevice, MTLLoadAction,
-    MTLPixelFormat, MTLRegion, MTLResourceOptions, MTLStoreAction, MTLTextureDescriptor,
-    MTLTextureUsage,
+    MTLOrigin, MTLPixelFormat, MTLRegion, MTLResourceOptions, MTLSize, MTLStorageMode,
+    MTLStoreAction, MTLTextureDescriptor, MTLTextureUsage,
 };
 use objc2_metal::{
-    MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder, MTLCommandQueue,
-    MTLDevice, MTLDrawable, MTLRenderPassDescriptor, MTLTexture,
+    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
+    MTLCommandQueue, MTLDevice, MTLDrawable, MTLRenderPassDescriptor, MTLTexture,
 };
 use objc2_metal::{
     MTLLibrary, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPipelineDescriptor,
@@ -668,6 +668,201 @@ impl MetalRendererImpl {
         }
 
         Ok(())
+    }
+
+    pub fn capture_video_frame_rgba(
+        &mut self,
+        mut frame: VideoRenderFrame<'_>,
+        overlay: Option<OverlayRenderFrame<'_>>,
+        danmaku: Option<DanmakuRenderFrame<'_>>,
+        width: u32,
+        height: u32,
+    ) -> Result<Vec<u8>> {
+        if width == 0 || height == 0 {
+            return Err(PlayerError::Renderer(
+                "capture size must be non-zero".to_string(),
+            ));
+        }
+
+        let Some(textures) = frame.frame.inner.as_ref() else {
+            return Err(PlayerError::Renderer(
+                "imported video frame has no Metal textures".to_string(),
+            ));
+        };
+        let Some(luma) = textures.luma_texture() else {
+            return Err(PlayerError::Renderer(
+                "imported video frame has no luma plane".to_string(),
+            ));
+        };
+        let Some(chroma) = textures.chroma_texture() else {
+            return Err(PlayerError::Renderer(
+                "imported video frame has no chroma plane".to_string(),
+            ));
+        };
+
+        let source_color = frame.pipeline.source;
+        frame.pipeline = frame
+            .pipeline
+            .with_target(self.output_mode.target_color_for_source(source_color));
+
+        let layout = VideoPresentationLayout::aspect_fit(
+            frame.frame.info.width as u32,
+            frame.frame.info.height as u32,
+            width,
+            height,
+        );
+
+        unsafe {
+            let metal_format = metal_pixel_format(self.drawable_pixel_format);
+            let descriptor =
+                MTLTextureDescriptor::texture2DDescriptorWithPixelFormat_width_height_mipmapped(
+                    metal_format,
+                    width as usize,
+                    height as usize,
+                    false,
+                );
+            descriptor.setStorageMode(MTLStorageMode::Private);
+            descriptor.setUsage(MTLTextureUsage::RenderTarget | MTLTextureUsage::ShaderRead);
+            let target = self
+                .device
+                .newTextureWithDescriptor(&descriptor)
+                .ok_or_else(|| {
+                    PlayerError::Renderer("capture texture allocation failed".to_string())
+                })?;
+
+            let Some(command_buffer) = self.queue.commandBuffer() else {
+                return Err(PlayerError::Renderer(
+                    "commandBuffer returned nil".to_string(),
+                ));
+            };
+
+            let pipeline = self.video_pipeline_state()?;
+            let sampler = self.video_sampler_state()?;
+            let pass_descriptor = MTLRenderPassDescriptor::new();
+            let attachments = pass_descriptor.colorAttachments();
+            let attachment = attachments.objectAtIndexedSubscript(0);
+            attachment.setTexture(Some(&*target));
+            attachment.setLoadAction(MTLLoadAction::Clear);
+            attachment.setStoreAction(MTLStoreAction::Store);
+            attachment.setClearColor(MTLClearColor {
+                red: 0.0,
+                green: 0.0,
+                blue: 0.0,
+                alpha: 1.0,
+            });
+
+            let Some(encoder) = command_buffer.renderCommandEncoderWithDescriptor(&pass_descriptor)
+            else {
+                return Err(PlayerError::Renderer(
+                    "renderCommandEncoderWithDescriptor returned nil".to_string(),
+                ));
+            };
+
+            let uniforms = VideoUniforms {
+                is_p010: matches!(frame.frame.info.format, ImportedVideoFormat::P010) as u32,
+                full_range: matches!(frame.pipeline.source.range, ColorRange::Full) as u32,
+                source_transfer: transfer_code(frame.pipeline.source.transfer),
+                target_transfer: transfer_code(frame.pipeline.target.transfer),
+                tone_map: tone_map_code(frame.pipeline.tone_map.operator),
+                edr_output: self.output_mode.is_edr() as u32,
+                _reserved0: 0,
+                _reserved1: 0,
+                rect: layout.target_rect,
+                viewport: layout.video_viewport(),
+                nits: [
+                    frame.pipeline.source.nominal_peak_nits,
+                    frame.pipeline.target.peak_nits,
+                    frame.pipeline.source.reference_white_nits,
+                    frame.pipeline.target.reference_white_nits,
+                ],
+                luma_coefficients: luma_coefficients(frame.pipeline.luma_coefficients()),
+                gamut_matrix_rows: frame.pipeline.gamut_matrix().row4s(),
+            };
+            encoder.setRenderPipelineState(&pipeline);
+            encoder.setFragmentTexture_atIndex(Some(luma), 0);
+            encoder.setFragmentTexture_atIndex(Some(chroma), 1);
+            encoder.setFragmentSamplerState_atIndex(Some(&sampler), 0);
+            encoder.setVertexBytes_length_atIndex(
+                NonNull::new(
+                    (&uniforms as *const VideoUniforms)
+                        .cast::<c_void>()
+                        .cast_mut(),
+                )
+                .expect("uniform pointer is non-null"),
+                mem::size_of::<VideoUniforms>(),
+                0,
+            );
+            encoder.setFragmentBytes_length_atIndex(
+                NonNull::new(
+                    (&uniforms as *const VideoUniforms)
+                        .cast::<c_void>()
+                        .cast_mut(),
+                )
+                .expect("uniform pointer is non-null"),
+                mem::size_of::<VideoUniforms>(),
+                0,
+            );
+            encoder.drawPrimitives_vertexStart_vertexCount(MTLPrimitiveType::TriangleStrip, 0, 4);
+
+            if let Some(overlay) = overlay {
+                self.draw_overlay_planes(&encoder, overlay, layout)?;
+            }
+            if let Some(danmaku) = danmaku.as_ref() {
+                self.draw_danmaku_plan(&encoder, danmaku.plan, layout)?;
+            }
+            encoder.endEncoding();
+
+            let bytes_per_pixel = match self.drawable_pixel_format {
+                MetalDrawablePixelFormat::Bgra8Unorm => 4usize,
+                MetalDrawablePixelFormat::Rgba16Float => 8usize,
+            };
+            let row_bytes = width as usize * bytes_per_pixel;
+            let buffer_len = row_bytes * height as usize;
+            let readback = self
+                .device
+                .newBufferWithLength_options(buffer_len, MTLResourceOptions::StorageModeShared)
+                .ok_or_else(|| {
+                    PlayerError::Renderer("capture readback buffer allocation failed".to_string())
+                })?;
+            let Some(blit) = command_buffer.blitCommandEncoder() else {
+                return Err(PlayerError::Renderer(
+                    "blitCommandEncoder returned nil".to_string(),
+                ));
+            };
+            blit.copyFromTexture_sourceSlice_sourceLevel_sourceOrigin_sourceSize_toBuffer_destinationOffset_destinationBytesPerRow_destinationBytesPerImage(
+                &target,
+                0,
+                0,
+                MTLOrigin { x: 0, y: 0, z: 0 },
+                MTLSize {
+                    width: width as usize,
+                    height: height as usize,
+                    depth: 1,
+                },
+                &readback,
+                0,
+                row_bytes,
+                buffer_len,
+            );
+            blit.endEncoding();
+            command_buffer.commit();
+            command_buffer.waitUntilCompleted();
+            if command_buffer.status() != MTLCommandBufferStatus::Completed {
+                return Err(PlayerError::Renderer(format!(
+                    "capture command buffer failed with status {:?}",
+                    command_buffer.status()
+                )));
+            }
+
+            let raw =
+                std::slice::from_raw_parts(readback.contents().as_ptr().cast::<u8>(), buffer_len);
+            Ok(convert_capture_to_rgba8(
+                raw,
+                width as usize,
+                height as usize,
+                self.drawable_pixel_format,
+            ))
+        }
     }
 
     pub fn set_luma_upscaler(&mut self, mode: LumaUpscalerMode) {
@@ -1446,6 +1641,62 @@ fn metal_pixel_format(format: MetalDrawablePixelFormat) -> MTLPixelFormat {
         MetalDrawablePixelFormat::Bgra8Unorm => MTLPixelFormat::BGRA8Unorm,
         MetalDrawablePixelFormat::Rgba16Float => MTLPixelFormat::RGBA16Float,
     }
+}
+
+fn convert_capture_to_rgba8(
+    raw: &[u8],
+    width: usize,
+    height: usize,
+    format: MetalDrawablePixelFormat,
+) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity(width * height * 4);
+    match format {
+        MetalDrawablePixelFormat::Bgra8Unorm => {
+            for pixel in raw.chunks_exact(4).take(width * height) {
+                rgba.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
+            }
+        }
+        MetalDrawablePixelFormat::Rgba16Float => {
+            for pixel in raw.chunks_exact(8).take(width * height) {
+                let r = half_to_unorm8(u16::from_le_bytes([pixel[0], pixel[1]]));
+                let g = half_to_unorm8(u16::from_le_bytes([pixel[2], pixel[3]]));
+                let b = half_to_unorm8(u16::from_le_bytes([pixel[4], pixel[5]]));
+                let a = half_to_unorm8(u16::from_le_bytes([pixel[6], pixel[7]]));
+                rgba.extend_from_slice(&[r, g, b, a]);
+            }
+        }
+    }
+    rgba
+}
+
+fn half_to_unorm8(bits: u16) -> u8 {
+    let value = half_to_f32(bits).clamp(0.0, 1.0);
+    (value * 255.0).round() as u8
+}
+
+fn half_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 0x1) as u32;
+    let exp = ((bits >> 10) & 0x1f) as i32;
+    let frac = (bits & 0x03ff) as u32;
+    let f_bits = if exp == 0 {
+        if frac == 0 {
+            sign << 31
+        } else {
+            let mut frac = frac;
+            let mut exp = -14;
+            while (frac & 0x0400) == 0 {
+                frac <<= 1;
+                exp -= 1;
+            }
+            frac &= 0x03ff;
+            (sign << 31) | (((exp + 127) as u32) << 23) | (frac << 13)
+        }
+    } else if exp == 0x1f {
+        (sign << 31) | 0x7f80_0000 | (frac << 13)
+    } else {
+        (sign << 31) | (((exp - 15 + 127) as u32) << 23) | (frac << 13)
+    };
+    f32::from_bits(f_bits)
 }
 
 fn edr_layer_color_space(

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 
 use crate::core::{
     ColorPrimaries, LumaUpscalerBackendStatus, PlatformSurface, PlayerError, PlayerVideoFrame,
-    RenderFrameContext, RendererBackend, RendererRuntimeStats, Result, TransferFunction,
+    RenderFrameContext, RendererBackend, RendererFrameCapture, RendererRuntimeStats, Result,
+    TransferFunction,
 };
 use crate::danmaku::DanmakuRenderPlan;
 use crate::ffmpeg::Frame;
@@ -476,6 +477,28 @@ impl MetalRenderer {
         }
     }
 
+    pub fn capture_video_frame_rgba(
+        &mut self,
+        frame: VideoRenderFrame<'_>,
+        overlay: Option<OverlayRenderFrame<'_>>,
+        danmaku: Option<DanmakuRenderFrame<'_>>,
+        width: u32,
+        height: u32,
+    ) -> Result<Vec<u8>> {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            self.inner
+                .capture_video_frame_rgba(frame, overlay, danmaku, width, height)
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        {
+            let _ = (frame, overlay, danmaku, width, height);
+            Err(PlayerError::Renderer(
+                "Metal renderer is only available on Apple platforms for v0".to_string(),
+            ))
+        }
+    }
+
     pub fn render_overlay_frame(&mut self, overlay: OverlayRenderFrame<'_>) -> Result<()> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
@@ -723,6 +746,42 @@ impl RendererBackend for MetalRenderer {
             ));
         }
         result.map(|()| true)
+    }
+
+    fn capture_current_frame(
+        &mut self,
+        context: RenderFrameContext<'_>,
+        width: u32,
+        height: u32,
+    ) -> Result<Option<RendererFrameCapture>> {
+        let Some(frame) = self.current_frame.take() else {
+            return Ok(None);
+        };
+        if width == 0 || height == 0 {
+            self.current_frame = Some(frame);
+            return Err(PlayerError::Renderer(
+                "capture size must be non-zero".to_string(),
+            ));
+        }
+        let danmaku = context.danmaku.filter(|plan| {
+            plan.generation == context.generation
+                && plan.viewport.width == width
+                && plan.viewport.height == height
+        });
+        let rgba = self.capture_video_frame_rgba(
+            VideoRenderFrame::new(&frame).frame_token(self.upload_counter),
+            context.overlay.map(OverlayRenderFrame::new),
+            danmaku.map(DanmakuRenderFrame::new),
+            width,
+            height,
+        );
+        self.current_frame = Some(frame);
+        let rgba = rgba?;
+        Ok(Some(RendererFrameCapture {
+            width,
+            height,
+            rgba,
+        }))
     }
 
     fn runtime_stats(&self) -> RendererRuntimeStats {

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -1706,6 +1706,38 @@ pub unsafe extern "C" fn erika_presenter_render_tick(
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_capture_frame_rgba(
+    handle: *mut ErikaPresenterHandle,
+    width: u32,
+    height: u32,
+    out_rgba: *mut u8,
+    out_capacity: usize,
+) -> ErikaStatus {
+    let Some(expected_len) = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|pixels| pixels.checked_mul(4))
+    else {
+        return ErikaStatus::PlayerError;
+    };
+    if expected_len == 0 || out_rgba.is_null() || out_capacity < expected_len {
+        return ErikaStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        match handle.presenter.capture_frame_rgba(width, height) {
+            Ok(Some(rgba)) if rgba.len() == expected_len => {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(rgba.as_ptr(), out_rgba, expected_len);
+                }
+                ErikaStatus::Ok
+            }
+            Ok(_) => ErikaStatus::PlayerError,
+            Err(_) => ErikaStatus::PlayerError,
+        }
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_poll_event(
     handle: *mut ErikaPresenterHandle,
     out_event: *mut ErikaEvent,

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -336,6 +336,7 @@ private final class ErikaNativeLibrary {
   typealias AttachMetalLayerFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, UInt32, UInt32, Double) -> Int32
   typealias ResizeSurfaceFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, Double) -> Int32
   typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
+  typealias CaptureFrameRgbaFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, UnsafeMutableRawPointer?, Int) -> Int32
   typealias PollEventFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
 
   static let shared = try? ErikaNativeLibrary()
@@ -380,6 +381,7 @@ private final class ErikaNativeLibrary {
   let resizeSurface: ResizeSurfaceFn
   let detachSurface: CommandFn
   let renderTick: RenderTickFn
+  let captureFrameRgba: CaptureFrameRgbaFn?
   let pollEvent: PollEventFn
 
   private let libraryHandle: UnsafeMutableRawPointer
@@ -434,6 +436,7 @@ private final class ErikaNativeLibrary {
     resizeSurface = try Self.load("erika_presenter_resize_surface", from: libraryHandle, as: ResizeSurfaceFn.self)
     detachSurface = try Self.load("erika_presenter_detach_surface", from: libraryHandle, as: CommandFn.self)
     renderTick = try Self.load("erika_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
+    captureFrameRgba = Self.loadOptional("erika_presenter_capture_frame_rgba", from: libraryHandle, as: CaptureFrameRgbaFn.self)
     pollEvent = try Self.load("erika_presenter_poll_event", from: libraryHandle, as: PollEventFn.self)
   }
 
@@ -800,7 +803,32 @@ private final class ErikaPlayerHost {
     return selection.toFlutterMap()
   }
 
-  func screenshot(view: ErikaMetalSurfaceView? = nil) -> Data? {
+  func captureFrameRgba(width: Int, height: Int) -> Data? {
+    guard width > 0, height > 0, let captureFrameRgba = library.captureFrameRgba else {
+      return nil
+    }
+    let byteCount = width * height * 4
+    var data = Data(count: byteCount)
+    let status = data.withUnsafeMutableBytes { buffer in
+      captureFrameRgba(
+        handle,
+        UInt32(width),
+        UInt32(height),
+        buffer.baseAddress,
+        byteCount
+      )
+    }
+    guard status == 0 else {
+      NSLog("Erika: captureFrameRgba failed with status \(status)")
+      return nil
+    }
+    return data
+  }
+
+  func screenshot(view: ErikaMetalSurfaceView? = nil, width: Int? = nil, height: Int? = nil) -> Data? {
+    if let width, let height, let data = captureFrameRgba(width: width, height: height) {
+      return data
+    }
     (view ?? attachedView)?.pngSnapshotData()
   }
 
@@ -1440,7 +1468,9 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
         let view = try optionalVideoView(from: args, host: host)
-        if let data = host.screenshot(view: view) {
+        let width = int64Value(args["width"]).map(Int.init)
+        let height = int64Value(args["height"]).map(Int.init)
+        if let data = host.screenshot(view: view, width: width, height: height) {
           result(FlutterStandardTypedData(bytes: data))
         } else {
           result(nil)

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -449,13 +449,15 @@ class ErikaPlayer {
     return ErikaUpscalerStatus.fromMap(status);
   }
 
-  Future<Uint8List?> screenshot({int? viewId}) async {
+  Future<Uint8List?> screenshot({int? viewId, int? width, int? height}) async {
     final playerId = await ensureCreated();
     return _channel.invokeMethod<Uint8List>(
       'screenshot',
       <String, Object?>{
         'playerId': playerId,
         if (viewId != null) 'viewId': viewId,
+        if (width != null) 'width': width,
+        if (height != null) 'height': height,
       },
     );
   }

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -207,6 +207,7 @@ private final class ErikaNativeLibrary {
   typealias AttachMetalLayerFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, UInt32, UInt32, Double) -> Int32
   typealias ResizeSurfaceFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, Double) -> Int32
   typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
+  typealias CaptureFrameRgbaFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, UnsafeMutableRawPointer?, Int) -> Int32
   typealias PollEventFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
 
   static let shared = try? ErikaNativeLibrary()
@@ -251,6 +252,7 @@ private final class ErikaNativeLibrary {
   let resizeSurface: ResizeSurfaceFn
   let detachSurface: CommandFn
   let renderTick: RenderTickFn
+  let captureFrameRgba: CaptureFrameRgbaFn?
   let pollEvent: PollEventFn
 
   private let libraryHandle: UnsafeMutableRawPointer
@@ -299,6 +301,7 @@ private final class ErikaNativeLibrary {
     resizeSurface = try Self.load("erika_presenter_resize_surface", from: libraryHandle, as: ResizeSurfaceFn.self)
     detachSurface = try Self.load("erika_presenter_detach_surface", from: libraryHandle, as: CommandFn.self)
     renderTick = try Self.load("erika_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
+    captureFrameRgba = Self.loadOptional("erika_presenter_capture_frame_rgba", from: libraryHandle, as: CaptureFrameRgbaFn.self)
     pollEvent = try Self.load("erika_presenter_poll_event", from: libraryHandle, as: PollEventFn.self)
   }
 
@@ -700,7 +703,32 @@ private final class ErikaPlayerHost {
     return selection.toFlutterMap()
   }
 
-  func screenshot(view: ErikaMetalSurfaceView? = nil) -> Data? {
+  func captureFrameRgba(width: Int, height: Int) -> Data? {
+    guard width > 0, height > 0, let captureFrameRgba = library.captureFrameRgba else {
+      return nil
+    }
+    let byteCount = width * height * 4
+    var data = Data(count: byteCount)
+    let status = data.withUnsafeMutableBytes { buffer in
+      captureFrameRgba(
+        handle,
+        UInt32(width),
+        UInt32(height),
+        buffer.baseAddress,
+        byteCount
+      )
+    }
+    guard status == 0 else {
+      NSLog("Erika: captureFrameRgba failed with status \(status)")
+      return nil
+    }
+    return data
+  }
+
+  func screenshot(view: ErikaMetalSurfaceView? = nil, width: Int? = nil, height: Int? = nil) -> Data? {
+    if let width, let height, let data = captureFrameRgba(width: width, height: height) {
+      return data
+    }
     (view ?? attachedView)?.pngSnapshotData()
   }
 
@@ -1419,7 +1447,9 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
         let view = try optionalVideoView(from: args, host: host)
-        if let data = host.screenshot(view: view) {
+        let width = int64Value(args["width"]).map(Int.init)
+        let height = int64Value(args["height"]).map(Int.init)
+        if let data = host.screenshot(view: view, width: width, height: height) {
           result(FlutterStandardTypedData(bytes: data))
         } else {
           result(nil)

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:erika_flutter/erika_flutter.dart';
@@ -118,6 +120,34 @@ void main() {
     expect(call.arguments, <String, Object?>{
       'playerId': 7,
       'trackId': 1000001,
+    });
+
+    await player.dispose();
+  });
+
+  test('screenshot forwards optional capture size', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(playerChannel, (MethodCall call) async {
+      playerCalls.add(call);
+      return switch (call.method) {
+        'create' => 7,
+        'screenshot' => Uint8List.fromList(<int>[1, 2, 3, 4]),
+        'dispose' => null,
+        _ => null,
+      };
+    });
+    final player = ErikaPlayer();
+
+    final bytes = await player.screenshot(width: 320, height: 180);
+
+    expect(bytes, <int>[1, 2, 3, 4]);
+    final call = playerCalls.singleWhere(
+      (MethodCall call) => call.method == 'screenshot',
+    );
+    expect(call.arguments, <String, Object?>{
+      'playerId': 7,
+      'width': 320,
+      'height': 180,
     });
 
     await player.dispose();


### PR DESCRIPTION
## Summary
- Add renderer-level Metal offscreen capture for the retained current frame.
- Expose `erika_presenter_capture_frame_rgba` through the C API and macOS/iOS Flutter plugin.
- Allow `ErikaPlayer.screenshot` to request a raw RGBA capture size while preserving the old view snapshot fallback.

## Validation
- `cargo fmt --all`
- `cargo test -p erika metal_output_mode --lib`
- `cargo check -p erika_capi`
- `flutter test test/erika_player_test.dart` from `packages/erika_flutter`

## Notes
- The capture API returns raw 8-bit RGBA sized to the requested width/height. Nipa can encode it to thumbnails or PNG screenshots without relying on Flutter view snapshots.