### PR TITLE
Fix iOS playback sync and ASS font fallback

### DIFF
--- a/crates/erika/src/danmaku.rs
+++ b/crates/erika/src/danmaku.rs
@@ -17,12 +17,12 @@ use ab_glyph::{Font, FontArc, FontVec, Glyph, GlyphId, PxScale, ScaleFont};
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::NIPAPLAY_FALLBACK_FONT;
 use crate::text::TextShaper;
 
 const DEFAULT_SOURCE_FONT_SIZE: f32 = 25.0;
 const DEFAULT_CONFIG_FONT_SIZE: f32 = 30.0;
 const DEFAULT_NATIVE_FONT_SIZE: f32 = DEFAULT_CONFIG_FONT_SIZE;
-const NIPAPLAY_DANMAKU_FONT: &[u8] = include_bytes!("../assets/subfont.ttf");
 const DEFAULT_SCROLL_DURATION: Duration = Duration::from_millis(9000);
 const DEFAULT_STATIC_DURATION: Duration = Duration::from_millis(3800);
 const DEFAULT_GENERATION: u64 = 1;
@@ -2303,7 +2303,7 @@ fn load_font_family(family: &str) -> Option<FontArc> {
 }
 
 fn load_default_font() -> Option<FontArc> {
-    if let Ok(font) = FontArc::try_from_slice(NIPAPLAY_DANMAKU_FONT) {
+    if let Ok(font) = FontArc::try_from_slice(NIPAPLAY_FALLBACK_FONT) {
         return Some(font);
     }
 

--- a/crates/erika/src/lib.rs
+++ b/crates/erika/src/lib.rs
@@ -15,4 +15,6 @@ pub mod windows;
 
 mod trace;
 
+pub(crate) const NIPAPLAY_FALLBACK_FONT: &[u8] = include_bytes!("../assets/subfont.ttf");
+
 pub use core::*;

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -726,32 +726,62 @@ impl PlaybackSession {
         max_packets: usize,
         max_duration: Duration,
     ) -> Result<Option<PcmAudioFrame>> {
+        self.next_audio_frame_bounded_where(max_packets, max_duration, |_| true)
+    }
+
+    fn next_audio_frame_bounded_where(
+        &mut self,
+        max_packets: usize,
+        max_duration: Duration,
+        mut keep_frame: impl FnMut(&mut PcmAudioFrame) -> bool,
+    ) -> Result<Option<PcmAudioFrame>> {
         if self.audio_decoder.is_none() {
             return Ok(None);
         }
 
         let started = Instant::now();
         let mut pumped_packets = 0usize;
-        while self.audio_frames.is_empty() && !self.eof && pumped_packets < max_packets {
+        let mut filtered_frames = 0usize;
+        let mut inspected_frames = 0usize;
+        let mut frame = pop_matching_audio_frame(
+            &mut self.audio_frames,
+            &mut keep_frame,
+            &mut filtered_frames,
+            &mut inspected_frames,
+            started,
+            max_duration,
+        );
+        while frame.is_none() && !self.eof && pumped_packets < max_packets {
             if started.elapsed() >= max_duration {
                 break;
             }
             if self.pump_once()? {
                 pumped_packets = pumped_packets.saturating_add(1);
+                frame = pop_matching_audio_frame(
+                    &mut self.audio_frames,
+                    &mut keep_frame,
+                    &mut filtered_frames,
+                    &mut inspected_frames,
+                    started,
+                    max_duration,
+                );
             } else {
                 break;
             }
         }
 
-        let frame = self.audio_frames.pop_front();
         if trace::enabled()
-            && (pumped_packets > 0 || frame.is_none() || started.elapsed() >= max_duration)
+            && (pumped_packets > 0
+                || filtered_frames > 0
+                || frame.is_none()
+                || started.elapsed() >= max_duration)
         {
             trace::log(format!(
-                "[erika-playback-trace] stage=session_audio_pump packets={} max_packets={} produced={} queued_audio={} eof={} pending_video={} elapsed_ms={:.3}",
+                "[erika-playback-trace] stage=session_audio_pump packets={} max_packets={} produced={} filtered={} queued_audio={} eof={} pending_video={} elapsed_ms={:.3}",
                 pumped_packets,
                 max_packets,
                 frame.is_some(),
+                filtered_frames,
                 self.audio_frames.len(),
                 self.eof,
                 self.pending_video_packets.len(),
@@ -1828,7 +1858,8 @@ pub struct VideoPlaybackEngine {
     last_presented_pts: Option<Duration>,
     eof: bool,
     waiting_for_first_frame: bool,
-    seek_floor: Option<Duration>,
+    video_seek_floor: Option<Duration>,
+    audio_seek_floor: Option<Duration>,
 }
 
 unsafe impl Send for VideoPlaybackEngine {}
@@ -1861,7 +1892,8 @@ impl VideoPlaybackEngine {
             last_presented_pts: None,
             eof: false,
             waiting_for_first_frame: false,
-            seek_floor: None,
+            video_seek_floor: None,
+            audio_seek_floor: None,
         }
     }
 
@@ -1940,7 +1972,8 @@ impl VideoPlaybackEngine {
         self.last_presented_pts = None;
         self.eof = false;
         self.waiting_for_first_frame = self.state == PlaybackRunState::Playing;
-        self.seek_floor = Some(media_time);
+        self.video_seek_floor = Some(media_time);
+        self.audio_seek_floor = Some(media_time);
         Ok(())
     }
 
@@ -2003,7 +2036,8 @@ impl VideoPlaybackEngine {
         self.state = PlaybackRunState::Stopped;
         self.eof = false;
         self.waiting_for_first_frame = false;
-        self.seek_floor = None;
+        self.video_seek_floor = None;
+        self.audio_seek_floor = None;
     }
 
     pub fn seek(&mut self, position: Duration) -> Result<()> {
@@ -2019,7 +2053,8 @@ impl VideoPlaybackEngine {
         self.last_presented_pts = None;
         self.eof = false;
         self.waiting_for_first_frame = self.state == PlaybackRunState::Playing;
-        self.seek_floor = Some(position);
+        self.video_seek_floor = Some(position);
+        self.audio_seek_floor = Some(position);
         Ok(())
     }
 
@@ -2071,13 +2106,19 @@ impl VideoPlaybackEngine {
             return None;
         }
         let media_time = snapshot.media_time?;
+        let audio_reference_time = media_time.saturating_add(
+            snapshot
+                .queued_duration
+                .unwrap_or_else(|| Duration::from_millis(0)),
+        );
         let now = Instant::now();
         let before = self.clock.media_time_at(now);
         if media_time + OUTPUT_AUDIO_CLOCK_STALE_TOLERANCE < before {
             trace::log(format!(
-                "[erika-clock-trace] stage=output_audio_clock_skip reason=stale before={} media={} queued={} queued_frames={} read={} written={} underflow={}",
+                "[erika-clock-trace] stage=output_audio_clock_skip reason=stale before={} media={} reference={} queued={} queued_frames={} read={} written={} underflow={}",
                 trace::duration_label(Some(before)),
                 trace::duration_label(Some(media_time)),
+                trace::duration_label(Some(audio_reference_time)),
                 trace::duration_label(snapshot.queued_duration),
                 snapshot.queued_frames,
                 snapshot.read_frames,
@@ -2204,7 +2245,7 @@ impl VideoPlaybackEngine {
             };
 
             let pts = frame.pts().and_then(|pts| pts.as_duration());
-            if self.should_drop_seek_preroll(pts) {
+            if self.should_drop_video_seek_preroll(pts) {
                 let _ = self.pending_frame.take();
                 continue;
             }
@@ -2255,18 +2296,18 @@ impl VideoPlaybackEngine {
         }
     }
 
-    fn should_drop_seek_preroll(&mut self, pts: Option<Duration>) -> bool {
-        let Some(target) = self.seek_floor else {
+    fn should_drop_video_seek_preroll(&mut self, pts: Option<Duration>) -> bool {
+        let Some(target) = self.video_seek_floor else {
             return false;
         };
         let Some(pts) = pts else {
-            self.seek_floor = None;
+            self.video_seek_floor = None;
             return false;
         };
         if pts < target {
             true
         } else {
-            self.seek_floor = None;
+            self.video_seek_floor = None;
             false
         }
     }
@@ -2292,7 +2333,12 @@ impl VideoPlaybackEngine {
         if self.pending_audio.is_some() || self.eof {
             return Ok(());
         }
-        self.pending_audio = self.session.next_audio_frame()?;
+        while let Some(mut frame) = self.session.next_audio_frame()? {
+            if keep_audio_frame_after_seek_floor(&mut self.audio_seek_floor, &mut frame) {
+                self.pending_audio = Some(frame);
+                break;
+            }
+        }
         Ok(())
     }
 
@@ -2304,9 +2350,12 @@ impl VideoPlaybackEngine {
         if self.pending_audio.is_some() || self.eof {
             return Ok(());
         }
-        self.pending_audio = self
-            .session
-            .next_audio_frame_bounded(max_packets, max_decode_duration)?;
+        let audio_seek_floor = &mut self.audio_seek_floor;
+        self.pending_audio = self.session.next_audio_frame_bounded_where(
+            max_packets,
+            max_decode_duration,
+            |frame| keep_audio_frame_after_seek_floor(audio_seek_floor, frame),
+        )?;
         Ok(())
     }
 
@@ -2403,6 +2452,103 @@ fn drain_video_frames(decoder: &mut Decoder, frames: &mut VecDeque<Frame>) -> Re
             DecoderOutputFrame::NeedMoreInput | DecoderOutputFrame::EndOfStream => return Ok(()),
         }
     }
+}
+
+fn pop_matching_audio_frame(
+    frames: &mut VecDeque<PcmAudioFrame>,
+    keep_frame: &mut impl FnMut(&mut PcmAudioFrame) -> bool,
+    filtered_frames: &mut usize,
+    inspected_frames: &mut usize,
+    started: Instant,
+    max_duration: Duration,
+) -> Option<PcmAudioFrame> {
+    while !frames.is_empty() {
+        if *inspected_frames > 0 && started.elapsed() >= max_duration {
+            return None;
+        }
+        let mut frame = frames.pop_front().expect("audio frame exists");
+        *inspected_frames = inspected_frames.saturating_add(1);
+        if keep_frame(&mut frame) {
+            return Some(frame);
+        }
+        *filtered_frames = filtered_frames.saturating_add(1);
+    }
+    None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AudioSeekFloorAction {
+    Drop,
+    Emit { trimmed_frames: usize },
+}
+
+fn keep_audio_frame_after_seek_floor(
+    seek_floor: &mut Option<Duration>,
+    frame: &mut PcmAudioFrame,
+) -> bool {
+    let Some(target) = *seek_floor else {
+        return true;
+    };
+    let original_pts = frame.pts;
+    match trim_audio_frame_to_seek_floor(frame, target) {
+        AudioSeekFloorAction::Drop => false,
+        AudioSeekFloorAction::Emit { trimmed_frames } => {
+            *seek_floor = None;
+            trace::log(format!(
+                "[erika-playback-trace] stage=audio_seek_floor_emit target={} pts_before={} pts_after={} trimmed_frames={} frames={}",
+                trace::duration_label(Some(target)),
+                trace::duration_label(original_pts),
+                trace::duration_label(frame.pts),
+                trimmed_frames,
+                frame.frames,
+            ));
+            true
+        }
+    }
+}
+
+fn trim_audio_frame_to_seek_floor(
+    frame: &mut PcmAudioFrame,
+    target: Duration,
+) -> AudioSeekFloorAction {
+    let Some(pts) = frame.pts else {
+        return AudioSeekFloorAction::Emit { trimmed_frames: 0 };
+    };
+    if pts >= target {
+        return AudioSeekFloorAction::Emit { trimmed_frames: 0 };
+    }
+
+    let channels = frame.format.channels as usize;
+    let sample_rate = frame.format.sample_rate;
+    if channels == 0 || sample_rate == 0 {
+        return AudioSeekFloorAction::Emit { trimmed_frames: 0 };
+    }
+
+    let available_frames = frame.samples.len() / channels;
+    let delta = target.saturating_sub(pts);
+    let frames_to_trim = duration_to_audio_frames_ceil(delta, sample_rate);
+    if frames_to_trim >= available_frames {
+        return AudioSeekFloorAction::Drop;
+    }
+
+    frame.samples = frame.samples.split_off(frames_to_trim * channels);
+    frame.frames = frame.samples.len() / channels;
+    frame.pts = Some(pts.saturating_add(Duration::from_secs_f64(
+        frames_to_trim as f64 / sample_rate as f64,
+    )));
+    AudioSeekFloorAction::Emit {
+        trimmed_frames: frames_to_trim,
+    }
+}
+
+fn duration_to_audio_frames_ceil(duration: Duration, sample_rate: u32) -> usize {
+    const NANOS_PER_SECOND: u128 = 1_000_000_000;
+    let numerator = duration.as_nanos().saturating_mul(sample_rate as u128);
+    let frames = numerator
+        .saturating_add(NANOS_PER_SECOND - 1)
+        .checked_div(NANOS_PER_SECOND)
+        .unwrap_or(0);
+    frames.min(usize::MAX as u128) as usize
 }
 
 fn trim_video_queue(frames: &mut VecDeque<Frame>, limit: usize) {
@@ -2584,6 +2730,84 @@ mod tests {
         assert_eq!(frame.text[0].display_text(), "External subtitle");
 
         let _ = fs::remove_file(path);
+    }
+
+    fn pcm_frame(pts: Duration, frames: usize) -> PcmAudioFrame {
+        PcmAudioFrame {
+            format: PcmFormat::f32_interleaved(10, 2),
+            pts: Some(pts),
+            frames,
+            samples: (0..frames * 2).map(|sample| sample as f32).collect(),
+        }
+    }
+
+    #[test]
+    fn audio_seek_floor_drops_pcm_ending_at_target() {
+        let mut frame = pcm_frame(Duration::from_secs(9), 5);
+
+        let action = trim_audio_frame_to_seek_floor(&mut frame, Duration::from_millis(9_500));
+
+        assert_eq!(action, AudioSeekFloorAction::Drop);
+    }
+
+    #[test]
+    fn audio_seek_floor_trims_overlapping_pcm_to_first_sample_at_or_after_target() {
+        let mut frame = pcm_frame(Duration::from_secs(9), 10);
+
+        let action = trim_audio_frame_to_seek_floor(&mut frame, Duration::from_millis(9_450));
+
+        assert_eq!(action, AudioSeekFloorAction::Emit { trimmed_frames: 5 });
+        assert_eq!(frame.pts, Some(Duration::from_millis(9_500)));
+        assert_eq!(frame.frames, 5);
+        assert_eq!(
+            frame.samples,
+            (10..20).map(|sample| sample as f32).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn audio_seek_floor_survives_dropped_frames_and_clears_on_emit() {
+        let target = Duration::from_secs(10);
+        let mut seek_floor = Some(target);
+        let mut preroll = pcm_frame(Duration::from_millis(9_500), 5);
+        let mut on_target = pcm_frame(target, 5);
+
+        assert!(!keep_audio_frame_after_seek_floor(
+            &mut seek_floor,
+            &mut preroll
+        ));
+        assert_eq!(seek_floor, Some(target));
+        assert!(keep_audio_frame_after_seek_floor(
+            &mut seek_floor,
+            &mut on_target
+        ));
+        assert_eq!(seek_floor, None);
+    }
+
+    #[test]
+    fn bounded_audio_filter_preserves_remaining_queue_after_deadline() {
+        let mut frames = VecDeque::from([
+            pcm_frame(Duration::from_secs(9), 5),
+            pcm_frame(Duration::from_millis(9_500), 5),
+            pcm_frame(Duration::from_secs(10), 5),
+        ]);
+        let mut filtered_frames = 0;
+        let mut inspected_frames = 0;
+        let mut reject_all = |_: &mut PcmAudioFrame| false;
+
+        let frame = pop_matching_audio_frame(
+            &mut frames,
+            &mut reject_all,
+            &mut filtered_frames,
+            &mut inspected_frames,
+            Instant::now(),
+            Duration::ZERO,
+        );
+
+        assert!(frame.is_none());
+        assert_eq!(filtered_frames, 1);
+        assert_eq!(inspected_frames, 1);
+        assert_eq!(frames.len(), 2);
     }
 
     #[test]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -1477,7 +1477,10 @@ impl PresenterRuntime {
     }
 
     fn ensure_audio_started(&mut self) {
-        if self.audio_started || !self.audio_output_ready_to_start() || !self.audio_start_allowed()
+        if !self.is_playing()
+            || self.audio_started
+            || !self.audio_output_ready_to_start()
+            || !self.audio_start_allowed()
         {
             return;
         }
@@ -2341,6 +2344,31 @@ mod tests {
             written_frames: 28_800,
             underflow_frames: 0,
         }));
+    }
+
+    #[test]
+    fn audio_start_is_blocked_while_player_is_not_playing() {
+        use crate::audio::{AudioOutputState, BufferedAudioOutput};
+        use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
+
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+        let format = PcmFormat::f32_interleaved(48_000, 2);
+        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
+        output.configure(format).unwrap();
+        output
+            .push(PcmAudioFrame {
+                format,
+                pts: Some(Duration::ZERO),
+                frames: 12_000,
+                samples: vec![0.0; 24_000],
+            })
+            .unwrap();
+        presenter.audio_output = Box::new(output);
+
+        presenter.ensure_audio_started();
+
+        assert!(!presenter.audio_started);
+        assert_eq!(presenter.audio_output.state(), AudioOutputState::Stopped);
     }
 
     #[test]

--- a/crates/erika/src/subtitle.rs
+++ b/crates/erika/src/subtitle.rs
@@ -4,6 +4,9 @@ use std::{ffi::CStr, ptr::NonNull};
 
 use thiserror::Error;
 
+#[cfg(all(feature = "libass", target_os = "ios"))]
+use crate::NIPAPLAY_FALLBACK_FONT;
+
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum SubtitleError {
     #[error("invalid subtitle timestamp: {0}")]
@@ -544,6 +547,13 @@ mod libass_ffi {
     unsafe extern "C" {
         pub fn ass_library_init() -> *mut AssLibrary;
         pub fn ass_library_done(library: *mut AssLibrary);
+        #[cfg(target_os = "ios")]
+        pub fn ass_add_font(
+            library: *mut AssLibrary,
+            name: *const c_char,
+            data: *const c_char,
+            data_size: c_int,
+        );
         pub fn ass_renderer_init(library: *mut AssLibrary) -> *mut AssRenderer;
         pub fn ass_renderer_done(renderer: *mut AssRenderer);
         pub fn ass_set_frame_size(renderer: *mut AssRenderer, width: c_int, height: c_int);
@@ -577,6 +587,8 @@ mod libass_ffi {
     }
 }
 
+#[cfg(feature = "libass")]
+const ASS_FONTPROVIDER_NONE: libc::c_int = 0;
 #[cfg(feature = "libass")]
 const ASS_FONTPROVIDER_AUTODETECT: libc::c_int = 1;
 #[cfg(feature = "libass")]
@@ -678,6 +690,8 @@ impl LibassSubtitleRenderer {
             let library = NonNull::new(libass_ffi::ass_library_init()).ok_or_else(|| {
                 SubtitleError::Libass("failed to initialize libass library".to_string())
             })?;
+
+            add_bundled_ass_fallback_font(library.as_ptr());
 
             let Some(renderer) = NonNull::new(libass_ffi::ass_renderer_init(library.as_ptr()))
             else {
@@ -1379,14 +1393,18 @@ fn escape_ass_text(value: &str) -> String {
 
 const DEFAULT_ASS_FONT_SIZE: f64 = 48.0;
 const DEFAULT_ASS_OUTLINE: f64 = 2.0;
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(target_os = "ios")]
+const DEFAULT_ASS_FONT_FAMILY: &str = "Droid Sans Fallback";
+#[cfg(target_os = "macos")]
 const DEFAULT_ASS_FONT_FAMILY: &str = "PingFang SC";
 #[cfg(not(any(target_os = "ios", target_os = "macos")))]
 const DEFAULT_ASS_FONT_FAMILY: &str = "Arial";
 
 #[cfg(feature = "libass")]
 fn default_ass_font_provider() -> libc::c_int {
-    if cfg!(any(target_os = "ios", target_os = "macos")) {
+    if cfg!(target_os = "ios") {
+        ASS_FONTPROVIDER_NONE
+    } else if cfg!(target_os = "macos") {
         ASS_FONTPROVIDER_CORETEXT
     } else {
         ASS_FONTPROVIDER_AUTODETECT
@@ -1395,12 +1413,30 @@ fn default_ass_font_provider() -> libc::c_int {
 
 #[cfg(feature = "libass")]
 fn default_ass_font_family_cstr() -> &'static CStr {
-    if cfg!(any(target_os = "ios", target_os = "macos")) {
+    if cfg!(target_os = "ios") {
+        c"Droid Sans Fallback"
+    } else if cfg!(target_os = "macos") {
         c"PingFang SC"
     } else {
         c"Arial"
     }
 }
+
+#[cfg(all(feature = "libass", target_os = "ios"))]
+unsafe fn add_bundled_ass_fallback_font(library: *mut libass_ffi::AssLibrary) {
+    debug_assert!(NIPAPLAY_FALLBACK_FONT.len() <= libc::c_int::MAX as usize);
+    unsafe {
+        libass_ffi::ass_add_font(
+            library,
+            c"subfont.ttf".as_ptr(),
+            NIPAPLAY_FALLBACK_FONT.as_ptr().cast(),
+            NIPAPLAY_FALLBACK_FONT.len() as libc::c_int,
+        );
+    }
+}
+
+#[cfg(all(feature = "libass", not(target_os = "ios")))]
+unsafe fn add_bundled_ass_fallback_font(_library: *mut libass_ffi::AssLibrary) {}
 
 fn normalize_ass_font_scale(scale: f64) -> f64 {
     if scale.is_finite() {

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -1,7 +1,11 @@
 use std::cell::RefCell;
+use std::env;
 use std::ffi::{CStr, CString, c_char};
+use std::fs::{OpenOptions, create_dir_all};
+use std::io::Write;
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::time::Duration;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crossbeam_channel::Receiver;
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
@@ -70,6 +74,62 @@ fn finalize_status(status: ErikaStatus) -> ErikaStatus {
 fn player_error(message: impl Into<String>) -> ErikaStatus {
     set_last_error(message);
     ErikaStatus::PlayerError
+}
+
+fn capi_trace_enabled() -> bool {
+    env_flag("ERIKA_CAPI_TRACE") || env_flag("ERIKA_PLAYBACK_TRACE")
+}
+
+fn env_flag(name: &str) -> bool {
+    match env::var(name).ok().as_deref() {
+        Some("0" | "false" | "FALSE" | "off" | "OFF" | "") | None => false,
+        Some(_) => true,
+    }
+}
+
+fn capi_trace_path() -> PathBuf {
+    env::var_os("ERIKA_CAPI_TRACE_FILE")
+        .or_else(|| env::var_os("ERIKA_PLAYBACK_TRACE_FILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp/erika_capi_trace.log"))
+}
+
+fn capi_trace(line: impl AsRef<str>) {
+    if !capi_trace_enabled() {
+        return;
+    }
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis())
+        .unwrap_or(0);
+    let path = capi_trace_path();
+    if let Some(parent) = path.parent() {
+        let _ = create_dir_all(parent);
+    }
+    let line = format!("[erika-capi-trace] ts_ms={now_ms} {}", line.as_ref());
+    eprintln!("{line}");
+    let _ = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .and_then(|mut file| writeln!(file, "{line}"));
+}
+
+fn redacted_uri(uri: &str) -> String {
+    let mut value = uri.to_string();
+    for key in ["token=", "api_key=", "AccessToken="] {
+        let mut search_from = 0;
+        while let Some(relative) = value[search_from..].find(key) {
+            let start = search_from + relative + key.len();
+            let end = value[start..]
+                .find('&')
+                .map(|relative_end| start + relative_end)
+                .unwrap_or(value.len());
+            value.replace_range(start..end, "REDACTED");
+            search_from = start + "REDACTED".len();
+        }
+    }
+    value
 }
 
 #[repr(C)]
@@ -433,6 +493,11 @@ pub struct ErikaPresenterStats {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn erika_create() -> *mut ErikaHandle {
+    capi_trace(format!(
+        "fn=erika_create playback_trace={} playback_trace_file={}",
+        env::var("ERIKA_PLAYBACK_TRACE").unwrap_or_else(|_| "<unset>".to_string()),
+        env::var("ERIKA_PLAYBACK_TRACE_FILE").unwrap_or_else(|_| "<unset>".to_string()),
+    ));
     let player = Player::new(PlayerConfig::default());
     let events = player.subscribe();
     Box::into_raw(Box::new(ErikaHandle { player, events }))
@@ -465,21 +530,39 @@ pub unsafe extern "C" fn erika_open(handle: *mut ErikaHandle, uri: *const c_char
             Ok(uri) => uri,
             Err(status) => return status,
         };
-        status_from_player_result(handle.player.open(MediaRequest::new(uri)))
+        capi_trace(format!(
+            "fn=erika_open handle={handle:p} uri={}",
+            redacted_uri(&uri)
+        ));
+        let status = status_from_player_result(handle.player.open(MediaRequest::new(uri)));
+        capi_trace(format!(
+            "fn=erika_open.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_play(handle: *mut ErikaHandle) -> ErikaStatus {
     with_handle_mut(handle, |handle| {
-        status_from_player_result(handle.player.play())
+        capi_trace(format!("fn=erika_play handle={handle:p}"));
+        let status = status_from_player_result(handle.player.play());
+        capi_trace(format!(
+            "fn=erika_play.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_pause(handle: *mut ErikaHandle) -> ErikaStatus {
     with_handle_mut(handle, |handle| {
-        status_from_player_result(handle.player.pause())
+        capi_trace(format!("fn=erika_pause handle={handle:p}"));
+        let status = status_from_player_result(handle.player.pause());
+        capi_trace(format!(
+            "fn=erika_pause.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -500,7 +583,15 @@ pub unsafe extern "C" fn erika_close(handle: *mut ErikaHandle) -> ErikaStatus {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_seek(handle: *mut ErikaHandle, position_micros: u64) -> ErikaStatus {
     with_handle_mut(handle, |handle| {
-        status_from_player_result(handle.player.seek(Duration::from_micros(position_micros)))
+        capi_trace(format!(
+            "fn=erika_seek handle={handle:p} position_micros={position_micros}"
+        ));
+        let status =
+            status_from_player_result(handle.player.seek(Duration::from_micros(position_micros)));
+        capi_trace(format!(
+            "fn=erika_seek.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -720,7 +811,12 @@ pub unsafe extern "C" fn erika_poll_event(
     }
     with_handle_mut(handle, |handle| match handle.events.try_recv() {
         Ok(event) => {
-            unsafe { *out_event = event_to_c(event) };
+            let event = event_to_c(event);
+            capi_trace(format!(
+                "fn=erika_poll_event event={:?} state={:?} position_micros={} duration_micros={}",
+                event.kind, event.state, event.position_micros, event.duration_micros
+            ));
+            unsafe { *out_event = event };
             ErikaStatus::Ok
         }
         Err(crossbeam_channel::TryRecvError::Empty) => ErikaStatus::NoEvent,
@@ -731,6 +827,11 @@ pub unsafe extern "C" fn erika_poll_event(
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "windows"))]
 #[unsafe(no_mangle)]
 pub extern "C" fn erika_presenter_create() -> *mut ErikaPresenterHandle {
+    capi_trace(format!(
+        "fn=erika_presenter_create playback_trace={} playback_trace_file={}",
+        env::var("ERIKA_PLAYBACK_TRACE").unwrap_or_else(|_| "<unset>".to_string()),
+        env::var("ERIKA_PLAYBACK_TRACE_FILE").unwrap_or_else(|_| "<unset>".to_string()),
+    ));
     create_presenter_handle(PresenterConfig::default())
 }
 
@@ -784,9 +885,12 @@ fn create_presenter_handle(config: PresenterConfig) -> *mut ErikaPresenterHandle
         Ok(presenter) => {
             clear_last_error();
             let events = presenter.player().subscribe();
-            Box::into_raw(Box::new(ErikaPresenterHandle { presenter, events }))
+            let handle = Box::into_raw(Box::new(ErikaPresenterHandle { presenter, events }));
+            capi_trace(format!("fn=create_presenter_handle.done handle={handle:p}"));
+            handle
         }
         Err(error) => {
+            capi_trace(format!("fn=create_presenter_handle.error error={error}"));
             set_last_error(format!("presenter create failed: {error}"));
             std::ptr::null_mut()
         }
@@ -960,7 +1064,15 @@ pub unsafe extern "C" fn erika_presenter_open(
             Ok(uri) => uri,
             Err(status) => return status,
         };
-        status_from_player_result(handle.presenter.open(MediaRequest::new(uri)))
+        capi_trace(format!(
+            "fn=erika_presenter_open handle={handle:p} uri={}",
+            redacted_uri(&uri)
+        ));
+        let status = status_from_player_result(handle.presenter.open(MediaRequest::new(uri)));
+        capi_trace(format!(
+            "fn=erika_presenter_open.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -968,7 +1080,12 @@ pub unsafe extern "C" fn erika_presenter_open(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_play(handle: *mut ErikaPresenterHandle) -> ErikaStatus {
     with_presenter_mut(handle, |handle| {
-        status_from_player_result(handle.presenter.play())
+        capi_trace(format!("fn=erika_presenter_play handle={handle:p}"));
+        let status = status_from_player_result(handle.presenter.play());
+        capi_trace(format!(
+            "fn=erika_presenter_play.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -976,7 +1093,12 @@ pub unsafe extern "C" fn erika_presenter_play(handle: *mut ErikaPresenterHandle)
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_pause(handle: *mut ErikaPresenterHandle) -> ErikaStatus {
     with_presenter_mut(handle, |handle| {
-        status_from_player_result(handle.presenter.pause())
+        capi_trace(format!("fn=erika_presenter_pause handle={handle:p}"));
+        let status = status_from_player_result(handle.presenter.pause());
+        capi_trace(format!(
+            "fn=erika_presenter_pause.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -1003,11 +1125,18 @@ pub unsafe extern "C" fn erika_presenter_seek(
     position_micros: u64,
 ) -> ErikaStatus {
     with_presenter_mut(handle, |handle| {
-        status_from_player_result(
+        capi_trace(format!(
+            "fn=erika_presenter_seek handle={handle:p} position_micros={position_micros}"
+        ));
+        let status = status_from_player_result(
             handle
                 .presenter
                 .seek(Duration::from_micros(position_micros)),
-        )
+        );
+        capi_trace(format!(
+            "fn=erika_presenter_seek.done handle={handle:p} status={status:?}"
+        ));
+        status
     })
 }
 
@@ -1930,6 +2059,18 @@ pub unsafe extern "C" fn erika_presenter_poll_event(
             Ok(event) => {
                 let event = event_to_c(event);
                 let is_error = event.kind == ErikaEventKind::Error;
+                capi_trace(format!(
+                    "fn=erika_presenter_poll_event event={:?} state={:?} position_micros={} duration_micros={} video={}x{} tracks={}/{}/{}",
+                    event.kind,
+                    event.state,
+                    event.position_micros,
+                    event.duration_micros,
+                    event.video.width,
+                    event.video.height,
+                    event.tracks.video,
+                    event.tracks.audio,
+                    event.tracks.subtitle,
+                ));
                 unsafe { *out_event = event };
                 if !is_error {
                     clear_last_error();


### PR DESCRIPTION
## Summary

- filter or trim decoded audio preroll against an independent audio seek floor so pre-target PCM cannot re-enter the output after seeking
- keep audio output stopped while the presenter is paused and improve opt-in, redacted playback/C API tracing
- register Erika's bundled Droid Sans Fallback with libass as an in-memory font on iOS and avoid the CoreText file-path provider there
- share the bundled fallback font bytes with the existing danmaku renderer instead of embedding a second copy

## Root cause

After a seek, video preroll was discarded but audio preroll could still reach the output queue. That let the audio clock and video presentation resume from different sides of the seek target.

For ASS subtitles on iOS 26, CoreText returned the private `PingFangUI.ttc` path to libass. The app could not open that path, so libass repeatedly retried font fallback for individual CJK glyphs. This produced missing-glyph boxes and could reduce playback to single-digit frame rates.

## Impact

Seek playback resumes with audio and video aligned. Chinese ASS subtitles on iOS use the bundled fallback font without touching inaccessible system font paths, avoiding both tofu glyphs and the associated rendering stall. Other platforms keep their existing font providers.

## Validation

- `cargo test -p erika --features libass --lib`: 218 passed
- `cargo test -p erika_capi --lib`: 17 passed
- `cargo check -p erika --target aarch64-apple-ios --features libass`
- Flutter Debug build installed on a physical Mate 50 Pro running iOS 26.5
- verified repeated seeks and Jellyfin external ASS playback on device; audio/video remained aligned and subtitle glyphs rendered without the previous frame-rate collapse
