### PR TITLE
Fix fast-forward audio clock handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,26 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -183,6 +203,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -370,6 +392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "soundtouch",
  "thiserror",
  "ureq",
  "wgpu",
@@ -389,7 +412,7 @@ dependencies = [
 name = "erika_ffmpeg_sys"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "libc",
 ]
 
@@ -528,6 +551,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -713,6 +748,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1218,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,7 +1351,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1454,6 +1505,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "soundtouch"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a9d07f6efdc0d9e76f0a14bea5f0cfd8b90f3ae2d3d63bd1710867864630e3"
+dependencies = [
+ "soundtouch-ffi",
+]
+
+[[package]]
+name = "soundtouch-ffi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6ff07be0b6d38d9244184d1b094dc08c52f5a1d1d23256089c3599faaeb57e"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+]
+
+[[package]]
 name = "spirv"
 version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1671,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1894,7 +1973,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2096,6 +2175,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rustc-hash = "2.1.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 smallvec = "1.15.1"
+soundtouch = { version = "0.5.4", features = ["bundled"] }
 coreaudio-rs = "0.14.2"
 libc = "0.2.177"
 objc2 = "0.6.3"

--- a/crates/erika/Cargo.toml
+++ b/crates/erika/Cargo.toml
@@ -24,6 +24,7 @@ rustc-hash.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smallvec.workspace = true
+soundtouch.workspace = true
 thiserror.workspace = true
 ureq.workspace = true
 wgpu = { version = "29.0.3", optional = true }

--- a/crates/erika/src/apple.rs
+++ b/crates/erika/src/apple.rs
@@ -346,6 +346,12 @@ pub mod iosaudio {
             IosAudioQueueOutput::volume(self)
         }
 
+        fn set_playback_rate(&mut self, rate: f64) {
+            if let Ok(mut buffer) = self.buffer.lock() {
+                buffer.set_playback_rate(rate);
+            }
+        }
+
         fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {
             IosAudioQueueOutput::push(self, frame)
                 .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))
@@ -650,6 +656,12 @@ pub mod coreaudio {
 
         fn volume(&self) -> f32 {
             CoreAudioOutput::volume(self)
+        }
+
+        fn set_playback_rate(&mut self, rate: f64) {
+            if let Ok(mut buffer) = self.buffer.lock() {
+                buffer.set_playback_rate(rate);
+            }
         }
 
         fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {

--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -1,10 +1,16 @@
 use std::collections::VecDeque;
 use std::time::Duration;
 
+use soundtouch::{Setting, SoundTouch};
 use thiserror::Error;
 
 use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
 use crate::trace;
+
+const RATE_CHANGE_AUDIO_BRIDGE: Duration = Duration::from_millis(80);
+const SOUNDTOUCH_SEQUENCE_MS: i32 = 25;
+const SOUNDTOUCH_SEEK_WINDOW_MS: i32 = 12;
+const SOUNDTOUCH_OVERLAP_MS: i32 = 6;
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AudioError {
@@ -78,15 +84,98 @@ pub struct AudioClockSnapshot {
     pub underflow_frames: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 struct AudioTimelineSegment {
     start: Option<Duration>,
     frames: usize,
+    media_frames_per_output_frame: f64,
 }
 
 impl AudioTimelineSegment {
-    fn new(start: Option<Duration>, frames: usize) -> Self {
-        Self { start, frames }
+    fn new(start: Option<Duration>, frames: usize, media_frames_per_output_frame: f64) -> Self {
+        Self {
+            start,
+            frames,
+            media_frames_per_output_frame,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AudioTempoProcessor {
+    format: PcmFormat,
+    playback_rate: f64,
+    processor: SoundTouch,
+    pending_pts: Option<Duration>,
+}
+
+impl AudioTempoProcessor {
+    fn new(format: PcmFormat, playback_rate: f64) -> Self {
+        let playback_rate = normalize_playback_rate(playback_rate);
+        let mut processor = SoundTouch::new();
+        processor
+            .set_sample_rate(format.sample_rate.max(8_000))
+            .set_channels(format.channels.max(1) as u32)
+            .set_tempo(playback_rate)
+            .set_setting(Setting::UseQuickseek, 1)
+            .set_setting(Setting::SequenceMs, SOUNDTOUCH_SEQUENCE_MS)
+            .set_setting(Setting::SeekwindowMs, SOUNDTOUCH_SEEK_WINDOW_MS)
+            .set_setting(Setting::OverlapMs, SOUNDTOUCH_OVERLAP_MS);
+        Self {
+            format,
+            playback_rate,
+            processor,
+            pending_pts: None,
+        }
+    }
+
+    fn matches(&self, format: PcmFormat, playback_rate: f64) -> bool {
+        self.format == format
+            && (self.playback_rate - normalize_playback_rate(playback_rate)).abs() < 0.001
+    }
+
+    fn process(&mut self, frame: PcmAudioFrame) -> (Vec<f32>, Option<Duration>, f64) {
+        let channels = self.format.channels.max(1) as usize;
+        let input_frames = frame.samples.len() / channels;
+        if input_frames == 0 {
+            return (Vec::new(), frame.pts, self.playback_rate);
+        }
+        if self.pending_pts.is_none() {
+            self.pending_pts = frame.pts;
+        }
+        self.processor.put_samples(&frame.samples, input_frames);
+        let output = self.receive_available();
+        let start = self.pending_pts;
+        let output_frames = output.len() / channels;
+        if output_frames > 0 {
+            if let Some(start) = self.pending_pts {
+                self.pending_pts = offset_pts_scaled(
+                    start,
+                    output_frames,
+                    self.format.sample_rate,
+                    self.playback_rate,
+                );
+            }
+        }
+        (output, start, self.playback_rate)
+    }
+
+    fn receive_available(&mut self) -> Vec<f32> {
+        const OUTPUT_FRAMES: usize = 4096;
+        let channels = self.format.channels.max(1) as usize;
+        let mut chunk = vec![0.0f32; OUTPUT_FRAMES * channels];
+        let mut output = Vec::new();
+        loop {
+            let frames = self.processor.receive_samples(&mut chunk, OUTPUT_FRAMES);
+            if frames == 0 {
+                break;
+            }
+            output.extend_from_slice(&chunk[..frames * channels]);
+            if frames < OUTPUT_FRAMES {
+                break;
+            }
+        }
+        output
     }
 }
 
@@ -97,6 +186,8 @@ pub struct AudioRingBuffer {
     samples: VecDeque<f32>,
     timeline: VecDeque<AudioTimelineSegment>,
     last_media_time: Option<Duration>,
+    playback_rate: f64,
+    tempo_processor: Option<AudioTempoProcessor>,
     stats: AudioRingBufferStats,
 }
 
@@ -108,6 +199,8 @@ impl AudioRingBuffer {
             samples: VecDeque::new(),
             timeline: VecDeque::new(),
             last_media_time: None,
+            playback_rate: 1.0,
+            tempo_processor: None,
             stats: AudioRingBufferStats::default(),
         }
     }
@@ -179,8 +272,19 @@ impl AudioRingBuffer {
         self.samples.clear();
         self.timeline.clear();
         self.last_media_time = None;
+        self.tempo_processor = None;
         self.stats.queued_frames = 0;
         self.stats.queued_samples = 0;
+    }
+
+    pub fn set_playback_rate(&mut self, rate: f64) {
+        let rate = normalize_playback_rate(rate);
+        if (self.playback_rate - rate).abs() <= 0.001 {
+            return;
+        }
+        self.playback_rate = rate;
+        self.tempo_processor = None;
+        self.trim_queued_to_front_frames(self.rate_change_bridge_frames());
     }
 
     pub fn push_frame(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult> {
@@ -197,10 +301,23 @@ impl AudioRingBuffer {
 
         let format = self.format.expect("audio format exists");
         let channels = format.channels as usize;
-        let incoming_frames = frame.samples.len() / channels;
+        let original_frames = frame.samples.len() / channels;
         let mut dropped_frames = 0usize;
         let frame_pts = frame.pts;
-        let frame_samples = frame.samples;
+        let (frame_samples, segment_start, media_frames_per_output_frame) =
+            self.prepare_frame_samples(frame, format);
+        let incoming_frames = frame_samples.len() / channels;
+        if incoming_frames == 0 {
+            return Ok(AudioPushResult {
+                accepted_frames: 0,
+                dropped_frames: 0,
+            });
+        }
+        let media_frames_per_output_frame = if media_frames_per_output_frame > 0.0 {
+            media_frames_per_output_frame
+        } else {
+            original_frames as f64 / incoming_frames.max(1) as f64
+        };
 
         if self.config.drop_oldest_on_overflow {
             while self.queued_frames() + incoming_frames > self.config.capacity_frames {
@@ -232,8 +349,16 @@ impl AudioRingBuffer {
                 .take(accepted_samples),
         );
         self.push_timeline_segment(
-            frame_pts.and_then(|pts| offset_pts(pts, skip_incoming_frames, format.sample_rate)),
+            segment_start.and_then(|pts| {
+                offset_pts_scaled(
+                    pts,
+                    skip_incoming_frames,
+                    format.sample_rate,
+                    media_frames_per_output_frame,
+                )
+            }),
             accepted_frames,
+            media_frames_per_output_frame,
         );
         self.stats.written_frames += accepted_frames as u64;
         self.stats.dropped_frames +=
@@ -326,6 +451,24 @@ impl AudioRingBuffer {
         })
     }
 
+    fn prepare_frame_samples(
+        &mut self,
+        frame: PcmAudioFrame,
+        format: PcmFormat,
+    ) -> (Vec<f32>, Option<Duration>, f64) {
+        if (self.playback_rate - 1.0).abs() <= 0.001 {
+            self.tempo_processor = None;
+            return (frame.samples, frame.pts, 1.0);
+        }
+        let processor = self
+            .tempo_processor
+            .get_or_insert_with(|| AudioTempoProcessor::new(format, self.playback_rate));
+        if !processor.matches(format, self.playback_rate) {
+            *processor = AudioTempoProcessor::new(format, self.playback_rate);
+        }
+        processor.process(frame)
+    }
+
     fn drop_oldest_frame(&mut self, channels: usize) -> bool {
         if self.samples.len() < channels {
             self.samples.clear();
@@ -338,12 +481,58 @@ impl AudioRingBuffer {
         true
     }
 
-    fn push_timeline_segment(&mut self, start: Option<Duration>, frames: usize) {
+    fn rate_change_bridge_frames(&self) -> usize {
+        self.format.map_or(0, |format| {
+            (format.sample_rate as f64 * RATE_CHANGE_AUDIO_BRIDGE.as_secs_f64()).round() as usize
+        })
+    }
+
+    fn trim_queued_to_front_frames(&mut self, frames: usize) {
+        let Some(format) = self.format else {
+            self.samples.clear();
+            self.timeline.clear();
+            return;
+        };
+        let channels = format.channels as usize;
+        let target_samples = frames.saturating_mul(channels);
+        if self.samples.len() > target_samples {
+            self.samples.truncate(target_samples);
+        }
+        self.trim_timeline_to_front_frames(self.samples.len() / channels.max(1));
+    }
+
+    fn trim_timeline_to_front_frames(&mut self, mut frames: usize) {
+        let mut trimmed = VecDeque::new();
+        while frames > 0 {
+            let Some(mut segment) = self.timeline.pop_front() else {
+                break;
+            };
+            if segment.frames <= frames {
+                frames -= segment.frames;
+                trimmed.push_back(segment);
+            } else {
+                segment.frames = frames;
+                trimmed.push_back(segment);
+                break;
+            }
+        }
+        self.timeline = trimmed;
+    }
+
+    fn push_timeline_segment(
+        &mut self,
+        start: Option<Duration>,
+        frames: usize,
+        media_frames_per_output_frame: f64,
+    ) {
         if frames == 0 {
             return;
         }
-        self.timeline
-            .push_back(AudioTimelineSegment::new(start, frames));
+        self.timeline.push_back(AudioTimelineSegment::new(
+            start,
+            frames,
+            media_frames_per_output_frame,
+        ));
     }
 
     fn advance_timeline(&mut self, mut frames: usize, sample_rate: u32) {
@@ -353,7 +542,12 @@ impl AudioRingBuffer {
             };
             let consumed = frames.min(front.frames);
             if let Some(start) = front.start {
-                self.last_media_time = offset_pts(start, consumed, sample_rate);
+                self.last_media_time = offset_pts_scaled(
+                    start,
+                    consumed,
+                    sample_rate,
+                    front.media_frames_per_output_frame,
+                );
                 front.start = self.last_media_time;
             }
             front.frames -= consumed;
@@ -372,6 +566,7 @@ pub trait AudioOutputBackend {
     fn stop(&mut self) -> Result<()>;
     fn set_volume(&mut self, volume: f32);
     fn volume(&self) -> f32;
+    fn set_playback_rate(&mut self, _rate: f64) {}
     fn push(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult>;
     fn state(&self) -> AudioOutputState;
     fn stats(&self) -> AudioRingBufferStats;
@@ -444,6 +639,10 @@ impl AudioOutputBackend for BufferedAudioOutput {
         self.volume
     }
 
+    fn set_playback_rate(&mut self, rate: f64) {
+        self.buffer.set_playback_rate(rate);
+    }
+
     fn push(&mut self, frame: PcmAudioFrame) -> Result<AudioPushResult> {
         self.buffer.push_frame(frame)
     }
@@ -479,11 +678,25 @@ pub fn apply_volume(samples: &mut [f32], volume: f32) {
     }
 }
 
-fn offset_pts(pts: Duration, frames: usize, sample_rate: u32) -> Option<Duration> {
+fn offset_pts_scaled(
+    pts: Duration,
+    frames: usize,
+    sample_rate: u32,
+    media_frames_per_output_frame: f64,
+) -> Option<Duration> {
     if sample_rate == 0 {
         return Some(pts);
     }
-    Some(pts + Duration::from_secs_f64(frames as f64 / sample_rate as f64))
+    let media_frames = frames as f64 * media_frames_per_output_frame.max(0.0);
+    Some(pts + Duration::from_secs_f64(media_frames / sample_rate as f64))
+}
+
+fn normalize_playback_rate(rate: f64) -> f64 {
+    if rate.is_finite() && rate > 0.0 {
+        rate.clamp(0.25, 4.0)
+    } else {
+        1.0
+    }
 }
 
 #[cfg(test)]
@@ -627,6 +840,64 @@ mod tests {
     }
 
     #[test]
+    fn ring_buffer_fast_rate_preserves_pitch_and_media_timeline() {
+        let mut buffer = AudioRingBuffer::with_format(
+            AudioRingBufferConfig {
+                capacity_frames: 48_000,
+                drop_oldest_on_overflow: true,
+            },
+            stereo_format(),
+        )
+        .unwrap();
+        buffer.set_playback_rate(2.0);
+        for index in 0..8 {
+            buffer
+                .push_frame(timed_frame(
+                    Duration::from_secs(10)
+                        + Duration::from_secs_f64(index as f64 * 2048.0 / 48_000.0),
+                    2048,
+                ))
+                .unwrap();
+        }
+
+        let queued_frames = buffer.clock_snapshot().queued_frames;
+        assert!(queued_frames > 0);
+        assert!(queued_frames < 16_384);
+
+        let mut output = vec![0.0; queued_frames * 2];
+        let result = buffer.read_interleaved(&mut output).unwrap();
+
+        assert_eq!(result.frames, queued_frames);
+        let media_time = buffer.clock_snapshot().media_time.unwrap();
+        let expected = Duration::from_secs(10)
+            + Duration::from_secs_f64(queued_frames as f64 * 2.0 / 48_000.0);
+        assert!(duration_abs_diff(media_time, expected) < Duration::from_millis(2));
+    }
+
+    #[test]
+    fn ring_buffer_rate_change_keeps_short_audio_bridge() {
+        let mut buffer = AudioRingBuffer::with_format(
+            AudioRingBufferConfig {
+                capacity_frames: 48_000,
+                drop_oldest_on_overflow: true,
+            },
+            stereo_format(),
+        )
+        .unwrap();
+        buffer
+            .push_frame(timed_frame(Duration::from_secs(4), 4_800))
+            .unwrap();
+
+        buffer.set_playback_rate(2.0);
+
+        assert_eq!(buffer.clock_snapshot().queued_frames, 3_840);
+        assert_eq!(
+            buffer.clock_snapshot().media_time,
+            Some(Duration::from_secs(4))
+        );
+    }
+
+    #[test]
     fn ring_buffer_clock_survives_frame_drop() {
         let mut buffer = AudioRingBuffer::with_format(
             AudioRingBufferConfig {
@@ -644,5 +915,11 @@ mod tests {
             buffer.clock_snapshot().media_time,
             Some(Duration::from_nanos(1_000_041_667))
         );
+    }
+
+    fn duration_abs_diff(a: Duration, b: Duration) -> Duration {
+        a.checked_sub(b)
+            .or_else(|| b.checked_sub(a))
+            .unwrap_or(Duration::ZERO)
     }
 }

--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -18,9 +18,9 @@ use crate::trace;
 static NEXT_PLAYER_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_EXTERNAL_SUBTITLE_TRACK_ID: AtomicU64 = AtomicU64::new(1);
 const EXTERNAL_SUBTITLE_TRACK_ID_BASE: i64 = 1_000_000;
-const AUDIO_PREFILL_AFTER_VIDEO_LIMIT: usize = 4;
-const AUDIO_PREFILL_PACKET_BUDGET: usize = 4;
-const AUDIO_PREFILL_TIME_BUDGET: Duration = Duration::from_millis(3);
+const AUDIO_PREFILL_AFTER_VIDEO_LIMIT: usize = 8;
+const AUDIO_PREFILL_PACKET_BUDGET: usize = 6;
+const AUDIO_PREFILL_TIME_BUDGET: Duration = Duration::from_millis(5);
 const AUDIO_PREFILL_LOW_WATER: Duration = Duration::from_millis(350);
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -48,6 +48,7 @@ const SUBTITLE_FRAME_QUEUE_LIMIT: usize = 32;
 const EXTERNAL_SUBTITLE_LOOKAHEAD: Duration = Duration::from_secs(5);
 const DEFAULT_AUDIO_LEAD_TIME: Duration = Duration::from_millis(120);
 const STREAMING_AUDIO_LEAD_TIME: Duration = Duration::from_millis(1500);
+const OUTPUT_AUDIO_CLOCK_STALE_TOLERANCE: Duration = Duration::from_millis(250);
 const DEMUX_PACKET_QUEUE_LIMIT: usize = 512;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1920,6 +1921,19 @@ impl VideoPlaybackEngine {
         let media_time = snapshot.media_time?;
         let now = Instant::now();
         let before = self.clock.media_time_at(now);
+        if media_time + OUTPUT_AUDIO_CLOCK_STALE_TOLERANCE < before {
+            trace::log(format!(
+                "[erika-clock-trace] stage=output_audio_clock_skip reason=stale before={} media={} queued={} queued_frames={} read={} written={} underflow={}",
+                trace::duration_label(Some(before)),
+                trace::duration_label(Some(media_time)),
+                trace::duration_label(snapshot.queued_duration),
+                snapshot.queued_frames,
+                snapshot.read_frames,
+                snapshot.written_frames,
+                snapshot.underflow_frames,
+            ));
+            return None;
+        }
         let correction = self.clock.discipline_to(
             media_time,
             now,

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -1904,6 +1904,19 @@ impl VideoPlaybackEngine {
         if self.state != PlaybackRunState::Playing {
             return None;
         }
+        if (self.clock.rate() - 1.0).abs() > 0.001 {
+            trace::log(format!(
+                "[erika-clock-trace] stage=output_audio_clock_skip reason=playback_rate rate={:.3} media={} queued={} queued_frames={} read={} written={} underflow={}",
+                self.clock.rate(),
+                trace::duration_label(snapshot.media_time),
+                trace::duration_label(snapshot.queued_duration),
+                snapshot.queued_frames,
+                snapshot.read_frames,
+                snapshot.written_frames,
+                snapshot.underflow_frames,
+            ));
+            return None;
+        }
         let media_time = snapshot.media_time?;
         let now = Instant::now();
         let before = self.clock.media_time_at(now);

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -50,6 +50,8 @@ use crate::{PlayerError, Result};
 const AUDIO_START_BUFFER: Duration = Duration::from_millis(250);
 const AUDIO_PUMP_FRAME_LIMIT: usize = 16;
 const AUDIO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+const AUDIO_CLOCK_STALE_TOLERANCE: Duration = Duration::from_millis(250);
+const PLAYBACK_RATE_EPSILON: f64 = 0.001;
 const VIDEO_PUMP_FRAME_LIMIT: usize = 8;
 const VIDEO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
 const DANMAKU_PLAN_REQUEST_QUANTUM: Duration = Duration::from_millis(250);
@@ -189,6 +191,7 @@ pub struct PresenterRuntime {
     audio_configured: bool,
     audio_started: bool,
     last_audio_clock_sync: Option<AudioClockSyncState>,
+    playback_rate: f64,
     current_overlay: Option<OverlayFrame>,
     current_danmaku: Option<DanmakuRenderPlan>,
     current_danmaku_prepared: Option<CurrentDanmakuPrepared>,
@@ -448,6 +451,7 @@ impl PresenterRuntime {
             audio_configured: false,
             audio_started: false,
             last_audio_clock_sync: None,
+            playback_rate: 1.0,
             current_overlay: None,
             current_danmaku: None,
             current_danmaku_prepared: None,
@@ -565,8 +569,22 @@ impl PresenterRuntime {
         result
     }
 
-    pub fn set_playback_rate(&self, rate: f64) -> Result<()> {
-        self.player.set_playback_rate(rate)
+    pub fn set_playback_rate(&mut self, rate: f64) -> Result<()> {
+        let previous_rate = self.playback_rate;
+        let next_rate = normalize_playback_rate(rate);
+        let was_audio_enabled = playback_rate_uses_audio(previous_rate);
+        let will_audio_enable = playback_rate_uses_audio(next_rate);
+        let resume_time = self.player.current_media_time();
+        self.player.set_playback_rate(rate)?;
+        self.playback_rate = next_rate;
+        if was_audio_enabled != will_audio_enable {
+            self.reset_audio_output();
+            self.drain_pending_audio_frames();
+            if will_audio_enable {
+                self.player.seek(resume_time)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn set_volume(&mut self, volume: f64) {
@@ -1364,6 +1382,11 @@ impl PresenterRuntime {
     }
 
     fn pump_audio(&mut self) {
+        if !self.audio_playback_enabled() {
+            self.suspend_audio_output_for_playback_rate();
+            self.drain_pending_audio_frames();
+            return;
+        }
         let started = Instant::now();
         let mut pumped = 0usize;
         loop {
@@ -1389,6 +1412,9 @@ impl PresenterRuntime {
     }
 
     fn sync_player_to_audio_output(&mut self) {
+        if !self.audio_playback_enabled() {
+            return;
+        }
         let Some(snapshot) = self.audio_output.clock_snapshot() else {
             return;
         };
@@ -1408,10 +1434,17 @@ impl PresenterRuntime {
     }
 
     fn should_sync_audio_clock(&mut self, snapshot: AudioClockSnapshot) -> bool {
+        if !self.audio_playback_enabled() {
+            return false;
+        }
         let Some(media_time) = snapshot.media_time else {
             return false;
         };
         if snapshot.read_frames == 0 {
+            return false;
+        }
+        let player_time = self.player.current_media_time();
+        if media_time + AUDIO_CLOCK_STALE_TOLERANCE < player_time {
             return false;
         }
         let next = AudioClockSyncState {
@@ -1428,6 +1461,9 @@ impl PresenterRuntime {
     }
 
     fn push_audio(&mut self, frame: PlayerAudioFrame) {
+        if !self.audio_playback_enabled() {
+            return;
+        }
         if !self.audio_configured {
             if let Err(error) = self.audio_output.configure(frame.frame.format) {
                 self.stats.audio_failures += 1;
@@ -1450,7 +1486,10 @@ impl PresenterRuntime {
     }
 
     fn ensure_audio_started(&mut self) {
-        if self.audio_started || !self.audio_output_ready_to_start() || !self.audio_start_allowed()
+        if self.audio_started
+            || !self.audio_playback_enabled()
+            || !self.audio_output_ready_to_start()
+            || !self.audio_start_allowed()
         {
             return;
         }
@@ -1484,11 +1523,38 @@ impl PresenterRuntime {
         self.last_audio_clock_sync = None;
     }
 
+    fn suspend_audio_output_for_playback_rate(&mut self) {
+        if self.audio_configured || self.audio_started {
+            self.reset_audio_output();
+        }
+        self.last_audio_clock_sync = None;
+    }
+
+    fn audio_playback_enabled(&self) -> bool {
+        playback_rate_uses_audio(self.playback_rate)
+    }
+
+    fn drain_pending_audio_frames(&mut self) {
+        while self.audio_frames.try_recv().is_ok() {}
+    }
+
     fn drain_pending_player_frames(&mut self) {
         while self.video_frames.try_recv().is_ok() {}
         while self.audio_frames.try_recv().is_ok() {}
         while self.subtitle_frames.try_recv().is_ok() {}
     }
+}
+
+fn normalize_playback_rate(rate: f64) -> f64 {
+    if rate.is_finite() && rate > 0.0 {
+        rate
+    } else {
+        1.0
+    }
+}
+
+fn playback_rate_uses_audio(rate: f64) -> bool {
+    (normalize_playback_rate(rate) - 1.0).abs() <= PLAYBACK_RATE_EPSILON
 }
 
 #[cfg(test)]
@@ -2292,6 +2358,16 @@ mod tests {
             queued_frames: 14_400,
             read_frames: 9_600,
             written_frames: 24_000,
+            underflow_frames: 0,
+        }));
+
+        presenter.playback_rate = 2.0;
+        assert!(!presenter.should_sync_audio_clock(AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
+            queued_duration: Some(Duration::from_millis(300)),
+            queued_frames: 14_400,
+            read_frames: 14_400,
+            written_frames: 28_800,
             underflow_frames: 0,
         }));
     }

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -50,7 +50,8 @@ use crate::{PlayerError, Result};
 const AUDIO_START_BUFFER: Duration = Duration::from_millis(250);
 const AUDIO_PUMP_FRAME_LIMIT: usize = 16;
 const AUDIO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
-const AUDIO_CLOCK_STALE_TOLERANCE: Duration = Duration::from_millis(250);
+const AUDIO_FAST_RATE_PUMP_FRAME_LIMIT: usize = 48;
+const AUDIO_FAST_RATE_PUMP_TIME_BUDGET: Duration = Duration::from_millis(8);
 const PLAYBACK_RATE_EPSILON: f64 = 0.001;
 const VIDEO_PUMP_FRAME_LIMIT: usize = 8;
 const VIDEO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
@@ -190,7 +191,7 @@ pub struct PresenterRuntime {
     audio_output: Box<dyn AudioOutputBackend>,
     audio_configured: bool,
     audio_started: bool,
-    last_audio_clock_sync: Option<AudioClockSyncState>,
+    last_audio_clock_report: Option<AudioClockReportState>,
     playback_rate: f64,
     current_overlay: Option<OverlayFrame>,
     current_danmaku: Option<DanmakuRenderPlan>,
@@ -222,9 +223,11 @@ pub struct PresenterRuntime {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct AudioClockSyncState {
+struct AudioClockReportState {
     media_time: Duration,
+    queued_frames: usize,
     read_frames: u64,
+    underflow_frames: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -450,7 +453,7 @@ impl PresenterRuntime {
             audio_output: build_audio_output(config.audio),
             audio_configured: false,
             audio_started: false,
-            last_audio_clock_sync: None,
+            last_audio_clock_report: None,
             playback_rate: 1.0,
             current_overlay: None,
             current_danmaku: None,
@@ -503,7 +506,7 @@ impl PresenterRuntime {
     pub fn resize_surface(&mut self, width: u32, height: u32, scale: f64) -> Result<()> {
         self.current_output_viewport = Some(surface_dimensions_to_viewport(width, height, scale));
         self.clear_current_danmaku_state();
-        self.last_audio_clock_sync = None;
+        self.last_audio_clock_report = None;
         self.renderer.resize_surface(width, height, scale)
     }
 
@@ -526,7 +529,7 @@ impl PresenterRuntime {
             eprintln!("Erika presenter audio pause failed: {error}");
         }
         self.audio_started = false;
-        self.last_audio_clock_sync = None;
+        self.last_audio_clock_report = None;
         result
     }
 
@@ -570,20 +573,11 @@ impl PresenterRuntime {
     }
 
     pub fn set_playback_rate(&mut self, rate: f64) -> Result<()> {
-        let previous_rate = self.playback_rate;
         let next_rate = normalize_playback_rate(rate);
-        let was_audio_enabled = playback_rate_uses_audio(previous_rate);
-        let will_audio_enable = playback_rate_uses_audio(next_rate);
-        let resume_time = self.player.current_media_time();
-        self.player.set_playback_rate(rate)?;
+        self.player.set_playback_rate(next_rate)?;
         self.playback_rate = next_rate;
-        if was_audio_enabled != will_audio_enable {
-            self.reset_audio_output();
-            self.drain_pending_audio_frames();
-            if will_audio_enable {
-                self.player.seek(resume_time)?;
-            }
-        }
+        self.audio_output.set_playback_rate(next_rate);
+        self.last_audio_clock_report = None;
         Ok(())
     }
 
@@ -1339,7 +1333,7 @@ impl PresenterRuntime {
         self.subtitles.clear();
         self.clear_current_danmaku_state();
         self.current_media_time = media_time;
-        self.last_audio_clock_sync = None;
+        self.last_audio_clock_report = None;
         if let Err(error) = self.renderer.clear_current_frame() {
             self.stats.render_failures += 1;
             eprintln!("Erika presenter renderer clear failed: {error}");
@@ -1382,15 +1376,11 @@ impl PresenterRuntime {
     }
 
     fn pump_audio(&mut self) {
-        if !self.audio_playback_enabled() {
-            self.suspend_audio_output_for_playback_rate();
-            self.drain_pending_audio_frames();
-            return;
-        }
         let started = Instant::now();
         let mut pumped = 0usize;
+        let (frame_limit, time_budget) = self.audio_pump_limits();
         loop {
-            if pumped >= AUDIO_PUMP_FRAME_LIMIT || started.elapsed() >= AUDIO_PUMP_TIME_BUDGET {
+            if pumped >= frame_limit || started.elapsed() >= time_budget {
                 break;
             }
             match self.audio_frames.try_recv() {
@@ -1407,18 +1397,27 @@ impl PresenterRuntime {
         }
         self.ensure_audio_started();
         if self.audio_started {
-            self.sync_player_to_audio_output();
+            self.report_audio_clock_snapshot();
         }
     }
 
-    fn sync_player_to_audio_output(&mut self) {
-        if !self.audio_playback_enabled() {
-            return;
+    fn audio_pump_limits(&self) -> (usize, Duration) {
+        if (self.playback_rate - 1.0).abs() > PLAYBACK_RATE_EPSILON {
+            (
+                AUDIO_FAST_RATE_PUMP_FRAME_LIMIT,
+                AUDIO_FAST_RATE_PUMP_TIME_BUDGET,
+            )
+        } else {
+            (AUDIO_PUMP_FRAME_LIMIT, AUDIO_PUMP_TIME_BUDGET)
         }
+    }
+
+    fn report_audio_clock_snapshot(&mut self) {
         let Some(snapshot) = self.audio_output.clock_snapshot() else {
             return;
         };
-        if !self.should_sync_audio_clock(snapshot) {
+        // Report queue/underflow movement even when the engine later rejects the clock for sync.
+        if !self.should_report_audio_clock(snapshot) {
             return;
         }
         trace::log(format!(
@@ -1433,37 +1432,29 @@ impl PresenterRuntime {
         let _ = self.player.update_audio_clock(snapshot);
     }
 
-    fn should_sync_audio_clock(&mut self, snapshot: AudioClockSnapshot) -> bool {
-        if !self.audio_playback_enabled() {
-            return false;
-        }
+    fn should_report_audio_clock(&mut self, snapshot: AudioClockSnapshot) -> bool {
         let Some(media_time) = snapshot.media_time else {
             return false;
         };
-        if snapshot.read_frames == 0 {
-            return false;
-        }
-        let player_time = self.player.current_media_time();
-        if media_time + AUDIO_CLOCK_STALE_TOLERANCE < player_time {
-            return false;
-        }
-        let next = AudioClockSyncState {
+        let next = AudioClockReportState {
             media_time,
+            queued_frames: snapshot.queued_frames,
             read_frames: snapshot.read_frames,
+            underflow_frames: snapshot.underflow_frames,
         };
-        let should_sync = self.last_audio_clock_sync.is_none_or(|previous| {
-            snapshot.read_frames > previous.read_frames && media_time >= previous.media_time
+        let should_report = self.last_audio_clock_report.is_none_or(|previous| {
+            snapshot.read_frames > previous.read_frames
+                || snapshot.underflow_frames > previous.underflow_frames
+                || snapshot.queued_frames != previous.queued_frames
+                || media_time > previous.media_time
         });
-        if should_sync {
-            self.last_audio_clock_sync = Some(next);
+        if should_report {
+            self.last_audio_clock_report = Some(next);
         }
-        should_sync
+        should_report
     }
 
     fn push_audio(&mut self, frame: PlayerAudioFrame) {
-        if !self.audio_playback_enabled() {
-            return;
-        }
         if !self.audio_configured {
             if let Err(error) = self.audio_output.configure(frame.frame.format) {
                 self.stats.audio_failures += 1;
@@ -1471,7 +1462,7 @@ impl PresenterRuntime {
                 return;
             }
             self.audio_configured = true;
-            self.last_audio_clock_sync = None;
+            self.last_audio_clock_report = None;
         }
         match self.audio_output.push(frame.frame) {
             Ok(_) => self.stats.pushed_audio_frames += 1,
@@ -1486,10 +1477,7 @@ impl PresenterRuntime {
     }
 
     fn ensure_audio_started(&mut self) {
-        if self.audio_started
-            || !self.audio_playback_enabled()
-            || !self.audio_output_ready_to_start()
-            || !self.audio_start_allowed()
+        if self.audio_started || !self.audio_output_ready_to_start() || !self.audio_start_allowed()
         {
             return;
         }
@@ -1499,7 +1487,7 @@ impl PresenterRuntime {
             return;
         }
         self.audio_started = true;
-        self.last_audio_clock_sync = None;
+        self.last_audio_clock_report = None;
     }
 
     fn audio_output_ready_to_start(&self) -> bool {
@@ -1520,22 +1508,7 @@ impl PresenterRuntime {
         }
         self.audio_configured = false;
         self.audio_started = false;
-        self.last_audio_clock_sync = None;
-    }
-
-    fn suspend_audio_output_for_playback_rate(&mut self) {
-        if self.audio_configured || self.audio_started {
-            self.reset_audio_output();
-        }
-        self.last_audio_clock_sync = None;
-    }
-
-    fn audio_playback_enabled(&self) -> bool {
-        playback_rate_uses_audio(self.playback_rate)
-    }
-
-    fn drain_pending_audio_frames(&mut self) {
-        while self.audio_frames.try_recv().is_ok() {}
+        self.last_audio_clock_report = None;
     }
 
     fn drain_pending_player_frames(&mut self) {
@@ -1551,10 +1524,6 @@ fn normalize_playback_rate(rate: f64) -> f64 {
     } else {
         1.0
     }
-}
-
-fn playback_rate_uses_audio(rate: f64) -> bool {
-    (normalize_playback_rate(rate) - 1.0).abs() <= PLAYBACK_RATE_EPSILON
 }
 
 #[cfg(test)]
@@ -2333,36 +2302,38 @@ mod tests {
     }
 
     #[test]
-    fn audio_clock_sync_ignores_unread_and_regressing_snapshots() {
+    fn audio_clock_report_tracks_queue_and_underflow_changes() {
         let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
 
-        assert!(!presenter.should_sync_audio_clock(AudioClockSnapshot {
+        let first = AudioClockSnapshot {
             media_time: Some(Duration::from_secs(1)),
             queued_duration: Some(Duration::from_millis(500)),
             queued_frames: 24_000,
             read_frames: 0,
             written_frames: 24_000,
             underflow_frames: 0,
-        }));
-        assert!(presenter.should_sync_audio_clock(AudioClockSnapshot {
-            media_time: Some(Duration::from_millis(900)),
+        };
+        assert!(presenter.should_report_audio_clock(first));
+        assert!(!presenter.should_report_audio_clock(first));
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
             queued_duration: Some(Duration::from_millis(300)),
             queued_frames: 14_400,
-            read_frames: 4_800,
+            read_frames: 0,
             written_frames: 19_200,
             underflow_frames: 0,
         }));
-        assert!(!presenter.should_sync_audio_clock(AudioClockSnapshot {
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
             media_time: Some(Duration::from_millis(100)),
-            queued_duration: Some(Duration::from_millis(300)),
-            queued_frames: 14_400,
-            read_frames: 9_600,
+            queued_duration: Some(Duration::ZERO),
+            queued_frames: 0,
+            read_frames: 0,
             written_frames: 24_000,
-            underflow_frames: 0,
+            underflow_frames: 512,
         }));
 
         presenter.playback_rate = 2.0;
-        assert!(!presenter.should_sync_audio_clock(AudioClockSnapshot {
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
             media_time: Some(Duration::from_secs(1)),
             queued_duration: Some(Duration::from_millis(300)),
             queued_frames: 14_400,

--- a/crates/erika/src/windows.rs
+++ b/crates/erika/src/windows.rs
@@ -223,6 +223,12 @@ pub mod wasapi {
             WasapiAudioOutput::volume(self)
         }
 
+        fn set_playback_rate(&mut self, rate: f64) {
+            if let Ok(mut buffer) = self.buffer.lock() {
+                buffer.set_playback_rate(rate);
+            }
+        }
+
         fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {
             WasapiAudioOutput::push(self, frame)
                 .map_err(|error| crate::audio::AudioError::Backend(error.to_string()))


### PR DESCRIPTION
## Summary
- suspend presenter audio output while playback rate is not 1x so fast-forward preview does not produce chipmunk audio
- ignore audio clock snapshots during non-1x playback so audio cannot pull video/danmaku time backward
- reset and realign audio output when returning to 1x, and reject stale audio snapshots before resuming audio sync

## Testing
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo check -p erika_capi
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika audio_clock_sync_ignores_unread_and_regressing_snapshots -- --nocapture
- flutter run -d macos with ERIKA_FORCE_SOURCE_BUILD=1, verified long-press fast-forward and audio recovery manually

Note: cargo emits the existing unused trace_ffmpeg warning.