### PR TITLE
Keep last frame available for screenshots

### DIFF
--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -57,6 +57,7 @@ pub struct MetalRenderer {
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     _unsupported: (),
     current_frame: Option<ImportedVideoFrame>,
+    current_frame_visible: bool,
     current_media_time: Duration,
     current_generation: u64,
     upload_counter: u64,
@@ -376,6 +377,7 @@ impl MetalRenderer {
             Ok(Self {
                 inner: apple::MetalRendererImpl::new(_config)?,
                 current_frame: None,
+                current_frame_visible: false,
                 current_media_time: Duration::ZERO,
                 current_generation: 1,
                 upload_counter: 0,
@@ -664,10 +666,9 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn clear_current_frame(&mut self) -> Result<()> {
-        self.current_frame = None;
+        self.current_frame_visible = false;
         self.current_media_time = Duration::ZERO;
         self.current_generation = 1;
-        self.upload_counter = 0;
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             if self.inner.has_surface() {
@@ -706,6 +707,7 @@ impl RendererBackend for MetalRenderer {
         let started = std::time::Instant::now();
         let imported = self.import_player_frame(&frame.frame)?;
         self.current_frame = Some(imported);
+        self.current_frame_visible = true;
         self.current_media_time = frame.pts.unwrap_or(frame.media_time);
         self.current_generation = frame.generation.max(1);
         self.upload_counter = self.upload_counter.wrapping_add(1);
@@ -732,6 +734,9 @@ impl RendererBackend for MetalRenderer {
     }
 
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {
+        if !self.current_frame_visible {
+            return Ok(false);
+        }
         let Some(frame) = self.current_frame.take() else {
             if trace::enabled() {
                 trace::log(format!(

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -264,6 +264,7 @@ pub struct WgpuRenderer {
     video_pipeline: Option<VideoPipeline>,
     overlay_pipeline: Option<OverlayPipeline>,
     current_video: Option<UploadedVideoFrame>,
+    current_video_visible: bool,
     danmaku_atlas_cache: Option<WgpuDanmakuAtlasCache>,
     supports_16bit_norm: bool,
     upscaler_mode: LumaUpscalerMode,
@@ -315,6 +316,7 @@ impl WgpuRenderer {
             video_pipeline: None,
             overlay_pipeline: None,
             current_video: None,
+            current_video_visible: false,
             danmaku_atlas_cache: None,
             supports_16bit_norm,
             upscaler_mode: LumaUpscalerMode::Off,
@@ -594,6 +596,7 @@ impl WgpuRenderer {
             height,
             uniforms,
         });
+        self.current_video_visible = true;
         Ok(())
     }
 
@@ -1512,7 +1515,7 @@ impl RendererBackend for WgpuRenderer {
     }
 
     fn clear_current_frame(&mut self) -> Result<()> {
-        self.current_video = None;
+        self.current_video_visible = false;
         if self.surface.is_some() {
             self.render_surface_clear(WgpuClearColor::new(0.0, 0.0, 0.0, 1.0))?;
         }
@@ -1520,7 +1523,7 @@ impl RendererBackend for WgpuRenderer {
     }
 
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {
-        if self.current_video.is_none() {
+        if !self.current_video_visible || self.current_video.is_none() {
             return Ok(false);
         }
         let Some(format) = self.surface.as_ref().map(|attached| attached.config.format) else {


### PR DESCRIPTION
## Summary
- keep renderer-retained video frames available after playback visual clear
- hide cleared frames from presentation while preserving them for screenshot capture
- apply the same behavior to Metal and WGPU renderers

## Tests
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika --features wgpu wgpu_renderer_is_usable_as_dyn_backend_and_reports_no_current_frame