### PR TITLE
fix(flutter): sync Swift ErikaPresenterStatsC with C ABI (fix macOS/iOS crash)

### DIFF
--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -202,6 +202,27 @@ private struct ErikaPresenterStatsC {
   var importFailures: UInt64 = 0
   var renderFailures: UInt64 = 0
   var audioFailures: UInt64 = 0
+  // The fields below must mirror `ErikaPresenterStats` in
+  // crates/erika_capi/include/erika.h exactly (order and types). erika_presenter_render_tick
+  // writes the full struct through this pointer, so any missing field overflows the buffer.
+  var softwareVideoFrames: UInt64 = 0
+  var hardwareVideoFrames: UInt64 = 0
+  var zeroCopyVideoFrames: UInt64 = 0
+  var cpuVideoFrameFallbacks: UInt64 = 0
+  var lastRenderMicros: UInt64 = 0
+  var lastRenderCurrentMicros: UInt64 = 0
+  var audioClockReadFrames: UInt64 = 0
+  var audioClockQueuedFrames: UInt64 = 0
+  var audioClockUnderflowFrames: UInt64 = 0
+  var directZeroCopyVideoFrames: UInt64 = 0
+  var sharedHandleVideoFrames: UInt64 = 0
+  var hdrSourceFrames: UInt64 = 0
+  var hdr10OutputFrames: UInt64 = 0
+  var sdrTonemapFrames: UInt64 = 0
+  var hdr10MetadataUpdates: UInt64 = 0
+  var hdr10MetadataFailures: UInt64 = 0
+  var hdr10OutputFailures: UInt64 = 0
+  var hdr10OutputActive: Bool = false
 }
 
 private struct ErikaUpscalerStatusC {

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -74,6 +74,27 @@ private struct ErikaPresenterStatsC {
   var importFailures: UInt64 = 0
   var renderFailures: UInt64 = 0
   var audioFailures: UInt64 = 0
+  // The fields below must mirror `ErikaPresenterStats` in
+  // crates/erika_capi/include/erika.h exactly (order and types). erika_presenter_render_tick
+  // writes the full struct through this pointer, so any missing field overflows the buffer.
+  var softwareVideoFrames: UInt64 = 0
+  var hardwareVideoFrames: UInt64 = 0
+  var zeroCopyVideoFrames: UInt64 = 0
+  var cpuVideoFrameFallbacks: UInt64 = 0
+  var lastRenderMicros: UInt64 = 0
+  var lastRenderCurrentMicros: UInt64 = 0
+  var audioClockReadFrames: UInt64 = 0
+  var audioClockQueuedFrames: UInt64 = 0
+  var audioClockUnderflowFrames: UInt64 = 0
+  var directZeroCopyVideoFrames: UInt64 = 0
+  var sharedHandleVideoFrames: UInt64 = 0
+  var hdrSourceFrames: UInt64 = 0
+  var hdr10OutputFrames: UInt64 = 0
+  var sdrTonemapFrames: UInt64 = 0
+  var hdr10MetadataUpdates: UInt64 = 0
+  var hdr10MetadataFailures: UInt64 = 0
+  var hdr10OutputFailures: UInt64 = 0
+  var hdr10OutputActive: Bool = false
 }
 
 private struct ErikaUpscalerStatusC {


### PR DESCRIPTION
## Problem
On macOS/iOS the app crashes shortly after starting playback with:

```
objc[*]: autorelease pool page 0x... corrupted
  magic     0x........ ...
  should be 0xa1a1a1a1 0x4f545541 ...
```

(SIGABRT on the main thread, inside `objc_autoreleasePoolPop`.) The pool page is a bystander — its memory gets stomped by a stack buffer overflow.

## Root cause
The macOS/iOS Swift plugins hand-mirror the C `ErikaPresenterStats` as a private `ErikaPresenterStatsC` struct and pass a pointer to a **stack-local** instance into `erika_presenter_render_tick`:

```swift
var stats = ErikaPresenterStatsC()          // 10 fields = 80 bytes
library.renderTick(handle, t, &stats)        // Rust writes 28 fields = 224 bytes
```

`ErikaPresenterStats` grew from 10 → **28 fields** (HDR / zero-copy / audio-clock counters), but the Swift mirror was never updated. So `render_tick` writes ~144 bytes past the 80-byte buffer **every tick**, corrupting adjacent stack memory. The Windows C++ plugin includes `erika.h` directly, so it was unaffected; only the hand-maintained Swift mirrors drifted.

## Fix
Add the 18 missing fields (in exact C-header order) to `ErikaPresenterStatsC` in both the macOS and iOS plugins, with a comment that it must mirror `erika.h`.

Verified the field order/types against `crates/erika_capi/include/erika.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)