### PR TITLE
Fix iOS ASS font fallback

### DIFF
--- a/crates/erika/build.rs
+++ b/crates/erika/build.rs
@@ -56,12 +56,17 @@ fn main() {
     println!("cargo:rustc-link-lib=static=harfbuzz");
     println!("cargo:rustc-link-lib=static=freetype");
 
-    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
-        println!("cargo:rustc-link-lib=framework=ApplicationServices");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").ok();
+    if matches!(target_os.as_deref(), Some("ios" | "macos")) {
+        if target_os.as_deref() == Some("macos") {
+            println!("cargo:rustc-link-lib=framework=ApplicationServices");
+        }
         println!("cargo:rustc-link-lib=framework=CoreText");
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=framework=CoreGraphics");
-        println!("cargo:rustc-link-lib=iconv");
+        if target_os.as_deref() == Some("macos") {
+            println!("cargo:rustc-link-lib=iconv");
+        }
     }
 }
 

--- a/crates/erika/src/subtitle.rs
+++ b/crates/erika/src/subtitle.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "libass")]
-use std::ptr::NonNull;
 use std::time::Duration;
+#[cfg(feature = "libass")]
+use std::{ffi::CStr, ptr::NonNull};
 
 use thiserror::Error;
 
@@ -577,6 +577,11 @@ mod libass_ffi {
     }
 }
 
+#[cfg(feature = "libass")]
+const ASS_FONTPROVIDER_AUTODETECT: libc::c_int = 1;
+#[cfg(feature = "libass")]
+const ASS_FONTPROVIDER_CORETEXT: libc::c_int = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LibassRenderConfig {
     pub glyph_cache_limit: i32,
@@ -685,8 +690,8 @@ impl LibassSubtitleRenderer {
             libass_ffi::ass_set_fonts(
                 renderer.as_ptr(),
                 std::ptr::null(),
-                std::ptr::null(),
-                1,
+                default_ass_font_family_cstr().as_ptr(),
+                default_ass_font_provider(),
                 std::ptr::null(),
                 1,
             );
@@ -1374,6 +1379,28 @@ fn escape_ass_text(value: &str) -> String {
 
 const DEFAULT_ASS_FONT_SIZE: f64 = 48.0;
 const DEFAULT_ASS_OUTLINE: f64 = 2.0;
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+const DEFAULT_ASS_FONT_FAMILY: &str = "PingFang SC";
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+const DEFAULT_ASS_FONT_FAMILY: &str = "Arial";
+
+#[cfg(feature = "libass")]
+fn default_ass_font_provider() -> libc::c_int {
+    if cfg!(any(target_os = "ios", target_os = "macos")) {
+        ASS_FONTPROVIDER_CORETEXT
+    } else {
+        ASS_FONTPROVIDER_AUTODETECT
+    }
+}
+
+#[cfg(feature = "libass")]
+fn default_ass_font_family_cstr() -> &'static CStr {
+    if cfg!(any(target_os = "ios", target_os = "macos")) {
+        c"PingFang SC"
+    } else {
+        c"Arial"
+    }
+}
 
 fn normalize_ass_font_scale(scale: f64) -> f64 {
     if scale.is_finite() {
@@ -1396,6 +1423,7 @@ fn default_ass_script_header(style: SubtitleAssStyle) -> String {
     let scale = normalize_ass_font_scale(style.font_scale);
     let font_size = ass_number(DEFAULT_ASS_FONT_SIZE * scale);
     let outline = ass_number(DEFAULT_ASS_OUTLINE * scale);
+    let font_family = DEFAULT_ASS_FONT_FAMILY;
     let play_res_width = style.play_res_width.max(1);
     let play_res_height = style.play_res_height.max(1);
     format!(
@@ -1406,7 +1434,7 @@ PlayResY: {play_res_height}
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,Arial,{font_size},&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,{outline},0,2,48,48,54,1
+Style: Default,{font_family},{font_size},&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,{outline},0,2,48,48,54,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
@@ -1595,7 +1623,7 @@ Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,Hello libass
         )
         .unwrap();
 
-        assert!(script.contains("Style: Default,Arial,72,"));
+        assert!(script.contains(&format!("Style: Default,{DEFAULT_ASS_FONT_FAMILY},72,")));
     }
 
     #[test]

--- a/packages/erika_flutter/ios/erika_flutter.podspec
+++ b/packages/erika_flutter/ios/erika_flutter.podspec
@@ -83,13 +83,18 @@ fi
 case "${PLATFORM_NAME:-iphoneos}" in
   iphoneos)
     RUST_TARGET="aarch64-apple-ios"
+    BINDGEN_CLANG_TARGET="arm64-apple-ios"
+    BINDGEN_SDK="iphoneos"
     ;;
   iphonesimulator)
     if [ "$ARCH" = "x86_64" ]; then
       RUST_TARGET="x86_64-apple-ios"
+      BINDGEN_CLANG_TARGET="x86_64-apple-ios-simulator"
     else
       RUST_TARGET="aarch64-apple-ios-sim"
+      BINDGEN_CLANG_TARGET="arm64-apple-ios-simulator"
     fi
+    BINDGEN_SDK="iphonesimulator"
     ;;
   *)
     echo "error: unsupported Erika iOS platform: ${PLATFORM_NAME:-unknown}" >&2
@@ -117,6 +122,10 @@ fi
 if command -v rustup >/dev/null 2>&1; then
   rustup target add "$RUST_TARGET"
 fi
+
+BINDGEN_SDKROOT="$(xcrun --sdk "$BINDGEN_SDK" --show-sdk-path)"
+BINDGEN_TARGET_ENV="$(echo "$RUST_TARGET" | tr '-' '_')"
+export "BINDGEN_EXTRA_CLANG_ARGS_$BINDGEN_TARGET_ENV=--target=$BINDGEN_CLANG_TARGET -isysroot $BINDGEN_SDKROOT"
 
 if [ -z "${ERIKA_FFMPEG_DIR:-}" ]; then
   ERIKA_FFMPEG_DIR="$ERIKA_ROOT/third_party/dist/$RUST_TARGET/$ERIKA_NATIVE_PROFILE/ffmpeg"
@@ -186,6 +195,6 @@ fi
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    'OTHER_LDFLAGS' => "$(inherited) \"$(PODS_TARGET_SRCROOT)/native/liberika_capi.a\" #{erika_cabi_undefined_flags} -framework AVFoundation -framework AudioToolbox -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox -framework CoreFoundation -framework CoreGraphics -framework Foundation -liconv -lbz2 -lz",
+    'OTHER_LDFLAGS' => "$(inherited) \"$(PODS_TARGET_SRCROOT)/native/liberika_capi.a\" #{erika_cabi_undefined_flags} -framework AVFoundation -framework AudioToolbox -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox -framework CoreText -framework CoreFoundation -framework CoreGraphics -framework Foundation -liconv -lbz2 -lz",
   }
 end


### PR DESCRIPTION
## Summary
- use CoreText explicitly for libass font lookup on Apple platforms
- default generated ASS styles to PingFang SC on iOS/macOS instead of Arial
- link CoreText for iOS local source builds and pass iOS SDK/target args to bindgen

## Testing
- cargo fmt
- git diff --check
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo check -p erika_capi
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika subtitle::tests -- --nocapture
- ERIKA_PREBUILT=0 flutter run -d 00008120-000925513410C01E (iOS device build/install/launch succeeded after freeing local disk space)

Stacked on #31 / codex/fast-forward-pitch-preserve.