### PR TITLE
Preserve danmaku tracks across planning windows

### DIFF
--- a/crates/erika/src/danmaku.rs
+++ b/crates/erika/src/danmaku.rs
@@ -1735,6 +1735,8 @@ pub struct DfmLayoutEngine {
     config: DanmakuLayoutConfig,
     rasterizer: DanmakuTextRasterizer,
     prepared: Option<DfmPreparedLayout>,
+    stable_tracks: HashMap<u64, usize>,
+    stable_viewport: Option<DanmakuViewport>,
 }
 
 impl DfmLayoutEngine {
@@ -1746,12 +1748,15 @@ impl DfmLayoutEngine {
             config,
             rasterizer,
             prepared: None,
+            stable_tracks: HashMap::new(),
+            stable_viewport: None,
         }
     }
 
     pub fn set_timeline(&mut self, timeline: DanmakuTimeline) {
         self.timeline = timeline;
         self.prepared = None;
+        self.invalidate_stable_tracks();
     }
 
     pub fn sync_timeline(&mut self, timeline: &DanmakuTimeline) {
@@ -1764,6 +1769,7 @@ impl DfmLayoutEngine {
     pub fn clear_timeline(&mut self) {
         self.timeline = DanmakuTimeline::default();
         self.prepared = None;
+        self.invalidate_stable_tracks();
     }
 
     pub fn set_config(&mut self, config: DanmakuLayoutConfig) -> bool {
@@ -1778,6 +1784,7 @@ impl DfmLayoutEngine {
             self.rasterizer = DanmakuTextRasterizer::for_config(&self.config);
         }
         self.prepared = None;
+        self.invalidate_stable_tracks();
         true
     }
 
@@ -1786,10 +1793,28 @@ impl DfmLayoutEngine {
     }
 
     pub fn prepare(&mut self, viewport: DanmakuViewport, _generation: u64) -> DfmPreparedLayout {
+        if self.stable_viewport != Some(viewport) {
+            self.invalidate_stable_tracks();
+            self.stable_viewport = Some(viewport);
+        }
         let config = self.config.sanitized();
-        let prepared = prepare_layout(&self.timeline, viewport, &config, &self.rasterizer);
+        let prepared = prepare_layout(
+            &self.timeline,
+            viewport,
+            &config,
+            &self.rasterizer,
+            &self.stable_tracks,
+        );
+        for item in prepared.items() {
+            self.stable_tracks.insert(item.id, item.track_index);
+        }
         self.prepared = Some(prepared.clone());
         prepared
+    }
+
+    pub fn invalidate_stable_tracks(&mut self) {
+        self.stable_tracks.clear();
+        self.stable_viewport = None;
     }
 
     pub fn frame_layout(
@@ -1837,6 +1862,7 @@ fn prepare_layout(
     viewport: DanmakuViewport,
     config: &DanmakuLayoutConfig,
     rasterizer: &DanmakuTextRasterizer,
+    stable_tracks: &HashMap<u64, usize>,
 ) -> DfmPreparedLayout {
     if timeline.is_empty() || !config.enabled {
         let dfm_layout = dfm::PreparedLayout {
@@ -1899,6 +1925,7 @@ fn prepare_layout(
         max_lines_per_type: config.max_lines_per_mode,
         track_gap_ratio: config.track_gap_ratio as f64,
         outline_width: config.outline_width as f64,
+        preferred_tracks: stable_tracks,
         block_words: config.block_words.clone(),
         block_top: config.block_top,
         block_bottom: config.block_bottom,
@@ -2619,6 +2646,62 @@ mod tests {
             &prepared.items()[0].text_layout,
             &first_text_layout
         ));
+    }
+
+    #[test]
+    fn sliding_timeline_window_preserves_tracks_for_overlapping_items() {
+        let timeline = DanmakuTimeline::new(
+            (0..80)
+                .map(|index| {
+                    let mut entry = item(
+                        index as f64 * 0.25,
+                        &format!("scroll {index}"),
+                        DanmakuMode::Scroll,
+                    );
+                    entry.id = index + 1;
+                    entry
+                })
+                .collect(),
+        )
+        .unwrap();
+        let config = DanmakuLayoutConfig {
+            allow_stacking: true,
+            merge_duplicates: false,
+            ..DanmakuLayoutConfig::default()
+        };
+        let viewport = DanmakuViewport::new(640, 360);
+        let first_window = timeline.window(Duration::ZERO, Duration::from_secs(12));
+        let second_window = timeline.window(Duration::from_secs(4), Duration::from_secs(16));
+        let mut engine = DfmLayoutEngine::new(first_window, config.clone());
+
+        let first = engine.prepare(viewport, 1);
+        let first_tracks = first
+            .items()
+            .iter()
+            .map(|item| (item.id, item.track_index))
+            .collect::<HashMap<_, _>>();
+        engine.sync_timeline(&second_window);
+        let second = engine.prepare(viewport, 1);
+
+        let overlap = second
+            .items()
+            .iter()
+            .filter_map(|item| {
+                first_tracks
+                    .get(&item.id)
+                    .map(|track| (*track, item.track_index))
+            })
+            .collect::<Vec<_>>();
+        assert!(!overlap.is_empty());
+        assert!(overlap.iter().all(|(before, after)| before == after));
+
+        let mut fresh_engine = DfmLayoutEngine::new(second_window, config);
+        let fresh = fresh_engine.prepare(viewport, 1);
+        assert!(fresh.items().iter().any(|item| {
+            first_tracks
+                .get(&item.id)
+                .is_some_and(|track| *track != item.track_index)
+        }));
     }
 
     #[test]

--- a/crates/erika/src/danmaku/dfm.rs
+++ b/crates/erika/src/danmaku/dfm.rs
@@ -7,6 +7,8 @@
 
 use rustc_hash::{FxHashMap, FxHasher};
 
+use std::collections::HashMap;
+
 use super::dfm_core::{
     filters::{FilterContext, FilterSystem},
     model::{DanmakuItem, DanmakuType, Duration, GlobalFlags},
@@ -31,7 +33,7 @@ pub struct PrepareItem {
 }
 
 #[derive(Debug, Clone)]
-pub struct PrepareRequest {
+pub struct PrepareRequest<'a> {
     pub items: Vec<PrepareItem>,
     pub width: f64,
     pub height: f64,
@@ -45,6 +47,7 @@ pub struct PrepareRequest {
     pub max_lines_per_type: Option<u32>,
     pub track_gap_ratio: f64,
     pub outline_width: f64,
+    pub preferred_tracks: &'a HashMap<u64, usize>,
     pub block_words: Vec<String>,
     pub block_top: bool,
     pub block_bottom: bool,
@@ -222,7 +225,8 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
     for (type_idx, _) in type_order.iter().enumerate() {
         for &i in &type_indices[type_idx] {
             let is_me = items[i].1;
-            let (placed, displaced_index) = retainer.fix_with_options(
+            let preferred_track = request.preferred_tracks.get(&items[i].0).copied();
+            let (placed, displaced_index) = retainer.fix_with_options_and_preferred_track(
                 &mut items[i].4,
                 width,
                 height,
@@ -231,6 +235,7 @@ pub fn prepare_layout(request: PrepareRequest) -> Result<PreparedLayout, String>
                 is_me,
                 request.allow_stacking,
                 request.allow_scroll_overwrite,
+                preferred_track,
             );
             if !placed {
                 items[i].4.is_filtered = true;

--- a/crates/erika/src/danmaku/dfm_core/retainer.rs
+++ b/crates/erika/src/danmaku/dfm_core/retainer.rs
@@ -146,6 +146,31 @@ impl DanmakuRetainer {
         allow_stacking: bool,
         allow_scroll_overwrite: bool,
     ) -> (bool, DisplacedIndices) {
+        self.fix_with_options_and_preferred_track(
+            item,
+            view_width,
+            view_height,
+            flags,
+            display_area,
+            is_me,
+            allow_stacking,
+            allow_scroll_overwrite,
+            None,
+        )
+    }
+
+    pub fn fix_with_options_and_preferred_track(
+        &mut self,
+        item: &mut DanmakuItem,
+        view_width: f32,
+        view_height: f32,
+        flags: &GlobalFlags,
+        display_area: f32,
+        is_me: bool,
+        allow_stacking: bool,
+        allow_scroll_overwrite: bool,
+        preferred_track: Option<usize>,
+    ) -> (bool, DisplacedIndices) {
         // Each type has independent track systems (r2l_tracks, top_tracks, etc.).
         // Respect display_area exactly; display_area=1.0 means full-screen danmaku.
         let effective_height = view_height * display_area;
@@ -166,6 +191,7 @@ impl DanmakuRetainer {
                     is_me,
                     allow_stacking,
                     allow_scroll_overwrite,
+                    preferred_track,
                 ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
@@ -186,6 +212,7 @@ impl DanmakuRetainer {
                     is_me,
                     allow_stacking,
                     allow_scroll_overwrite,
+                    preferred_track,
                 ) {
                     Some((row, displaced)) => {
                         item.y = self.margin + row as f32 * track_height;
@@ -198,7 +225,8 @@ impl DanmakuRetainer {
             }
             DanmakuType::FixTop => {
                 self.top_tracks.ensure_track_count(track_count);
-                match select_fixed_track(&entry, &mut self.top_tracks, track_count) {
+                match select_fixed_track(&entry, &mut self.top_tracks, track_count, preferred_track)
+                {
                     Some(row) => {
                         item.y = self.margin + row as f32 * track_height;
                         item.is_shown = true;
@@ -210,7 +238,12 @@ impl DanmakuRetainer {
             }
             DanmakuType::FixBottom => {
                 self.bottom_tracks.ensure_track_count(track_count);
-                match select_fixed_track(&entry, &mut self.bottom_tracks, track_count) {
+                match select_fixed_track(
+                    &entry,
+                    &mut self.bottom_tracks,
+                    track_count,
+                    preferred_track,
+                ) {
                     Some(row) => {
                         item.y = effective_height - (row as f32 + 1.0) * track_height;
                         item.is_shown = true;
@@ -248,8 +281,20 @@ fn select_scroll_track(
     is_me: bool,
     allow_stacking: bool,
     allow_scroll_overwrite: bool,
+    preferred_track: Option<usize>,
 ) -> Option<(usize, DisplacedIndices)> {
     track_data.compact(new_entry.time_ms, new_entry.duration_ms);
+
+    if let Some(row) = preferred_track.filter(|row| *row < track_count) {
+        let can_reuse = allow_stacking
+            || track_data.tracks[row]
+                .iter()
+                .all(|existing| !scroll_entries_collide(new_entry, existing, view_width));
+        if can_reuse {
+            track_data.tracks[row].push(new_entry.clone());
+            return Some((row, SmallVec::new()));
+        }
+    }
 
     if allow_stacking && track_count > 0 {
         let row = stack_track_for(new_entry, track_count);
@@ -357,6 +402,7 @@ fn select_fixed_track(
     new_entry: &TrackEntry,
     track_data: &mut TrackData,
     track_count: usize,
+    preferred_track: Option<usize>,
 ) -> Option<usize> {
     let new_start = new_entry.time_ms;
 
@@ -366,6 +412,13 @@ fn select_fixed_track(
     }
 
     let tracks = &mut track_data.tracks;
+    if let Some(row) = preferred_track.filter(|row| *row < track_count) {
+        let track = &mut tracks[row];
+        if track.is_empty() || new_start >= track.last().expect("track is not empty").end_ms() {
+            track.push(new_entry.clone());
+            return Some(row);
+        }
+    }
     for i in 0..track_count {
         if tracks[i].is_empty() {
             tracks[i].push(new_entry.clone());

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -1585,6 +1585,7 @@ fn run_async_danmaku_planner(
         if let Some((revision, next_timeline, next_config)) = config_update {
             timeline = next_timeline;
             config = next_config;
+            engine.invalidate_stable_tracks();
             engine.set_config(config.clone());
             applied_config_revision = revision;
         }


### PR DESCRIPTION
## Summary

- preserve track assignments for danmaku items that overlap consecutive asynchronous planning windows
- register reused tracks in the DFM retainer so newly planned items still perform collision checks against the actual occupied tracks
- invalidate cached assignments when the viewport, layout configuration, or source timeline changes
- add a regression test covering track continuity across sliding timeline windows

## Root cause

The presenter plans an 8-second danmaku lookahead and refreshes it when roughly 4 seconds remain. Each refresh replaces the prepared timeline window. Because the DFM retainer previously started empty for every replacement, danmaku items shared by the old and new windows could be assigned different vertical tracks while they were still visible, making them jump vertically near the left side of the screen.

## Impact

Scrolling danmaku now keeps its original vertical position across planner refreshes. New items continue to use the normal collision and stacking rules.

## Validation

- `cargo check -p erika --features libass`
- `cargo test -p erika --features libass` (219 tests)
- `cargo check -p erika_capi`
- `cargo fmt --all -- --check`
- `git diff --check`
- manual playback verification in NipaPlay Debug with the Erika backend across multiple planner refresh cycles
