### PR TITLE
chore(release): prepare v0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # Build prebuilt erika_capi bundles and attach them to a GitHub Release.
 #
-# Trigger: push a tag like `v0.1.2` to publish. Use the manual "Run workflow"
+# Trigger: push a tag like `v0.1.3` to publish. Use the manual "Run workflow"
 # button (workflow_dispatch) to dry-run the builds without publishing (the
 # publish job is gated on a tag ref).
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.1.3 - 2026-07-17
+
+### Android playback and packaging
+
+- Added the complete MediaCodec, AHardwareBuffer/wgpu, AAudio, Flutter
+  PlatformView, SAF/content-source, subtitle, danmaku, screenshot, SDR/HDR,
+  diagnostics, and recovery paths.
+- `ERIKA_PREBUILT=1` now stages `liberika_capi.so` and `libc++_shared.so` from
+  the tagged Android release archive for the requested Flutter ABIs, with an
+  explicit source-build fallback.
+
 ### Breaking C API surface-size semantics
 
 The `width` and `height` arguments passed to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capi_smoke"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika_capi",
 ]
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "coreaudio_smoke"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -330,7 +330,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "danmaku_perf_lab"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "erika",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "danmaku_sync_smoke"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
@@ -385,7 +385,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erika"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ab_glyph",
  "aho-corasick",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "erika_capi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "erika_ffmpeg_sys"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bindgen 0.72.1",
  "libc",
@@ -447,42 +447,42 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg_audio_decode"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_decode"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_demux"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_probe"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_probe_source"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "ffmpeg_videotoolbox"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
@@ -870,7 +870,7 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "macos_native_demo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "crossbeam-channel",
@@ -894,14 +894,14 @@ dependencies = [
 
 [[package]]
 name = "metal_import_videotoolbox"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "metal_overlay_check"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "erika",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "metal_presenter_check"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "erika",
@@ -1240,21 +1240,21 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "playback_audio_tick"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "playback_tick"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
 
 [[package]]
 name = "player_tick"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "erika",
@@ -1413,7 +1413,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "render_pipeline_plan"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
 ]
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_decode_png"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
  "png",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_overlay_png"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
  "png",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_video_png"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
  "png",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "wgpu_window_check"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cc",
  "erika",
@@ -2350,7 +2350,7 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_native_demo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "erika",
  "windows-sys 0.61.2",
@@ -2415,7 +2415,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/AimesSoft/Erika"
 rust-version = "1.92"
-version = "0.1.2"
+version = "0.1.3"
 
 [workspace.dependencies]
 ab_glyph = "0.2.32"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -48,8 +48,8 @@ The release is fully automated by
    section, and bump `version` in the root `Cargo.toml` if appropriate.
 2. Tag and push:
    ```sh
-   git tag v0.1.2
-   git push origin v0.1.2
+   git tag v0.1.3
+   git push origin v0.1.3
    ```
 3. The workflow builds the macOS / iOS / Windows / Android bundles (each builds the native
    deps from source, so expect a long run on a cold cache) and attaches the
@@ -83,12 +83,12 @@ Enable it by setting environment variables in the host app's build:
 | Variable | Effect |
 |----------|--------|
 | `ERIKA_PREBUILT=1` | Download the prebuilt `erika_capi` instead of building from source. |
-| `ERIKA_PREBUILT_TAG=v0.1.2` | Release tag to download (default `v0.1.2`). |
-| `ERIKA_FORCE_SOURCE_BUILD=1` | macOS/iOS only: bypass the prebuilt path and build the local source, useful when debugging Erika changes through the Flutter plugin. |
+| `ERIKA_PREBUILT_TAG=v0.1.3` | Release tag to download (default `v0.1.3`). |
+| `ERIKA_FORCE_SOURCE_BUILD=1` | Bypass the prebuilt path and build the local source, useful when debugging Erika changes through the Flutter plugin. |
 
 - **Windows** (`build_erika_runtime.cmake`): downloads `erika-capi-windows-x64.zip`
   and drops `erika_capi.dll` where the plugin bundles it. The plugin loads the
-  DLL dynamically, so this is feature-agnostic and works against `v0.1.2`.
+  DLL dynamically, so this is feature-agnostic and works against `v0.1.3`.
 - **iOS** (podspec): downloads `erika-capi-ios.zip`, picks the device or
   simulator slice from the XCFramework, and links it. The prebuilt static lib
   must be built `--no-default-features --features libass` to match the plugin's
@@ -101,10 +101,10 @@ Enable it by setting environment variables in the host app's build:
   universal dylib from source. `ERIKA_MACOS_CAPI_DYLIB` can point at an explicit
   dylib instead. The macOS plugin is self-contained, so a host app no longer
   needs its own dylib-provisioning step.
-- **Android**: `erika-capi-android.zip` provides `liberika_capi.so`,
-  `liberika_capi.a`, and `libc++_shared.so` per Android ABI. Flutter integration
-  packages the shared pair directly; native C/C++ embedders may instead link
-  the static archive and provide the matching C++ runtime themselves.
+- **Android** (`erika-native.gradle`): downloads `erika-capi-android.zip` and
+  stages `liberika_capi.so` plus `libc++_shared.so` for the requested Flutter
+  ABIs. Native C/C++ embedders may instead link the bundled static archive and
+  provide the matching C++ runtime themselves.
 
 Pin `ERIKA_PREBUILT_TAG` to a release whose Erika source matches the plugin
 revision you build against, so the C ABI in the header and the prebuilt library

--- a/packages/erika_flutter/README.md
+++ b/packages/erika_flutter/README.md
@@ -52,11 +52,11 @@ points the build phase at an explicit dylib to bundle instead of building.
 
 To skip building Erika (and FFmpeg) from source, set `ERIKA_PREBUILT=1` in the
 app build to download the prebuilt `erika_capi` from a GitHub Release
-(`ERIKA_PREBUILT_TAG` selects the tag, default `v0.1.2`). Supported on macOS,
-Windows, and iOS; any failure falls back to the source build. See
+(`ERIKA_PREBUILT_TAG` selects the tag, default `v0.1.3`). Supported on macOS,
+Windows, iOS, and Android; any failure falls back to the source build. See
 [`docs/releasing.md`](../../docs/releasing.md).
 
-When debugging local Erika source changes on macOS or iOS, set
+When debugging local Erika source changes, set
 `ERIKA_FORCE_SOURCE_BUILD=1` to bypass the prebuilt download path even if the
 host app enables `ERIKA_PREBUILT=1`.
 

--- a/packages/erika_flutter/android/erika-native.gradle
+++ b/packages/erika_flutter/android/erika-native.gradle
@@ -270,8 +270,14 @@ tasks.register("buildErikaAndroidRuntime") {
                     def destination = generatedJniLibs.get().dir(abi).asFile
                     project.copy {
                         from(project.zipTree(prebuiltArchive)) {
+                            // Official release bundles have an
+                            // erika-capi-android/ top-level directory. Keep
+                            // accepting a flat lib/ layout as well for mirrors
+                            // and locally produced archives.
                             include "lib/android/$abi/liberika_capi.so"
                             include "lib/android/$abi/libc++_shared.so"
+                            include "erika-capi-android/lib/android/$abi/liberika_capi.so"
+                            include "erika-capi-android/lib/android/$abi/libc++_shared.so"
                             eachFile { details -> details.path = details.name }
                             includeEmptyDirs = false
                         }

--- a/packages/erika_flutter/android/erika-native.gradle
+++ b/packages/erika_flutter/android/erika-native.gradle
@@ -1,4 +1,6 @@
 import java.util.Locale
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import org.gradle.process.ExecOperations
 
 def execOperations = project.services.get(ExecOperations)
@@ -85,6 +87,17 @@ def selectedAbis = requestedAbis()
 def skipNativeBuild = (project.findProperty("erikaSkipNativeBuild")
     ?: System.getenv("ERIKA_ANDROID_SKIP_NATIVE_BUILD")
     ?: "false").toString().toBoolean()
+def forceSourceBuild = (System.getenv("ERIKA_FORCE_SOURCE_BUILD") ?: "0") == "1"
+def usePrebuilt = (System.getenv("ERIKA_PREBUILT") ?: "0") == "1" && !forceSourceBuild
+def prebuiltTag = System.getenv("ERIKA_PREBUILT_TAG") ?: "v0.1.3"
+def prebuiltCacheKey = prebuiltTag.replaceAll(/[^A-Za-z0-9._-]/, "_")
+def prebuiltCacheDirectory = new File(
+    gradle.gradleUserHomeDir,
+    "caches/erika/$prebuiltCacheKey",
+)
+def prebuiltArchive = new File(prebuiltCacheDirectory, "erika-capi-android.zip")
+def prebuiltUrl =
+    "https://github.com/AimesSoft/Erika/releases/download/$prebuiltTag/erika-capi-android.zip"
 selectedAbis.each { abi ->
     if (!abiDefinitions.containsKey(abi)) {
         throw new GradleException(
@@ -206,7 +219,7 @@ def hostTag = {
 
 tasks.register("buildErikaAndroidRuntime") {
     group = "build"
-    description = "Build Erika native dependencies and erika_capi.so for the selected Android ABIs"
+    description = "Stage a prebuilt or source-built Erika runtime for the selected Android ABIs"
     outputs.dir(generatedJniLibs)
     // Cargo and xtask own their incremental caches. Always enter the native
     // build so Rust/source or ABI changes cannot leave stale packaged .so files.
@@ -220,6 +233,74 @@ tasks.register("buildErikaAndroidRuntime") {
     }
 
     doLast {
+        project.delete(generatedJniLibs.get().asFile)
+
+        if (usePrebuilt) {
+            try {
+                prebuiltCacheDirectory.mkdirs()
+                if (!prebuiltArchive.isFile()) {
+                    def temporaryArchive = new File(
+                        prebuiltCacheDirectory,
+                        "${prebuiltArchive.name}.part",
+                    )
+                    project.delete(temporaryArchive)
+                    logger.lifecycle("Downloading Erika Android prebuilt $prebuiltTag from $prebuiltUrl")
+                    ant.get(src: prebuiltUrl, dest: temporaryArchive, verbose: true)
+                    try {
+                        Files.move(
+                            temporaryArchive.toPath(),
+                            prebuiltArchive.toPath(),
+                            StandardCopyOption.REPLACE_EXISTING,
+                            StandardCopyOption.ATOMIC_MOVE,
+                        )
+                    } catch (java.nio.file.AtomicMoveNotSupportedException ignored) {
+                        Files.move(
+                            temporaryArchive.toPath(),
+                            prebuiltArchive.toPath(),
+                            StandardCopyOption.REPLACE_EXISTING,
+                        )
+                    }
+                } else {
+                    logger.lifecycle(
+                        "Using cached Erika Android prebuilt $prebuiltTag from $prebuiltArchive",
+                    )
+                }
+
+                selectedAbis.each { abi ->
+                    def destination = generatedJniLibs.get().dir(abi).asFile
+                    project.copy {
+                        from(project.zipTree(prebuiltArchive)) {
+                            include "lib/android/$abi/liberika_capi.so"
+                            include "lib/android/$abi/libc++_shared.so"
+                            eachFile { details -> details.path = details.name }
+                            includeEmptyDirs = false
+                        }
+                        into destination
+                    }
+                    ["liberika_capi.so", "libc++_shared.so"].each { library ->
+                        def staged = new File(destination, library)
+                        if (!staged.isFile() || staged.length() == 0L) {
+                            throw new GradleException(
+                                "Erika Android prebuilt $prebuiltTag is missing $abi/$library",
+                            )
+                        }
+                    }
+                }
+
+                logger.lifecycle(
+                    "Staged Erika Android prebuilt $prebuiltTag for ${selectedAbis.join(', ')}",
+                )
+                return
+            } catch (Exception error) {
+                logger.warn(
+                    "Unable to use Erika Android prebuilt $prebuiltTag; " +
+                        "falling back to a source build: ${error.message}",
+                )
+                project.delete(generatedJniLibs.get().asFile)
+                project.delete(prebuiltArchive)
+            }
+        }
+
         def repoRoot = findErikaRepoRoot()
         def cargoTargetDirectory = resolveCargoTargetDirectory(repoRoot)
         def ndkDirectory = resolveNdkDirectory()
@@ -246,8 +327,6 @@ tasks.register("buildErikaAndroidRuntime") {
         def apiLevel = Math.max(26, minSdkLevel)
         def nativeProfile = System.getenv("ERIKA_NATIVE_PROFILE") ?: "lgpl"
         def cargo = System.getenv("CARGO") ?: (hostIsWindows ? "cargo.exe" : "cargo")
-
-        project.delete(generatedJniLibs.get().asFile)
 
         selectedAbis.each { abi ->
             def definition = abiDefinitions[abi]

--- a/packages/erika_flutter/ios/erika_flutter.podspec
+++ b/packages/erika_flutter/ios/erika_flutter.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
     .join(' ')
 
   s.name             = 'erika_flutter'
-  s.version          = '0.1.2'
+  s.version          = '0.1.3'
   s.summary          = 'Flutter embedder glue for the Erika Rust media engine.'
   s.description      = <<-DESC
 Flutter iOS plugin that hosts a CAMetalLayer and drives Erika through its C ABI.
@@ -138,11 +138,11 @@ ERIKA_FRIBIDI_DIR="${ERIKA_FRIBIDI_DIR:-$ERIKA_TARGET_DIST/fribidi}"
 
 # Optional: use a prebuilt static lib from a GitHub Release (opt-in).
 # Enable with ERIKA_PREBUILT=1; ERIKA_PREBUILT_TAG selects the tag (default
-# v0.1.2). Any failure falls through to the source build below, so enabling it
+# v0.1.3). Any failure falls through to the source build below, so enabling it
 # never breaks a build. ERIKA_IOS_CAPI_STATICLIB still takes precedence.
 PREBUILT_LIB=""
 if [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" != "1" ] && [ "${ERIKA_PREBUILT:-0}" = "1" ] && [ -z "${ERIKA_IOS_CAPI_STATICLIB:-}" ]; then
-  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.2}"
+  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.3}"
   PREBUILT_WORK="$ERIKA_ROOT/target/erika-prebuilt-ios"
   PREBUILT_ZIP="$PREBUILT_WORK/erika-capi-ios.zip"
   PREBUILT_URL="https://github.com/AimesSoft/Erika/releases/download/$PREBUILT_TAG/erika-capi-ios.zip"

--- a/packages/erika_flutter/macos/erika_flutter.podspec
+++ b/packages/erika_flutter/macos/erika_flutter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'erika_flutter'
-  s.version          = '0.1.2'
+  s.version          = '0.1.3'
   s.summary          = 'Flutter embedder glue for the Erika Rust media engine.'
   s.description      = <<-DESC
 Flutter macOS plugin that hosts a CAMetalLayer and drives Erika through its C ABI.
@@ -54,11 +54,11 @@ mkdir -p "$DEST_DIR"
 
 # Optional: use a prebuilt universal dylib from a GitHub Release (opt-in).
 # Enable with ERIKA_PREBUILT=1; ERIKA_PREBUILT_TAG selects the tag (default
-# v0.1.2). Any failure falls through to the source build. ERIKA_MACOS_CAPI_DYLIB
+# v0.1.3). Any failure falls through to the source build. ERIKA_MACOS_CAPI_DYLIB
 # takes precedence (explicit dylib path).
 UNIVERSAL_DYLIB=""
 if [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" != "1" ] && [ "${ERIKA_PREBUILT:-0}" = "1" ] && [ -z "${ERIKA_MACOS_CAPI_DYLIB:-}" ]; then
-  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.2}"
+  PREBUILT_TAG="${ERIKA_PREBUILT_TAG:-v0.1.3}"
   PREBUILT_WORK="$ERIKA_ROOT/target/erika-prebuilt-macos"
   PREBUILT_ZIP="$PREBUILT_WORK/erika-capi-macos-universal.zip"
   PREBUILT_URL="https://github.com/AimesSoft/Erika/releases/download/$PREBUILT_TAG/erika-capi-macos-universal.zip"

--- a/packages/erika_flutter/pubspec.yaml
+++ b/packages/erika_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: erika_flutter
 description: Flutter embedder glue for the Erika Rust media engine.
-version: 0.1.2
+version: 0.1.3
 publish_to: none
 
 environment:

--- a/packages/erika_flutter/windows/build_erika_runtime.cmake
+++ b/packages/erika_flutter/windows/build_erika_runtime.cmake
@@ -55,7 +55,7 @@ endfunction()
 
 # --- Optional: use a prebuilt erika_capi.dll from a GitHub Release ---
 # Opt in with ERIKA_PREBUILT=1. ERIKA_PREBUILT_TAG selects the release tag
-# (default v0.1.2). On any failure this falls through to the source build below,
+# (default v0.1.3). On any failure this falls through to the source build below,
 # so enabling it never breaks a build. The Windows plugin loads the DLL
 # dynamically, so only erika_capi.dll is required.
 if("$ENV{ERIKA_PREBUILT}" STREQUAL "1")
@@ -64,7 +64,7 @@ if("$ENV{ERIKA_PREBUILT}" STREQUAL "1")
   else()
     set(_erika_cfg_dir "release")
   endif()
-  set(_erika_tag "v0.1.2")
+  set(_erika_tag "v0.1.3")
   if(NOT "$ENV{ERIKA_PREBUILT_TAG}" STREQUAL "")
     set(_erika_tag "$ENV{ERIKA_PREBUILT_TAG}")
   endif()


### PR DESCRIPTION
## Summary

- add Android consumption of tagged `erika-capi-android.zip` prebuilt runtimes, cached per release tag
- validate ABI payloads and fall back to source builds with explicit diagnostics
- support both the official `erika-capi-android/lib/android/...` bundle layout and flat mirror/local archives
- add `ERIKA_FORCE_SOURCE_BUILD=1` for deterministic local/source builds
- prepare the workspace, Flutter package, podspecs, defaults, changelog, and release docs for `v0.1.3`
- include Android arm64-v8a, armeabi-v7a, x86_64, and x86 in the release bundle

## Commit split

1. `feat(android): consume tagged prebuilt runtime`
2. `chore(release): prepare v0.1.3`
3. `fix(android): extract packaged prebuilt bundle`

## Validation

- Gradle configuration and local prebuilt ZIP extraction for x86_64
- Rust workspace tests: 308 passed
- C ABI tests: 23 passed
- Flutter analyze: clean
- Flutter plugin tests: 33 passed
- `cargo fmt --check`
- `git diff --check`
- full Release workflow dry-run: https://github.com/AimesSoft/Erika/actions/runs/29589952765

## Release procedure

After review and merge, tag the merge commit as `v0.1.3`. The tag-triggered Release workflow will publish macOS, iOS, Windows, and Android archives.

This PR does not create or merge the release tag.