### PR TITLE
Add playback clock contract tests

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -1571,7 +1571,57 @@ mod tests {
     }
 
     #[test]
-    fn player_seek_updates_shared_media_time_and_generation_immediately() {
+    fn player_rapid_seeks_enqueue_fifo_and_publish_latest_target() {
+        let player = Player::new(PlayerConfig::default());
+        let events = player.subscribe();
+        let receiver = {
+            let (commands, receiver) = unbounded();
+            let mut inner = player.inner.lock().expect("player mutex poisoned");
+            inner.state = PlayerState::Playing;
+            inner.playback = Some(PlaybackRuntime {
+                commands,
+                worker: None,
+            });
+            receiver
+        };
+        let before_generation = player.playback_generation();
+        let targets = [
+            Duration::from_secs(1),
+            Duration::from_secs(4),
+            Duration::from_secs(2),
+        ];
+
+        for target in targets {
+            player.seek(target).unwrap();
+        }
+
+        let queued_targets = receiver
+            .try_iter()
+            .map(|command| match command {
+                PlaybackCommand::Seek(position) => position,
+                _ => panic!("unexpected playback command"),
+            })
+            .collect::<Vec<_>>();
+        let published_targets = events
+            .try_iter()
+            .map(|event| match event {
+                PlayerEvent::PositionChanged(position) => position,
+                _ => panic!("unexpected player event"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(queued_targets, targets);
+        assert_eq!(published_targets, targets);
+        assert_eq!(player.current_media_time(), targets[2]);
+        assert_eq!(
+            player.playback_generation(),
+            before_generation + targets.len() as u64
+        );
+        assert_eq!(player.state(), PlayerState::Playing);
+    }
+
+    #[test]
+    fn player_seek_updates_shared_media_time_and_generation_immediately_when_ready() {
         let player = Player::new(PlayerConfig::default());
         let receiver = {
             let (commands, receiver) = bounded(1);
@@ -1592,7 +1642,37 @@ mod tests {
             Ok(PlaybackCommand::Seek(position)) if position == Duration::from_secs(12)
         ));
         assert_eq!(player.current_media_time(), Duration::from_secs(12));
-        assert!(player.playback_generation() > before_generation);
+        assert_eq!(player.playback_generation(), before_generation + 1);
+        assert_eq!(player.state(), PlayerState::Ready);
+    }
+
+    #[test]
+    fn player_seek_while_paused_preserves_paused_state() {
+        let player = Player::new(PlayerConfig::default());
+        let events = player.subscribe();
+        let receiver = {
+            let (commands, receiver) = unbounded();
+            let mut inner = player.inner.lock().expect("player mutex poisoned");
+            inner.state = PlayerState::Paused;
+            inner.current_media_time = Duration::from_secs(8);
+            inner.playback = Some(PlaybackRuntime {
+                commands,
+                worker: None,
+            });
+            receiver
+        };
+        let target = Duration::from_secs(23);
+
+        player.seek(target).unwrap();
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(PlaybackCommand::Seek(position)) if position == target
+        ));
+        assert_eq!(player.current_media_time(), target);
+        assert_eq!(player.state(), PlayerState::Paused);
+        assert_eq!(events.try_recv(), Ok(PlayerEvent::PositionChanged(target)));
+        assert!(events.try_recv().is_err());
     }
 
     #[test]

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -2811,31 +2811,118 @@ mod tests {
     }
 
     #[test]
-    fn playback_clock_tracks_pause_seek_and_rate() {
+    fn playback_clock_paused_seek_remains_frozen() {
         let t0 = Instant::now();
         let mut clock = PlaybackClock::paused_at(Duration::from_secs(10));
 
-        assert_eq!(clock.media_time_at(t0), Duration::from_secs(10));
-        clock.play(t0);
-        assert_eq!(
-            clock.media_time_at(t0 + Duration::from_millis(250)),
-            Duration::from_millis(10_250)
-        );
+        clock.seek(Duration::from_secs(2), t0);
 
-        clock.pause(t0 + Duration::from_millis(500));
+        assert!(!clock.is_running());
+        assert_eq!(clock.media_time_at(t0), Duration::from_secs(2));
         assert_eq!(
-            clock.media_time_at(t0 + Duration::from_secs(10)),
+            clock.media_time_at(t0 + Duration::from_secs(60)),
+            Duration::from_secs(2)
+        );
+    }
+
+    #[test]
+    fn playback_clock_pause_freezes_accumulated_time() {
+        let t0 = Instant::now();
+        let mut clock = PlaybackClock::paused_at(Duration::from_secs(10));
+        let pause_time = t0 + Duration::from_millis(500);
+
+        clock.play(t0);
+        clock.pause(pause_time);
+
+        assert!(!clock.is_running());
+        assert_eq!(
+            clock.media_time_at(pause_time),
             Duration::from_millis(10_500)
         );
-
-        clock.seek(Duration::from_secs(2), t0 + Duration::from_secs(10));
-        clock.play(t0 + Duration::from_secs(10));
-        clock.set_rate(2.0, t0 + Duration::from_secs(11));
-
         assert_eq!(
-            clock.media_time_at(t0 + Duration::from_secs(12)),
-            Duration::from_secs(5)
+            clock.media_time_at(pause_time + Duration::from_secs(60)),
+            Duration::from_millis(10_500)
         );
+    }
+
+    #[test]
+    fn playback_clock_paused_seek_then_resume_starts_from_new_target() {
+        let t0 = Instant::now();
+        let mut clock = PlaybackClock::running_at(Duration::from_secs(10), t0);
+        let pause_time = t0 + Duration::from_millis(500);
+        let seek_time = pause_time + Duration::from_secs(5);
+        let resume_time = seek_time + Duration::from_secs(5);
+
+        clock.pause(pause_time);
+        clock.seek(Duration::from_secs(2), seek_time);
+
+        assert!(!clock.is_running());
+        assert_eq!(clock.media_time_at(resume_time), Duration::from_secs(2));
+
+        clock.play(resume_time);
+
+        assert_eq!(clock.media_time_at(resume_time), Duration::from_secs(2));
+        assert_eq!(
+            clock.media_time_at(resume_time + Duration::from_millis(250)),
+            Duration::from_millis(2_250)
+        );
+    }
+
+    #[test]
+    fn playback_clock_running_seek_reanchors_elapsed_time() {
+        let t0 = Instant::now();
+        let mut clock = PlaybackClock::running_at(Duration::from_secs(10), t0);
+        let seek_time = t0 + Duration::from_secs(3);
+
+        clock.seek(Duration::from_secs(2), seek_time);
+
+        assert!(clock.is_running());
+        assert_eq!(clock.media_time_at(seek_time), Duration::from_secs(2));
+        assert_eq!(
+            clock.media_time_at(seek_time + Duration::from_millis(750)),
+            Duration::from_millis(2_750)
+        );
+    }
+
+    #[test]
+    fn playback_clock_rate_change_is_continuous_and_scales_elapsed_time() {
+        let t0 = Instant::now();
+        let mut clock = PlaybackClock::running_at(Duration::from_secs(10), t0);
+        let rate_change_time = t0 + Duration::from_millis(500);
+
+        clock.set_rate(2.0, rate_change_time);
+
+        assert_eq!(clock.rate(), 2.0);
+        assert_eq!(
+            clock.media_time_at(rate_change_time),
+            Duration::from_millis(10_500)
+        );
+        assert_eq!(
+            clock.media_time_at(rate_change_time + Duration::from_secs(1)),
+            Duration::from_millis(12_500)
+        );
+    }
+
+    #[test]
+    fn playback_clock_invalid_rate_falls_back_to_one() {
+        let t0 = Instant::now();
+
+        for invalid_rate in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let mut clock = PlaybackClock::running_at(Duration::from_secs(10), t0);
+            let rate_change_time = t0 + Duration::from_millis(500);
+
+            clock.set_rate(invalid_rate, rate_change_time);
+
+            assert_eq!(clock.rate(), 1.0);
+            assert_eq!(
+                clock.media_time_at(rate_change_time),
+                Duration::from_millis(10_500)
+            );
+            assert_eq!(
+                clock.media_time_at(rate_change_time + Duration::from_secs(1)),
+                Duration::from_millis(11_500)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- lock rapid seek command/event FIFO and latest-target generation behavior
- preserve seek contracts in Ready and Paused states
- cover pause freezing, paused seek/resume, running seek re-anchoring, rate continuity, and invalid-rate fallback

## Why

These tests establish the existing playback clock and Player command contracts before deeper playback-state refactoring. They make timing and seek regressions observable without changing production behavior.

## Impact

Test-only change. No production code, public API, ABI, dependency, or release artifact changes.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p erika --lib` — 226 passed