### PR TITLE
Clear stale visual state between media

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -420,6 +420,12 @@ pub trait RendererBackend {
     /// textures, wgpu textures, ...) so the presenter stays backend-agnostic.
     fn upload_player_frame(&mut self, frame: &PlayerVideoFrame) -> Result<()>;
 
+    /// Drop any retained video frame and clear the attached output surface when
+    /// the backend can do so.
+    fn clear_current_frame(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     /// Render the current frame (optionally compositing `overlay`) to the attached
     /// surface. Returns `false` if there is no current frame to draw, letting the
     /// caller fall back to a test frame.

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -560,7 +560,14 @@ impl SubtitleDecoder {
             return Ok(None);
         }
 
-        let frame = unsafe { import_av_subtitle(i64::from(self.stream_index), packet, &subtitle) };
+        let canvas = unsafe {
+            (
+                (*self.context).width.max(0) as u32,
+                (*self.context).height.max(0) as u32,
+            )
+        };
+        let frame =
+            unsafe { import_av_subtitle(i64::from(self.stream_index), packet, &subtitle, canvas) };
         unsafe { sys::avsubtitle_free(&mut subtitle) };
         frame.map(Some)
     }
@@ -1956,6 +1963,7 @@ unsafe fn import_av_subtitle(
     track_id: i64,
     packet: &Packet,
     subtitle: &sys::AVSubtitle,
+    canvas: (u32, u32),
 ) -> Result<DecodedSubtitleFrame> {
     let start = subtitle_start_time(packet, subtitle);
     let start_offset = Duration::from_millis(u64::from(subtitle.start_display_time));
@@ -1993,7 +2001,7 @@ unsafe fn import_av_subtitle(
             }
             sys::AVSubtitleType_SUBTITLE_BITMAP => {
                 if let Some(plane) = unsafe { subtitle_bitmap_rect_to_rgba_plane(rect) }? {
-                    frame.push_bitmap_plane(plane, forced);
+                    frame.push_bitmap_plane(plane.with_canvas(canvas.0, canvas.1), forced);
                 }
             }
             _ => {}
@@ -2076,13 +2084,13 @@ unsafe fn subtitle_bitmap_rect_to_rgba_plane(
         }
     }
 
-    Ok(Some(SubtitleBitmapPlane {
-        x: rect.x,
-        y: rect.y,
-        width: rect.w as u32,
-        height: rect.h as u32,
+    Ok(Some(SubtitleBitmapPlane::new(
+        rect.x,
+        rect.y,
+        rect.w as u32,
+        rect.h as u32,
         rgba,
-    }))
+    )))
 }
 
 fn palette_color_to_rgba(color: u32) -> [u8; 4] {
@@ -2472,7 +2480,7 @@ mod tests {
             ..sys::AVSubtitle::default()
         };
 
-        let frame = unsafe { import_av_subtitle(7, &packet, &subtitle) }.unwrap();
+        let frame = unsafe { import_av_subtitle(7, &packet, &subtitle, (0, 0)) }.unwrap();
 
         assert_eq!(frame.track_id, 7);
         assert_eq!(frame.start, Some(Duration::from_millis(1250)));
@@ -2516,7 +2524,7 @@ mod tests {
             ..sys::AVSubtitle::default()
         };
 
-        let frame = unsafe { import_av_subtitle(9, &packet, &subtitle) }.unwrap();
+        let frame = unsafe { import_av_subtitle(9, &packet, &subtitle, (1920, 1080)) }.unwrap();
 
         assert_eq!(frame.start, Some(Duration::from_secs(2)));
         assert_eq!(frame.end, Some(Duration::from_millis(2500)));
@@ -2526,6 +2534,7 @@ mod tests {
             (plane.x, plane.y, plane.width, plane.height),
             (11, 22, 2, 2)
         );
+        assert_eq!((plane.canvas_width, plane.canvas_height), (1920, 1080));
         assert_eq!(
             plane.rgba,
             vec![

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -491,11 +491,8 @@ impl PresenterRuntime {
     pub fn open(&mut self, media: MediaRequest) -> Result<()> {
         self.reset_audio_output();
         self.drain_pending_player_frames();
-        self.current_overlay = None;
-        self.clear_current_danmaku_state();
-        self.current_media_time = Duration::ZERO;
+        self.clear_playback_visual_state(Duration::ZERO);
         self.current_generation = self.current_generation.saturating_add(1).max(1);
-        self.last_audio_clock_sync = None;
         self.player.open(media)
     }
 
@@ -530,10 +527,8 @@ impl PresenterRuntime {
         let result = self.player.stop();
         self.reset_audio_output();
         self.drain_pending_player_frames();
-        self.current_overlay = None;
-        self.clear_current_danmaku_state();
-        self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
+        self.clear_playback_visual_state(Duration::ZERO);
         result
     }
 
@@ -541,10 +536,8 @@ impl PresenterRuntime {
         let result = self.player.close();
         self.reset_audio_output();
         self.drain_pending_player_frames();
-        self.current_overlay = None;
-        self.clear_current_danmaku_state();
-        self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
+        self.clear_playback_visual_state(Duration::ZERO);
         result
     }
 
@@ -552,11 +545,8 @@ impl PresenterRuntime {
         let result = self.player.seek(position);
         self.reset_audio_output();
         self.drain_pending_player_frames();
-        self.current_overlay = None;
-        self.clear_current_danmaku_state();
-        self.current_media_time = position;
-        self.last_audio_clock_sync = None;
         self.bump_danmaku_generation();
+        self.clear_playback_visual_state(position);
         result
     }
 
@@ -1311,6 +1301,18 @@ impl PresenterRuntime {
         self.current_danmaku_viewport = None;
     }
 
+    fn clear_playback_visual_state(&mut self, media_time: Duration) {
+        self.current_overlay = None;
+        self.subtitles.clear();
+        self.clear_current_danmaku_state();
+        self.current_media_time = media_time;
+        self.last_audio_clock_sync = None;
+        if let Err(error) = self.renderer.clear_current_frame() {
+            self.stats.render_failures += 1;
+            eprintln!("Erika presenter renderer clear failed: {error}");
+        }
+    }
+
     fn sync_danmaku_engine_timeline(&mut self) {
         let timeline = self.danmaku_session.active_timeline_clone();
         self.danmaku.sync_timeline(&timeline);
@@ -1774,6 +1776,14 @@ struct SubtitleFrameState {
 }
 
 impl SubtitleFrameState {
+    fn clear(&mut self) {
+        self.frames.clear();
+        #[cfg(feature = "libass")]
+        {
+            self.text_renderer.clear();
+        }
+    }
+
     fn push(&mut self, frame: PlayerSubtitleFrame) {
         self.retain_at(subtitle_start(&frame).unwrap_or(frame.media_time));
         if frame.frame.is_empty() {
@@ -1876,6 +1886,11 @@ struct CachedLibassTextRenderer {
 
 #[cfg(feature = "libass")]
 impl CachedLibassTextRenderer {
+    fn clear(&mut self) {
+        self.script = None;
+        self.renderer = None;
+    }
+
     fn render(
         &mut self,
         pts: Duration,
@@ -1939,13 +1954,7 @@ mod tests {
     fn subtitle_frame(start: Duration, end: Option<Duration>) -> PlayerSubtitleFrame {
         let mut frame = DecodedSubtitleFrame::new(2, Some(start), end);
         frame.push_bitmap_plane(
-            SubtitleBitmapPlane {
-                x: 0,
-                y: 0,
-                width: 1,
-                height: 1,
-                rgba: vec![255, 255, 255, 255],
-            },
+            SubtitleBitmapPlane::new(0, 0, 1, 1, vec![255, 255, 255, 255]),
             false,
         );
         PlayerSubtitleFrame {
@@ -2078,6 +2087,30 @@ mod tests {
         let mut overlay = empty_overlay();
         state.append_to_overlay(
             Duration::from_millis(4500),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
+
+        assert!(overlay.subtitle_planes.is_empty());
+    }
+
+    #[test]
+    fn subtitle_state_clear_removes_open_ended_bitmap_frames() {
+        let mut state = SubtitleFrameState::default();
+        state.push(subtitle_frame(Duration::from_secs(1), None));
+        let mut overlay = empty_overlay();
+
+        state.append_to_overlay(
+            Duration::from_secs(2),
+            &mut overlay,
+            SubtitleAssStyle::default(),
+        );
+        assert_eq!(overlay.subtitle_planes.len(), 1);
+
+        state.clear();
+        let mut overlay = empty_overlay();
+        state.append_to_overlay(
+            Duration::from_secs(3),
             &mut overlay,
             SubtitleAssStyle::default(),
         );

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -286,6 +286,10 @@ impl MetalRendererImpl {
         self.stats.prepared_overlay_subtitle_planes += info.subtitle_planes as u64;
     }
 
+    pub fn has_surface(&self) -> bool {
+        self.layer.is_some()
+    }
+
     pub fn render_clear(&mut self, color: ClearColor) -> Result<()> {
         let Some(layer) = &self.layer else {
             return Err(PlayerError::Renderer(
@@ -897,14 +901,16 @@ impl MetalRendererImpl {
 
         let pipeline = self.overlay_pipeline_state()?;
         let sampler = self.video_sampler_state()?;
+        let viewport_width = overlay.frame.viewport.width;
+        let viewport_height = overlay.frame.viewport.height;
         for plane in &overlay.frame.subtitle_planes {
             let texture = self.create_overlay_texture(
                 plane.width as usize,
                 plane.height as usize,
                 &plane.rgba,
             )?;
-            let uniforms =
-                OverlayUniforms::from_plane(plane.x, plane.y, plane.width, plane.height, layout);
+            let (x, y, width, height) = plane.scaled_rect(viewport_width, viewport_height);
+            let uniforms = OverlayUniforms::from_plane(x, y, width, height, layout);
             unsafe {
                 encoder.setRenderPipelineState(&pipeline);
                 encoder.setFragmentTexture_atIndex(Some(&*texture), 0);

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -32,6 +32,15 @@ pub struct ClearColor {
 }
 
 impl ClearColor {
+    pub fn black() -> Self {
+        Self {
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+            alpha: 1.0,
+        }
+    }
+
     pub fn animated(time_seconds: f64) -> Self {
         Self {
             red: time_seconds.sin() * 0.5 + 0.5,
@@ -654,6 +663,20 @@ impl RendererBackend for MetalRenderer {
         Ok(())
     }
 
+    fn clear_current_frame(&mut self) -> Result<()> {
+        self.current_frame = None;
+        self.current_media_time = Duration::ZERO;
+        self.current_generation = 1;
+        self.upload_counter = 0;
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        {
+            if self.inner.has_surface() {
+                self.inner.render_clear(ClearColor::black())?;
+            }
+        }
+        Ok(())
+    }
+
     fn render_test_frame(&mut self, time_seconds: f64) -> Result<()> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
@@ -862,13 +885,7 @@ mod tests {
         let frame = OverlayFrame {
             pts: Duration::from_secs(1),
             viewport: OverlayViewport::new(640, 360),
-            subtitle_planes: vec![SubtitleBitmapPlane {
-                x: 0,
-                y: 0,
-                width: 10,
-                height: 4,
-                rgba: vec![255; 10 * 4 * 4],
-            }],
+            subtitle_planes: vec![SubtitleBitmapPlane::new(0, 0, 10, 4, vec![255; 10 * 4 * 4])],
             subtitle_alpha_planes: Vec::new(),
             subtitle_changed: true,
         };
@@ -927,13 +944,7 @@ mod tests {
         let frame = OverlayFrame {
             pts: Duration::ZERO,
             viewport: OverlayViewport::new(1, 1),
-            subtitle_planes: vec![SubtitleBitmapPlane {
-                x: 0,
-                y: 0,
-                width: 2,
-                height: 2,
-                rgba: vec![0; 15],
-            }],
+            subtitle_planes: vec![SubtitleBitmapPlane::new(0, 0, 2, 2, vec![0; 15])],
             subtitle_alpha_planes: Vec::new(),
             subtitle_changed: true,
         };

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -852,14 +852,8 @@ impl WgpuRenderer {
                 &plane.rgba,
                 plane.width * 4,
             );
-            let uniforms = OverlayUniforms::rgba_plane(
-                plane.x,
-                plane.y,
-                plane.width,
-                plane.height,
-                viewport_w,
-                viewport_h,
-            );
+            let (x, y, width, height) = plane.scaled_rect(viewport_w, viewport_h);
+            let uniforms = OverlayUniforms::rgba_plane(x, y, width, height, viewport_w, viewport_h);
             draws.push(self.make_overlay_draw(&texture, uniforms));
         }
 
@@ -1550,6 +1544,14 @@ impl RendererBackend for WgpuRenderer {
             VideoRenderPipeline::new(source, TargetColorState::sdr(ColorPrimaries::Bt709));
         let uniforms = VideoUniforms::from_pipeline(&pipeline, is_p010, false);
         self.upload_planar_with_context(planar, uniforms)
+    }
+
+    fn clear_current_frame(&mut self) -> Result<()> {
+        self.current_video = None;
+        if self.surface.is_some() {
+            self.render_surface_clear(WgpuClearColor::new(0.0, 0.0, 0.0, 1.0))?;
+        }
+        Ok(())
     }
 
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {

--- a/crates/erika/src/subtitle.rs
+++ b/crates/erika/src/subtitle.rs
@@ -224,7 +224,51 @@ pub struct SubtitleBitmapPlane {
     pub y: i32,
     pub width: u32,
     pub height: u32,
+    pub canvas_width: u32,
+    pub canvas_height: u32,
     pub rgba: Vec<u8>,
+}
+
+impl SubtitleBitmapPlane {
+    pub fn new(x: i32, y: i32, width: u32, height: u32, rgba: Vec<u8>) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+            canvas_width: 0,
+            canvas_height: 0,
+            rgba,
+        }
+    }
+
+    pub fn with_canvas(mut self, width: u32, height: u32) -> Self {
+        self.canvas_width = width;
+        self.canvas_height = height;
+        self
+    }
+
+    pub fn scaled_rect(&self, viewport_width: u32, viewport_height: u32) -> (i32, i32, u32, u32) {
+        if self.canvas_width == 0
+            || self.canvas_height == 0
+            || (self.canvas_width == viewport_width && self.canvas_height == viewport_height)
+        {
+            return (self.x, self.y, self.width, self.height);
+        }
+        let viewport_width = viewport_width.max(1) as f64;
+        let viewport_height = viewport_height.max(1) as f64;
+        let canvas_width = self.canvas_width.max(1) as f64;
+        let canvas_height = self.canvas_height.max(1) as f64;
+        let scale = (viewport_width / canvas_width).max(viewport_height / canvas_height);
+        let offset_x = (viewport_width - canvas_width * scale) * 0.5;
+        let offset_y = (viewport_height - canvas_height * scale) * 0.5;
+        (
+            (offset_x + self.x as f64 * scale).round() as i32,
+            (offset_y + self.y as f64 * scale).round() as i32,
+            ((self.width as f64 * scale).round() as u32).max(1),
+            ((self.height as f64 * scale).round() as u32).max(1),
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -332,13 +376,13 @@ impl SubtitleAlphaBitmap {
             }
         }
 
-        Some(SubtitleBitmapPlane {
-            x: self.placement.x,
-            y: self.placement.y,
-            width: self.placement.width,
-            height: self.placement.height,
+        Some(SubtitleBitmapPlane::new(
+            self.placement.x,
+            self.placement.y,
+            self.placement.width,
+            self.placement.height,
             rgba,
-        })
+        ))
     }
 }
 
@@ -1030,13 +1074,13 @@ impl SubtitleTimeline {
             let y = height
                 .saturating_sub(plane_height.saturating_mul(index as u32 + 1))
                 .saturating_sub(24) as i32;
-            planes.push(SubtitleBitmapPlane {
+            planes.push(SubtitleBitmapPlane::new(
                 x,
                 y,
-                width: plane_width,
-                height: plane_height,
-                rgba: debug_rgba_plane(plane_width, plane_height),
-            });
+                plane_width,
+                plane_height,
+                debug_rgba_plane(plane_width, plane_height),
+            ));
         }
         SubtitleFrame { pts, planes }
     }
@@ -1483,6 +1527,13 @@ Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,Hello libass
             Some(SubtitleFileFormat::Ass)
         );
         assert_eq!(SubtitleFileFormat::from_path("/tmp/movie.sup"), None);
+    }
+
+    #[test]
+    fn bitmap_plane_scales_from_subtitle_canvas_to_video_viewport() {
+        let plane = SubtitleBitmapPlane::new(800, 905, 322, 60, Vec::new()).with_canvas(1920, 1080);
+
+        assert_eq!(plane.scaled_rect(3840, 1816), (1600, 1638, 644, 120));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- clear retained video frames, overlays, danmaku, and subtitle frame state when opening, stopping, closing, or seeking media
- add renderer backend hooks so Metal and wgpu drop/present a cleared frame instead of showing the previous video
- preserve bitmap subtitle canvas dimensions and scale PGS planes into the active video viewport

## Testing
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika --features wgpu wgpu_renderer_is_usable_as_dyn_backend_and_reports_no_current_frame
- Verified via NipaPlay macOS debug playback that stale PGS/video frames clear and the affected PGS subtitle is positioned correctly
