### PR TITLE
Fix subtitle PlayRes and expose subtitle scale

### DIFF
--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -29,15 +29,14 @@ use crate::danmaku::{
 };
 use crate::overlay::{OverlayFrame, OverlayTimeline, OverlayViewport};
 use crate::renderer::metal::{MetalRenderer, MetalRendererConfig};
-#[cfg(feature = "libass")]
-use crate::subtitle::decoded_subtitle_frames_to_ass_script;
 use crate::subtitle::{
-    DecodedSubtitleFrame, SubtitleRendererCore, SubtitleTrackConfig, SubtitleViewport,
-    decoded_subtitle_frames_to_timeline,
+    DecodedSubtitleFrame, SubtitleAssStyle, SubtitleRendererCore, SubtitleTrackConfig,
+    SubtitleViewport, decoded_subtitle_frames_to_timeline,
 };
 #[cfg(feature = "libass")]
 use crate::subtitle::{
     LibassRenderConfig, LibassSubtitleRenderer, SubtitleRenderRequest, SubtitleRenderer,
+    decoded_subtitle_frames_to_ass_script_with_style,
 };
 use crate::trace;
 use crate::{PlayerError, Result};
@@ -51,6 +50,7 @@ const DANMAKU_PLAN_REQUEST_QUANTUM: Duration = Duration::from_millis(250);
 const DANMAKU_PREPARE_REFRESH_MARGIN: Duration = Duration::from_secs(4);
 const DANMAKU_PLAN_LOOKAHEAD: Duration = Duration::from_secs(8);
 const DANMAKU_PLAN_LOOKBACK_PADDING: Duration = Duration::from_secs(2);
+const DEFAULT_SUBTITLE_FONT_SCALE: f64 = 1.0;
 
 #[derive(Debug, Clone)]
 pub struct PresenterConfig {
@@ -183,6 +183,7 @@ pub struct PresenterRuntime {
     current_generation: u64,
     current_output_viewport: Option<DanmakuViewport>,
     current_danmaku_viewport: Option<DanmakuViewport>,
+    subtitle_font_scale: f64,
     subtitles: SubtitleFrameState,
     overlay: OverlayTimeline,
     render_test_pattern_when_idle: bool,
@@ -439,6 +440,7 @@ impl PresenterRuntime {
             current_generation: 1,
             current_output_viewport: None,
             current_danmaku_viewport: None,
+            subtitle_font_scale: DEFAULT_SUBTITLE_FONT_SCALE,
             subtitles: SubtitleFrameState::default(),
             overlay: config.overlay,
             render_test_pattern_when_idle: config.render_test_pattern_when_idle,
@@ -568,6 +570,15 @@ impl PresenterRuntime {
 
     pub fn volume(&self) -> f64 {
         self.audio_output.volume() as f64
+    }
+
+    pub fn set_subtitle_scale(&mut self, scale: f64) {
+        let scale = normalize_subtitle_font_scale(scale);
+        if (self.subtitle_font_scale - scale).abs() < 0.001 {
+            return;
+        }
+        self.subtitle_font_scale = scale;
+        self.refresh_current_overlay();
     }
 
     pub fn set_danmaku_timeline(&mut self, timeline: DanmakuTimeline) {
@@ -978,7 +989,19 @@ impl PresenterRuntime {
         let mut overlay = self
             .overlay
             .render(pts, OverlayViewport::new(viewport.width, viewport.height));
-        self.subtitles.append_to_overlay(pts, &mut overlay);
+        let subtitle_style = self.subtitle_ass_style(overlay.viewport);
+        self.subtitles
+            .append_to_overlay(pts, &mut overlay, subtitle_style);
+        if subtitle_diag_enabled() {
+            eprintln!(
+                "[erika-subtitle-diag] stage=update_overlay pts={} gen={} video={}x{} overlay={}",
+                duration_label(Some(pts)),
+                generation,
+                viewport.width,
+                viewport.height,
+                overlay_debug_summary(&overlay),
+            );
+        }
         if !overlay.is_empty() {
             self.stats.overlay_frames += 1;
         }
@@ -1115,12 +1138,28 @@ impl PresenterRuntime {
             .max(1);
         if player_time != self.current_media_time {
             self.current_media_time = player_time;
-            if let Some(viewport) = self.current_danmaku_viewport {
+            if let Some(viewport) = self
+                .current_overlay
+                .as_ref()
+                .map(|overlay| overlay.viewport)
+            {
                 let mut overlay = self.overlay.render(
                     player_time,
                     OverlayViewport::new(viewport.width, viewport.height),
                 );
-                self.subtitles.append_to_overlay(player_time, &mut overlay);
+                let subtitle_style = self.subtitle_ass_style(overlay.viewport);
+                self.subtitles
+                    .append_to_overlay(player_time, &mut overlay, subtitle_style);
+                if subtitle_diag_enabled() {
+                    eprintln!(
+                        "[erika-subtitle-diag] stage=clock_overlay player={} gen={} overlay_viewport={}x{} overlay={}",
+                        duration_label(Some(player_time)),
+                        self.current_generation,
+                        viewport.width,
+                        viewport.height,
+                        overlay_debug_summary(&overlay),
+                    );
+                }
                 self.current_overlay = Some(overlay);
             }
         }
@@ -1134,6 +1173,32 @@ impl PresenterRuntime {
             None,
             0,
         );
+    }
+
+    fn refresh_current_overlay(&mut self) {
+        let Some(viewport) = self
+            .current_overlay
+            .as_ref()
+            .map(|overlay| overlay.viewport)
+        else {
+            return;
+        };
+        let mut overlay = self.overlay.render(
+            self.current_media_time,
+            OverlayViewport::new(viewport.width, viewport.height),
+        );
+        let subtitle_style = self.subtitle_ass_style(overlay.viewport);
+        self.subtitles
+            .append_to_overlay(self.current_media_time, &mut overlay, subtitle_style);
+        self.current_overlay = Some(overlay);
+    }
+
+    fn subtitle_ass_style(&self, viewport: OverlayViewport) -> SubtitleAssStyle {
+        SubtitleAssStyle {
+            font_scale: self.subtitle_font_scale,
+            play_res_width: viewport.width,
+            play_res_height: viewport.height,
+        }
     }
 
     fn trace_danmaku_time(
@@ -1259,6 +1324,18 @@ impl PresenterRuntime {
                 Ok(frame) => {
                     if frame.generation < self.player.playback_generation() {
                         continue;
+                    }
+                    if subtitle_diag_enabled() {
+                        eprintln!(
+                            "[erika-subtitle-diag] stage=pump_subtitle gen={} track={} start={} end={} text_segments={} bitmap_planes={} empty={}",
+                            frame.generation,
+                            frame.frame.track_id,
+                            duration_label(frame.frame.start),
+                            duration_label(frame.frame.end),
+                            frame.frame.text.len(),
+                            frame.frame.bitmap.planes.len(),
+                            frame.frame.is_empty(),
+                        );
                     }
                     self.stats.decoded_subtitle_frames += 1;
                     self.subtitles.push(frame);
@@ -1529,6 +1606,14 @@ fn surface_dimensions_to_viewport(width: u32, height: u32, scale: f64) -> Danmak
     DanmakuViewport::with_scale(pixel_width, pixel_height, scale as f32)
 }
 
+fn normalize_subtitle_font_scale(scale: f64) -> f64 {
+    if scale.is_finite() {
+        scale.clamp(0.25, 4.0)
+    } else {
+        DEFAULT_SUBTITLE_FONT_SCALE
+    }
+}
+
 fn bump_generation(current_generation: &mut u64, danmaku_generation: &mut u64) {
     *danmaku_generation = danmaku_generation.saturating_add(1).max(1);
     *current_generation = current_generation
@@ -1555,6 +1640,60 @@ fn duration_label(value: Option<Duration>) -> String {
     value
         .map(|duration| format!("{:.3}", duration.as_secs_f64()))
         .unwrap_or_else(|| "-".to_string())
+}
+
+fn subtitle_diag_enabled() -> bool {
+    trace::env_flag("ERIKA_SUBTITLE_DIAG")
+}
+
+fn overlay_debug_summary(overlay: &OverlayFrame) -> String {
+    let first_plane = overlay
+        .subtitle_planes
+        .first()
+        .map(|plane| {
+            let max_alpha = plane
+                .rgba
+                .chunks_exact(4)
+                .map(|pixel| pixel[3])
+                .max()
+                .unwrap_or(0);
+            format!(
+                "first_rgba=x:{} y:{} w:{} h:{} max_a:{} bytes:{}",
+                plane.x,
+                plane.y,
+                plane.width,
+                plane.height,
+                max_alpha,
+                plane.rgba.len(),
+            )
+        })
+        .unwrap_or_else(|| "first_rgba=none".to_string());
+    let first_alpha = overlay
+        .subtitle_alpha_planes
+        .first()
+        .map(|plane| {
+            let max_alpha = plane.alpha.iter().copied().max().unwrap_or(0);
+            format!(
+                "first_alpha=x:{} y:{} w:{} h:{} max_a:{} bytes:{}",
+                plane.placement.x,
+                plane.placement.y,
+                plane.placement.width,
+                plane.placement.height,
+                max_alpha,
+                plane.alpha.len(),
+            )
+        })
+        .unwrap_or_else(|| "first_alpha=none".to_string());
+    format!(
+        "viewport={}x{} rgba_planes={} alpha_planes={} changed={} {} {}",
+        overlay.viewport.width,
+        overlay.viewport.height,
+        overlay.subtitle_planes.len(),
+        overlay.subtitle_alpha_planes.len(),
+        overlay.subtitle_changed,
+        first_plane,
+        first_alpha,
+    )
 }
 
 impl Drop for PresenterRuntime {
@@ -1656,7 +1795,12 @@ impl SubtitleFrameState {
             .retain(|frame| !frame.frame.is_empty() && frame.frame.end.is_none_or(|end| pts < end));
     }
 
-    fn append_to_overlay(&mut self, pts: Duration, overlay: &mut OverlayFrame) {
+    fn append_to_overlay(
+        &mut self,
+        pts: Duration,
+        overlay: &mut OverlayFrame,
+        style: SubtitleAssStyle,
+    ) {
         self.retain_at(pts);
         let active = self
             .frames
@@ -1683,7 +1827,7 @@ impl SubtitleFrameState {
             .map(|frame| frame.frame.clone())
             .collect::<Vec<_>>();
         if !text_frames.is_empty() {
-            self.append_text_subtitles(pts, overlay, &text_frames);
+            self.append_text_subtitles(pts, overlay, &text_frames, style);
             subtitle_changed = true;
         }
 
@@ -1696,8 +1840,12 @@ impl SubtitleFrameState {
         pts: Duration,
         overlay: &mut OverlayFrame,
         frames: &[DecodedSubtitleFrame],
+        style: SubtitleAssStyle,
     ) {
-        match self.text_renderer.render(pts, overlay.viewport, frames) {
+        match self
+            .text_renderer
+            .render(pts, overlay.viewport, frames, style)
+        {
             Ok(Some(frame)) => overlay.subtitle_planes.extend(frame.planes),
             Ok(None) => {}
             Err(error) => {
@@ -1713,6 +1861,7 @@ impl SubtitleFrameState {
         pts: Duration,
         overlay: &mut OverlayFrame,
         frames: &[DecodedSubtitleFrame],
+        _style: SubtitleAssStyle,
     ) {
         append_text_subtitles_debug(pts, overlay, frames);
     }
@@ -1732,9 +1881,11 @@ impl CachedLibassTextRenderer {
         pts: Duration,
         viewport: OverlayViewport,
         frames: &[DecodedSubtitleFrame],
+        style: SubtitleAssStyle,
     ) -> crate::subtitle::Result<Option<crate::subtitle::SubtitleFrame>> {
         let fallback_end = pts.saturating_add(Duration::from_secs(24 * 60 * 60));
-        let Some(script) = decoded_subtitle_frames_to_ass_script(frames.iter(), fallback_end)
+        let Some(script) =
+            decoded_subtitle_frames_to_ass_script_with_style(frames.iter(), fallback_end, style)
         else {
             self.script = None;
             self.renderer = None;
@@ -1886,7 +2037,11 @@ mod tests {
         ));
         let mut overlay = empty_overlay();
 
-        state.append_to_overlay(Duration::from_secs(3), &mut overlay);
+        state.append_to_overlay(
+            Duration::from_secs(3),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
 
         assert_eq!(overlay.subtitle_planes.len(), 2);
         assert!(overlay.subtitle_changed);
@@ -1905,7 +2060,11 @@ mod tests {
         ));
         let mut overlay = empty_overlay();
 
-        state.append_to_overlay(Duration::from_secs(4), &mut overlay);
+        state.append_to_overlay(
+            Duration::from_secs(4),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
 
         assert_eq!(overlay.subtitle_planes.len(), 1);
 
@@ -1917,7 +2076,11 @@ mod tests {
             generation: 1,
         });
         let mut overlay = empty_overlay();
-        state.append_to_overlay(Duration::from_millis(4500), &mut overlay);
+        state.append_to_overlay(
+            Duration::from_millis(4500),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
 
         assert!(overlay.subtitle_planes.is_empty());
     }
@@ -1933,7 +2096,11 @@ mod tests {
         ));
         let mut overlay = empty_overlay();
 
-        state.append_to_overlay(Duration::from_secs(2), &mut overlay);
+        state.append_to_overlay(
+            Duration::from_secs(2),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
 
         assert!(!overlay.subtitle_planes.is_empty());
         assert!(overlay.subtitle_changed);

--- a/crates/erika/src/subtitle.rs
+++ b/crates/erika/src/subtitle.rs
@@ -548,6 +548,23 @@ impl Default for LibassRenderConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SubtitleAssStyle {
+    pub font_scale: f64,
+    pub play_res_width: u32,
+    pub play_res_height: u32,
+}
+
+impl Default for SubtitleAssStyle {
+    fn default() -> Self {
+        Self {
+            font_scale: 1.0,
+            play_res_width: 1920,
+            play_res_height: 1080,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LibassRenderOperation {
     SetFrameSize { width: u32, height: u32 },
@@ -1132,6 +1149,18 @@ pub fn decoded_subtitle_frames_to_ass_script<'a>(
     frames: impl IntoIterator<Item = &'a DecodedSubtitleFrame>,
     fallback_end: Duration,
 ) -> Option<String> {
+    decoded_subtitle_frames_to_ass_script_with_style(
+        frames,
+        fallback_end,
+        SubtitleAssStyle::default(),
+    )
+}
+
+pub fn decoded_subtitle_frames_to_ass_script_with_style<'a>(
+    frames: impl IntoIterator<Item = &'a DecodedSubtitleFrame>,
+    fallback_end: Duration,
+    style: SubtitleAssStyle,
+) -> Option<String> {
     let mut events = String::new();
     for frame in frames {
         if !frame.has_text() {
@@ -1168,7 +1197,7 @@ pub fn decoded_subtitle_frames_to_ass_script<'a>(
         return None;
     }
 
-    let mut script = String::from(DEFAULT_ASS_SCRIPT_HEADER);
+    let mut script = default_ass_script_header(style);
     script.push_str(&events);
     Some(script)
 }
@@ -1299,18 +1328,47 @@ fn escape_ass_text(value: &str) -> String {
     output
 }
 
-const DEFAULT_ASS_SCRIPT_HEADER: &str = r#"[Script Info]
+const DEFAULT_ASS_FONT_SIZE: f64 = 48.0;
+const DEFAULT_ASS_OUTLINE: f64 = 2.0;
+
+fn normalize_ass_font_scale(scale: f64) -> f64 {
+    if scale.is_finite() {
+        scale.clamp(0.25, 4.0)
+    } else {
+        1.0
+    }
+}
+
+fn ass_number(value: f64) -> String {
+    let rounded = (value * 100.0).round() / 100.0;
+    if rounded.fract().abs() < 0.001 {
+        format!("{rounded:.0}")
+    } else {
+        format!("{rounded:.2}")
+    }
+}
+
+fn default_ass_script_header(style: SubtitleAssStyle) -> String {
+    let scale = normalize_ass_font_scale(style.font_scale);
+    let font_size = ass_number(DEFAULT_ASS_FONT_SIZE * scale);
+    let outline = ass_number(DEFAULT_ASS_OUTLINE * scale);
+    let play_res_width = style.play_res_width.max(1);
+    let play_res_height = style.play_res_height.max(1);
+    format!(
+        r#"[Script Info]
 ScriptType: v4.00+
-PlayResX: 1920
-PlayResY: 1080
+PlayResX: {play_res_width}
+PlayResY: {play_res_height}
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,Arial,48,&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,2,0,2,48,48,54,1
+Style: Default,Arial,{font_size},&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,{outline},0,2,48,48,54,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-"#;
+"#
+    )
+}
 
 fn debug_rgba_plane(width: u32, height: u32) -> Vec<u8> {
     let mut rgba = vec![0u8; width as usize * height as usize * 4];
@@ -1462,6 +1520,58 @@ Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,Hello libass
         assert!(script.contains("[Script Info]"));
         assert!(script.contains("Dialogue: 0,0:00:01.25,0:00:02.50"));
         assert!(script.contains("hello\\Nworld"));
+    }
+
+    #[test]
+    fn decoded_plain_text_subtitle_ass_script_honors_font_scale() {
+        let mut frame = DecodedSubtitleFrame::new(
+            2,
+            Some(Duration::from_millis(1250)),
+            Some(Duration::from_millis(2500)),
+        );
+        frame.push_text(SubtitleTextSegment::new(
+            SubtitleTextFormat::PlainText,
+            "scaled",
+        ));
+
+        let script = decoded_subtitle_frames_to_ass_script_with_style(
+            [&frame],
+            Duration::from_secs(5),
+            SubtitleAssStyle {
+                font_scale: 1.5,
+                ..SubtitleAssStyle::default()
+            },
+        )
+        .unwrap();
+
+        assert!(script.contains("Style: Default,Arial,72,"));
+    }
+
+    #[test]
+    fn decoded_plain_text_subtitle_ass_script_uses_render_viewport_as_play_res() {
+        let mut frame = DecodedSubtitleFrame::new(
+            2,
+            Some(Duration::from_millis(1250)),
+            Some(Duration::from_millis(2500)),
+        );
+        frame.push_text(SubtitleTextSegment::new(
+            SubtitleTextFormat::PlainText,
+            "wide",
+        ));
+
+        let script = decoded_subtitle_frames_to_ass_script_with_style(
+            [&frame],
+            Duration::from_secs(5),
+            SubtitleAssStyle {
+                play_res_width: 1920,
+                play_res_height: 816,
+                ..SubtitleAssStyle::default()
+            },
+        )
+        .unwrap();
+
+        assert!(script.contains("PlayResX: 1920"));
+        assert!(script.contains("PlayResY: 816"));
     }
 
     #[test]

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -268,6 +268,7 @@ ErikaStatus erika_presenter_seek(ErikaPresenterHandle *handle, uint64_t position
 ErikaStatus erika_presenter_set_playback_rate(ErikaPresenterHandle *handle, double rate);
 ErikaStatus erika_presenter_set_volume(ErikaPresenterHandle *handle, double volume);
 ErikaStatus erika_presenter_set_upscaler(ErikaPresenterHandle *handle, int32_t mode);
+ErikaStatus erika_presenter_set_subtitle_scale(ErikaPresenterHandle *handle, double scale);
 ErikaStatus erika_presenter_get_upscaler_status(
     ErikaPresenterHandle *handle,
     ErikaUpscalerStatus *out_status);

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -950,6 +950,18 @@ pub unsafe extern "C" fn erika_presenter_set_upscaler(
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_subtitle_scale(
+    handle: *mut ErikaPresenterHandle,
+    scale: f64,
+) -> ErikaStatus {
+    with_presenter_mut(handle, |handle| {
+        handle.presenter.set_subtitle_scale(scale);
+        ErikaStatus::Ok
+    })
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_get_upscaler_status(
     handle: *mut ErikaPresenterHandle,
     out_status: *mut ErikaUpscalerStatus,
@@ -1454,6 +1466,15 @@ pub unsafe extern "C" fn erika_presenter_set_volume(
 pub unsafe extern "C" fn erika_presenter_set_upscaler(
     _handle: *mut std::ffi::c_void,
     _mode: i32,
+) -> ErikaStatus {
+    ErikaStatus::PlayerError
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_subtitle_scale(
+    _handle: *mut std::ffi::c_void,
+    _scale: f64,
 ) -> ErikaStatus {
     ErikaStatus::PlayerError
 }

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -294,6 +294,7 @@ private final class ErikaNativeLibrary {
   typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetUpscalerFn = @convention(c) (UnsafeMutableRawPointer?, Int32) -> Int32
+  typealias SetSubtitleScaleFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
@@ -353,6 +354,7 @@ private final class ErikaNativeLibrary {
   let setPlaybackRate: SetPlaybackRateFn?
   let setVolume: SetVolumeFn?
   let setUpscaler: SetUpscalerFn?
+  let setSubtitleScale: SetSubtitleScaleFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
@@ -408,6 +410,7 @@ private final class ErikaNativeLibrary {
     setPlaybackRate = Self.loadOptional("erika_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
     setVolume = Self.loadOptional("erika_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     setUpscaler = Self.loadOptional("erika_presenter_set_upscaler", from: libraryHandle, as: SetUpscalerFn.self)
+    setSubtitleScale = Self.loadOptional("erika_presenter_set_subtitle_scale", from: libraryHandle, as: SetSubtitleScaleFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("erika_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
@@ -576,6 +579,14 @@ private final class ErikaPlayerHost {
       throw ErikaPluginError.symbolMissing("erika_presenter_set_upscaler")
     }
     try check(setUpscaler(handle, mode), operation: "set_upscaler")
+  }
+
+  func setSubtitleScale(_ scale: Double) throws {
+    guard let setSubtitleScale = library.setSubtitleScale else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_subtitle_scale")
+    }
+    let clampedScale = scale.isFinite ? min(max(scale, 0.25), 4.0) : 1.0
+    try check(setSubtitleScale(handle, clampedScale), operation: "set_subtitle_scale")
   }
 
   func upscalerStatus() throws -> [String: Any] {
@@ -1359,6 +1370,13 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           throw ErikaPluginError.invalidArguments("mode is required.")
         }
         try playerHost(from: args).setUpscaler(mode: mode)
+        result(nil)
+      case "setSubtitleScale":
+        let args = try dictionaryArgs(call.arguments)
+        guard let scale = doubleValue(args["scale"]) else {
+          throw ErikaPluginError.invalidArguments("scale is required.")
+        }
+        try playerHost(from: args).setSubtitleScale(scale)
         result(nil)
       case "getUpscalerStatus":
         let args = try dictionaryArgs(call.arguments)

--- a/packages/erika_flutter/ios/erika_flutter.podspec
+++ b/packages/erika_flutter/ios/erika_flutter.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     erika_presenter_set_danmaku_track_enabled
     erika_presenter_set_danmaku_track_offset
     erika_presenter_set_playback_rate
+    erika_presenter_set_subtitle_scale
     erika_presenter_set_upscaler
     erika_presenter_set_volume
     erika_presenter_stop

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -113,8 +113,9 @@ class ErikaDanmakuTrackInfo {
     return ErikaDanmakuTrackInfo(
       id: (map['id'] as num?)?.toInt() ?? 0,
       enabled: map['enabled'] == true,
-      offset:
-          Duration(microseconds: (map['offsetMicros'] as num?)?.toInt() ?? 0),
+      offset: Duration(
+        microseconds: (map['offsetMicros'] as num?)?.toInt() ?? 0,
+      ),
       itemCount: (map['itemCount'] as num?)?.toInt() ?? 0,
       name: map['name'] as String?,
       source: map['source'] as String?,
@@ -224,27 +225,21 @@ class _ErikaDanmakuConfigPatch {
     );
   }
 
-  _ErikaDanmakuConfigPatch differenceFrom(
-    _ErikaDanmakuConfigPatch? previous,
-  ) {
+  _ErikaDanmakuConfigPatch differenceFrom(_ErikaDanmakuConfigPatch? previous) {
     return _ErikaDanmakuConfigPatch(
       enabled: _changed(enabled, previous?.enabled) ? enabled : null,
       fontSize: _changed(fontSize, previous?.fontSize) ? fontSize : null,
       opacity: _changed(opacity, previous?.opacity) ? opacity : null,
       displayArea:
           _changed(displayArea, previous?.displayArea) ? displayArea : null,
-      scrollDurationSeconds: _changed(
-        scrollDurationSeconds,
-        previous?.scrollDurationSeconds,
-      )
-          ? scrollDurationSeconds
-          : null,
-      scrollSpeedFactor: _changed(
-        scrollSpeedFactor,
-        previous?.scrollSpeedFactor,
-      )
-          ? scrollSpeedFactor
-          : null,
+      scrollDurationSeconds:
+          _changed(scrollDurationSeconds, previous?.scrollDurationSeconds)
+              ? scrollDurationSeconds
+              : null,
+      scrollSpeedFactor:
+          _changed(scrollSpeedFactor, previous?.scrollSpeedFactor)
+              ? scrollSpeedFactor
+              : null,
       trackGapRatio: _changed(trackGapRatio, previous?.trackGapRatio)
           ? trackGapRatio
           : null,
@@ -271,12 +266,10 @@ class _ErikaDanmakuConfigPatch {
       allowStacking: _changed(allowStacking, previous?.allowStacking)
           ? allowStacking
           : null,
-      allowScrollOverwrite: _changed(
-        allowScrollOverwrite,
-        previous?.allowScrollOverwrite,
-      )
-          ? allowScrollOverwrite
-          : null,
+      allowScrollOverwrite:
+          _changed(allowScrollOverwrite, previous?.allowScrollOverwrite)
+              ? allowScrollOverwrite
+              : null,
       maxQuantity:
           _changed(maxQuantity, previous?.maxQuantity) ? maxQuantity : null,
       maxLinesPerMode: _changed(maxLinesPerMode, previous?.maxLinesPerMode)
@@ -330,11 +323,7 @@ class _ErikaDanmakuConfigPatch {
 }
 
 class ErikaPlayer {
-  ErikaPlayer({
-    this.outputMode,
-    this.edrHeadroom,
-    this.hdrDebug = false,
-  }) {
+  ErikaPlayer({this.outputMode, this.edrHeadroom, this.hdrDebug = false}) {
     _eventSubscription ??= _events.receiveBroadcastStream().listen(
       _dispatchNativeEvent,
       onError: (Object error, StackTrace stackTrace) {
@@ -353,8 +342,9 @@ class ErikaPlayer {
   int? _id;
   Future<int>? _createFuture;
   bool _disposed = false;
-  static const Duration _danmakuConfigCoalesceDelay =
-      Duration(milliseconds: 50);
+  static const Duration _danmakuConfigCoalesceDelay = Duration(
+    milliseconds: 50,
+  );
   Timer? _danmakuConfigTimer;
   bool _danmakuConfigInFlight = false;
   _ErikaDanmakuConfigPatch? _pendingDanmakuConfig;
@@ -437,6 +427,15 @@ class ErikaPlayer {
     });
   }
 
+  Future<void> setSubtitleScale(double scale) async {
+    final playerId = await ensureCreated();
+    final clampedScale = scale.isFinite ? scale.clamp(0.25, 4.0) : 1.0;
+    await _invoke('setSubtitleScale', <String, Object?>{
+      'playerId': playerId,
+      'scale': clampedScale,
+    });
+  }
+
   Future<ErikaUpscalerStatus> getUpscalerStatus() async {
     final playerId = await ensureCreated();
     final status = await _channel.invokeMethod<Map<dynamic, dynamic>>(
@@ -451,15 +450,12 @@ class ErikaPlayer {
 
   Future<Uint8List?> screenshot({int? viewId, int? width, int? height}) async {
     final playerId = await ensureCreated();
-    return _channel.invokeMethod<Uint8List>(
-      'screenshot',
-      <String, Object?>{
-        'playerId': playerId,
-        if (viewId != null) 'viewId': viewId,
-        if (width != null) 'width': width,
-        if (height != null) 'height': height,
-      },
-    );
+    return _channel.invokeMethod<Uint8List>('screenshot', <String, Object?>{
+      'playerId': playerId,
+      if (viewId != null) 'viewId': viewId,
+      if (width != null) 'width': width,
+      if (height != null) 'height': height,
+    });
   }
 
   Future<int> addExternalSubtitle(String uri) async {
@@ -504,15 +500,13 @@ class ErikaPlayer {
     Duration offset = Duration.zero,
   }) async {
     final playerId = await ensureCreated();
-    final trackId = await _channel.invokeMethod<int>(
-      'addDanmakuTrackFile',
-      <String, Object?>{
-        'playerId': playerId,
-        'uri': uri,
-        if (name != null) 'name': name,
-        'offsetMicros': offset.inMicroseconds,
-      },
-    );
+    final trackId = await _channel
+        .invokeMethod<int>('addDanmakuTrackFile', <String, Object?>{
+      'playerId': playerId,
+      'uri': uri,
+      if (name != null) 'name': name,
+      'offsetMicros': offset.inMicroseconds,
+    });
     if (trackId == null || trackId <= 0) {
       throw StateError('Erika danmaku track add returned no track id.');
     }
@@ -525,15 +519,13 @@ class ErikaPlayer {
     Duration offset = Duration.zero,
   }) async {
     final playerId = await ensureCreated();
-    final trackId = await _channel.invokeMethod<int>(
-      'addDanmakuTrackJson',
-      <String, Object?>{
-        'playerId': playerId,
-        'json': json,
-        if (name != null) 'name': name,
-        'offsetMicros': offset.inMicroseconds,
-      },
-    );
+    final trackId = await _channel
+        .invokeMethod<int>('addDanmakuTrackJson', <String, Object?>{
+      'playerId': playerId,
+      'json': json,
+      if (name != null) 'name': name,
+      'offsetMicros': offset.inMicroseconds,
+    });
     if (trackId == null || trackId <= 0) {
       throw StateError('Erika danmaku track add returned no track id.');
     }
@@ -852,10 +844,7 @@ class ErikaPlayer {
     if (hdrDebug) {
       debugPrint('ErikaHDR[Dart]: create arguments=$arguments');
     }
-    final playerId = await _channel.invokeMethod<int>(
-      'create',
-      arguments,
-    );
+    final playerId = await _channel.invokeMethod<int>('create', arguments);
     if (playerId == null || playerId <= 0) {
       throw StateError('Erika presenter creation failed.');
     }

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -165,6 +165,7 @@ private final class ErikaNativeLibrary {
   typealias SetPlaybackRateFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetUpscalerFn = @convention(c) (UnsafeMutableRawPointer?, Int32) -> Int32
+  typealias SetSubtitleScaleFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
@@ -224,6 +225,7 @@ private final class ErikaNativeLibrary {
   let setPlaybackRate: SetPlaybackRateFn?
   let setVolume: SetVolumeFn?
   let setUpscaler: SetUpscalerFn?
+  let setSubtitleScale: SetSubtitleScaleFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
@@ -273,6 +275,7 @@ private final class ErikaNativeLibrary {
     setPlaybackRate = Self.loadOptional("erika_presenter_set_playback_rate", from: libraryHandle, as: SetPlaybackRateFn.self)
     setVolume = Self.loadOptional("erika_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     setUpscaler = Self.loadOptional("erika_presenter_set_upscaler", from: libraryHandle, as: SetUpscalerFn.self)
+    setSubtitleScale = Self.loadOptional("erika_presenter_set_subtitle_scale", from: libraryHandle, as: SetSubtitleScaleFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("erika_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
@@ -454,6 +457,14 @@ private final class ErikaPlayerHost {
       throw ErikaPluginError.symbolMissing("erika_presenter_set_upscaler")
     }
     try check(setUpscaler(handle, mode), operation: "set_upscaler")
+  }
+
+  func setSubtitleScale(_ scale: Double) throws {
+    guard let setSubtitleScale = library.setSubtitleScale else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_subtitle_scale")
+    }
+    let clampedScale = scale.isFinite ? min(max(scale, 0.25), 4.0) : 1.0
+    try check(setSubtitleScale(handle, clampedScale), operation: "set_subtitle_scale")
   }
 
   func upscalerStatus() throws -> [String: Any] {
@@ -1319,6 +1330,14 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           throw ErikaPluginError.invalidArguments("mode is required.")
         }
         try host.setUpscaler(mode: mode)
+        result(nil)
+      case "setSubtitleScale":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        guard let scale = doubleValue(args["scale"]) else {
+          throw ErikaPluginError.invalidArguments("scale is required.")
+        }
+        try host.setSubtitleScale(scale)
         result(nil)
       case "getUpscalerStatus":
         let args = try dictionaryArgs(call.arguments)


### PR DESCRIPTION
## Summary
- render text subtitles with ASS PlayRes matching the current video overlay viewport
- expose subtitle scale through presenter, C API, and Flutter plugin methods on macOS/iOS
- keep subtitle diagnostics behind ERIKA_SUBTITLE_DIAG

## Verification
- ERIKA_FFMPEG_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/ffmpeg ERIKA_LIBASS_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/libass ERIKA_FREETYPE_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/freetype ERIKA_HARFBUZZ_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/harfbuzz ERIKA_FRIBIDI_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/fribidi cargo test -p erika decoded_plain_text_subtitle_ass_script --features libass
- ERIKA_FFMPEG_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/ffmpeg ERIKA_LIBASS_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/libass ERIKA_FREETYPE_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/freetype ERIKA_HARFBUZZ_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/harfbuzz ERIKA_FRIBIDI_DIR=/Users/sakiko/Desktop/Erika/third_party/dist/lgpl/fribidi cargo check -p erika_capi