### PR TITLE
Prepare Erika 0.1.1 prebuilt release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # Build prebuilt erika_capi bundles and attach them to a GitHub Release.
 #
-# Trigger: push a tag like `v0.1.0` to publish. Use the manual "Run workflow"
+# Trigger: push a tag like `v0.1.1` to publish. Use the manual "Run workflow"
 # button (workflow_dispatch) to dry-run the builds without publishing (the
 # publish job is gated on a tag ref).
 #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capi_smoke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika_capi",
 ]
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "coreaudio_smoke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -314,7 +314,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "danmaku_perf_lab"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "erika",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "danmaku_sync_smoke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
@@ -369,7 +369,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erika"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ab_glyph",
  "aho-corasick",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "erika_capi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "erika_ffmpeg_sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen 0.72.1",
  "libc",
@@ -427,42 +427,42 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg_audio_decode"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_decode"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_demux"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_probe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_probe_source"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_videotoolbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
@@ -834,7 +834,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "macos_native_demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "crossbeam-channel",
@@ -858,14 +858,14 @@ dependencies = [
 
 [[package]]
 name = "metal_import_videotoolbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "metal_overlay_check"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "erika",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "metal_presenter_check"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "erika",
@@ -1168,21 +1168,21 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "playback_audio_tick"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "playback_tick"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "player_tick"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -1332,7 +1332,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "render_pipeline_plan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
 ]
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_decode_png"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
  "png",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_overlay_png"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
  "png",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_video_png"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
  "png",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_window_check"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cc",
  "erika",
@@ -2152,7 +2152,7 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_native_demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "erika",
  "windows-sys 0.61.2",
@@ -2190,7 +2190,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/AimesSoft/Erika"
 rust-version = "1.92"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.dependencies]
 ab_glyph = "0.2.32"

--- a/crates/erika/build.rs
+++ b/crates/erika/build.rs
@@ -56,12 +56,17 @@ fn main() {
     println!("cargo:rustc-link-lib=static=harfbuzz");
     println!("cargo:rustc-link-lib=static=freetype");
 
-    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
-        println!("cargo:rustc-link-lib=framework=ApplicationServices");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").ok();
+    if matches!(target_os.as_deref(), Some("ios" | "macos")) {
+        if target_os.as_deref() == Some("macos") {
+            println!("cargo:rustc-link-lib=framework=ApplicationServices");
+        }
         println!("cargo:rustc-link-lib=framework=CoreText");
         println!("cargo:rustc-link-lib=framework=CoreFoundation");
         println!("cargo:rustc-link-lib=framework=CoreGraphics");
-        println!("cargo:rustc-link-lib=iconv");
+        if target_os.as_deref() == Some("macos") {
+            println!("cargo:rustc-link-lib=iconv");
+        }
     }
 }
 

--- a/crates/erika/src/subtitle.rs
+++ b/crates/erika/src/subtitle.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "libass")]
-use std::ptr::NonNull;
 use std::time::Duration;
+#[cfg(feature = "libass")]
+use std::{ffi::CStr, ptr::NonNull};
 
 use thiserror::Error;
 
@@ -577,6 +577,11 @@ mod libass_ffi {
     }
 }
 
+#[cfg(feature = "libass")]
+const ASS_FONTPROVIDER_AUTODETECT: libc::c_int = 1;
+#[cfg(feature = "libass")]
+const ASS_FONTPROVIDER_CORETEXT: libc::c_int = 2;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LibassRenderConfig {
     pub glyph_cache_limit: i32,
@@ -685,8 +690,8 @@ impl LibassSubtitleRenderer {
             libass_ffi::ass_set_fonts(
                 renderer.as_ptr(),
                 std::ptr::null(),
-                std::ptr::null(),
-                1,
+                default_ass_font_family_cstr().as_ptr(),
+                default_ass_font_provider(),
                 std::ptr::null(),
                 1,
             );
@@ -1374,6 +1379,28 @@ fn escape_ass_text(value: &str) -> String {
 
 const DEFAULT_ASS_FONT_SIZE: f64 = 48.0;
 const DEFAULT_ASS_OUTLINE: f64 = 2.0;
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+const DEFAULT_ASS_FONT_FAMILY: &str = "PingFang SC";
+#[cfg(not(any(target_os = "ios", target_os = "macos")))]
+const DEFAULT_ASS_FONT_FAMILY: &str = "Arial";
+
+#[cfg(feature = "libass")]
+fn default_ass_font_provider() -> libc::c_int {
+    if cfg!(any(target_os = "ios", target_os = "macos")) {
+        ASS_FONTPROVIDER_CORETEXT
+    } else {
+        ASS_FONTPROVIDER_AUTODETECT
+    }
+}
+
+#[cfg(feature = "libass")]
+fn default_ass_font_family_cstr() -> &'static CStr {
+    if cfg!(any(target_os = "ios", target_os = "macos")) {
+        c"PingFang SC"
+    } else {
+        c"Arial"
+    }
+}
 
 fn normalize_ass_font_scale(scale: f64) -> f64 {
     if scale.is_finite() {
@@ -1396,6 +1423,7 @@ fn default_ass_script_header(style: SubtitleAssStyle) -> String {
     let scale = normalize_ass_font_scale(style.font_scale);
     let font_size = ass_number(DEFAULT_ASS_FONT_SIZE * scale);
     let outline = ass_number(DEFAULT_ASS_OUTLINE * scale);
+    let font_family = DEFAULT_ASS_FONT_FAMILY;
     let play_res_width = style.play_res_width.max(1);
     let play_res_height = style.play_res_height.max(1);
     format!(
@@ -1406,7 +1434,7 @@ PlayResY: {play_res_height}
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,Arial,{font_size},&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,{outline},0,2,48,48,54,1
+Style: Default,{font_family},{font_size},&H00FFFFFF,&H000000FF,&H80000000,&H80000000,0,0,0,0,100,100,0,0,1,{outline},0,2,48,48,54,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
@@ -1595,7 +1623,7 @@ Dialogue: 0,0:00:00.00,0:00:02.00,Default,,0,0,0,,Hello libass
         )
         .unwrap();
 
-        assert!(script.contains("Style: Default,Arial,72,"));
+        assert!(script.contains(&format!("Style: Default,{DEFAULT_ASS_FONT_FAMILY},72,")));
     }
 
     #[test]

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,8 +37,8 @@ The release is fully automated by
    `version` in the root `Cargo.toml` if appropriate.
 2. Tag and push:
    ```sh
-   git tag v0.1.0
-   git push origin v0.1.0
+   git tag v0.1.1
+   git push origin v0.1.1
    ```
 3. The workflow builds the macOS / iOS / Windows bundles (each builds the native
    deps from source, so expect a long run on a cold cache) and attaches the
@@ -72,12 +72,12 @@ Enable it by setting environment variables in the host app's build:
 | Variable | Effect |
 |----------|--------|
 | `ERIKA_PREBUILT=1` | Download the prebuilt `erika_capi` instead of building from source. |
-| `ERIKA_PREBUILT_TAG=v0.1.0` | Release tag to download (default `v0.1.0`). |
+| `ERIKA_PREBUILT_TAG=v0.1.1` | Release tag to download (default `v0.1.1`). |
 | `ERIKA_FORCE_SOURCE_BUILD=1` | macOS/iOS only: bypass the prebuilt path and build the local source, useful when debugging Erika changes through the Flutter plugin. |
 
 - **Windows** (`build_erika_runtime.cmake`): downloads `erika-capi-windows-x64.zip`
   and drops `erika_capi.dll` where the plugin bundles it. The plugin loads the
-  DLL dynamically, so this is feature-agnostic and works against `v0.1.0`.
+  DLL dynamically, so this is feature-agnostic and works against `v0.1.1`.
 - **iOS** (podspec): downloads `erika-capi-ios.zip`, picks the device or
   simulator slice from the XCFramework, and links it. The prebuilt static lib
   must be built `--no-default-features --features libass` to match the plugin's

--- a/packages/erika_flutter/README.md
+++ b/packages/erika_flutter/README.md
@@ -41,7 +41,7 @@ points the build phase at an explicit dylib to bundle instead of building.
 
 To skip building Erika (and FFmpeg) from source, set `ERIKA_PREBUILT=1` in the
 app build to download the prebuilt `erika_capi` from a GitHub Release
-(`ERIKA_PREBUILT_TAG` selects the tag, default `v0.1.0`). Supported on macOS,
+(`ERIKA_PREBUILT_TAG` selects the tag, default `v0.1.1`). Supported on macOS,
 Windows, and iOS; any failure falls back to the source build. See
 [`docs/releasing.md`](../../docs/releasing.md).
 

--- a/packages/erika_flutter/ios/erika_flutter.podspec
+++ b/packages/erika_flutter/ios/erika_flutter.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
     .join(' ')
 
   s.name             = 'erika_flutter'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'Flutter embedder glue for the Erika Rust media engine.'
   s.description      = <<-DESC
 Flutter iOS plugin that hosts a CAMetalLayer and drives Erika through its C ABI.
@@ -138,11 +138,11 @@ ERIKA_FRIBIDI_DIR="${ERIKA_FRIBIDI_DIR:-$ERIKA_TARGET_DIST/fribidi}"
 
 # Optional: use a prebuilt static lib from a GitHub Release (opt-in).
 # Enable with ERIKA_PREBUILT=1; ERIKA_PREBUILT_TAG selects the tag (default
-# v0.1.0). Any failure falls through to the source build below, so enabling it
+# v0.1.1). Any failure falls through to the source build below, so enabling it
 # never breaks a build. ERIKA_IOS_CAPI_STATICLIB still takes precedence.
 PREBUILT_LIB=""
 if [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" != "1" ] && [ "${ERIKA_PREBUILT:-0}" = "1" ] && [ -z "${ERIKA_IOS_CAPI_STATICLIB:-}" ]; then
-  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.0}"
+  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.1}"
   PREBUILT_WORK="$ERIKA_ROOT/target/erika-prebuilt-ios"
   PREBUILT_ZIP="$PREBUILT_WORK/erika-capi-ios.zip"
   PREBUILT_URL="https://github.com/AimesSoft/Erika/releases/download/$PREBUILT_TAG/erika-capi-ios.zip"

--- a/packages/erika_flutter/ios/erika_flutter.podspec
+++ b/packages/erika_flutter/ios/erika_flutter.podspec
@@ -83,13 +83,18 @@ fi
 case "${PLATFORM_NAME:-iphoneos}" in
   iphoneos)
     RUST_TARGET="aarch64-apple-ios"
+    BINDGEN_CLANG_TARGET="arm64-apple-ios"
+    BINDGEN_SDK="iphoneos"
     ;;
   iphonesimulator)
     if [ "$ARCH" = "x86_64" ]; then
       RUST_TARGET="x86_64-apple-ios"
+      BINDGEN_CLANG_TARGET="x86_64-apple-ios-simulator"
     else
       RUST_TARGET="aarch64-apple-ios-sim"
+      BINDGEN_CLANG_TARGET="arm64-apple-ios-simulator"
     fi
+    BINDGEN_SDK="iphonesimulator"
     ;;
   *)
     echo "error: unsupported Erika iOS platform: ${PLATFORM_NAME:-unknown}" >&2
@@ -117,6 +122,10 @@ fi
 if command -v rustup >/dev/null 2>&1; then
   rustup target add "$RUST_TARGET"
 fi
+
+BINDGEN_SDKROOT="$(xcrun --sdk "$BINDGEN_SDK" --show-sdk-path)"
+BINDGEN_TARGET_ENV="$(echo "$RUST_TARGET" | tr '-' '_')"
+export "BINDGEN_EXTRA_CLANG_ARGS_$BINDGEN_TARGET_ENV=--target=$BINDGEN_CLANG_TARGET -isysroot $BINDGEN_SDKROOT"
 
 if [ -z "${ERIKA_FFMPEG_DIR:-}" ]; then
   ERIKA_FFMPEG_DIR="$ERIKA_ROOT/third_party/dist/$RUST_TARGET/$ERIKA_NATIVE_PROFILE/ffmpeg"
@@ -186,6 +195,6 @@ fi
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    'OTHER_LDFLAGS' => "$(inherited) \"$(PODS_TARGET_SRCROOT)/native/liberika_capi.a\" #{erika_cabi_undefined_flags} -framework AVFoundation -framework AudioToolbox -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox -framework CoreFoundation -framework CoreGraphics -framework Foundation -liconv -lbz2 -lz",
+    'OTHER_LDFLAGS' => "$(inherited) \"$(PODS_TARGET_SRCROOT)/native/liberika_capi.a\" #{erika_cabi_undefined_flags} -framework AVFoundation -framework AudioToolbox -framework QuartzCore -framework Metal -framework CoreVideo -framework CoreMedia -framework VideoToolbox -framework CoreText -framework CoreFoundation -framework CoreGraphics -framework Foundation -liconv -lbz2 -lz",
   }
 end

--- a/packages/erika_flutter/macos/erika_flutter.podspec
+++ b/packages/erika_flutter/macos/erika_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'erika_flutter'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'Flutter embedder glue for the Erika Rust media engine.'
   s.description      = <<-DESC
 Flutter macOS plugin that hosts a CAMetalLayer and drives Erika through its C ABI.
@@ -54,11 +54,11 @@ mkdir -p "$DEST_DIR"
 
 # Optional: use a prebuilt universal dylib from a GitHub Release (opt-in).
 # Enable with ERIKA_PREBUILT=1; ERIKA_PREBUILT_TAG selects the tag (default
-# v0.1.0). Any failure falls through to the source build. ERIKA_MACOS_CAPI_DYLIB
+# v0.1.1). Any failure falls through to the source build. ERIKA_MACOS_CAPI_DYLIB
 # takes precedence (explicit dylib path).
 UNIVERSAL_DYLIB=""
 if [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" != "1" ] && [ "${ERIKA_PREBUILT:-0}" = "1" ] && [ -z "${ERIKA_MACOS_CAPI_DYLIB:-}" ]; then
-  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.0}"
+  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.1}"
   PREBUILT_WORK="$ERIKA_ROOT/target/erika-prebuilt-macos"
   PREBUILT_ZIP="$PREBUILT_WORK/erika-capi-macos-universal.zip"
   PREBUILT_URL="https://github.com/AimesSoft/Erika/releases/download/$PREBUILT_TAG/erika-capi-macos-universal.zip"

--- a/packages/erika_flutter/pubspec.yaml
+++ b/packages/erika_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: erika_flutter
 description: Flutter embedder glue for the Erika Rust media engine.
-version: 0.1.0
+version: 0.1.1
 publish_to: none
 
 environment:

--- a/packages/erika_flutter/windows/build_erika_runtime.cmake
+++ b/packages/erika_flutter/windows/build_erika_runtime.cmake
@@ -55,7 +55,7 @@ endfunction()
 
 # --- Optional: use a prebuilt erika_capi.dll from a GitHub Release ---
 # Opt in with ERIKA_PREBUILT=1. ERIKA_PREBUILT_TAG selects the release tag
-# (default v0.1.0). On any failure this falls through to the source build below,
+# (default v0.1.1). On any failure this falls through to the source build below,
 # so enabling it never breaks a build. The Windows plugin loads the DLL
 # dynamically, so only erika_capi.dll is required.
 if("$ENV{ERIKA_PREBUILT}" STREQUAL "1")
@@ -69,7 +69,7 @@ if("$ENV{ERIKA_PREBUILT}" STREQUAL "1")
     message(STATUS "Erika: reusing prebuilt ${_erika_dll_out}")
     return()
   endif()
-  set(_erika_tag "v0.1.0")
+  set(_erika_tag "v0.1.1")
   if(NOT "$ENV{ERIKA_PREBUILT_TAG}" STREQUAL "")
     set(_erika_tag "$ENV{ERIKA_PREBUILT_TAG}")
   endif()


### PR DESCRIPTION
## Summary
- carry the iOS ASS font fallback fix onto the current main branch
- bump Erika / erika_flutter versions to 0.1.1
- update default prebuilt download tags and release docs to v0.1.1

## Testing
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo check -p erika_capi
- cargo fmt
- git diff --check
- ERIKA_NATIVE_TARGET=aarch64-apple-darwin cargo test -p erika subtitle::tests -- --nocapture

After this lands, tag main as v0.1.1 to publish fresh erika_capi prebuilt bundles.