### PR TITLE
Fix macOS screenshot fallback return

### DIFF
--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -740,7 +740,7 @@ private final class ErikaPlayerHost {
     if let width, let height, let data = captureFrameRgba(width: width, height: height) {
       return data
     }
-    (view ?? attachedView)?.pngSnapshotData()
+    return (view ?? attachedView)?.pngSnapshotData()
   }
 
   func attach(view: ErikaMetalSurfaceView) throws {


### PR DESCRIPTION
## Summary
- add the missing explicit return for the macOS screenshot PNG fallback
- fixes Swift compile failure after the frame capture path made screenshot() no longer a single-expression function

## Verification
- local Nipa pub-cache patched with the same one-line fix for immediate macOS build testing