### PR TITLE
fix(audio): recover WASAPI from device loss and ramp volume changes

### DIFF
--- a/crates/erika/src/android.rs
+++ b/crates/erika/src/android.rs
@@ -654,6 +654,9 @@ pub mod aaudio {
                     channels: format.channels as usize,
                 })?,
             );
+            // Seed both ramp endpoints: the stream has not started, so there
+            // is no previous gain to ramp from.
+            ring.snap_volume(self.signals.volume());
             let callback = Arc::new(CallbackState {
                 ring,
                 signals: Arc::clone(&self.signals),
@@ -735,6 +738,8 @@ pub mod aaudio {
             self.signals
                 .volume
                 .store(volume.to_bits(), Ordering::Relaxed);
+            // The ring only records the new target; the realtime callback ramps
+            // toward it so queued samples are never rewritten under the reader.
             if let Ok(control) = self.control.lock()
                 && let Some(callback) = &control.callback
             {
@@ -774,11 +779,9 @@ pub mod aaudio {
             )?;
             let mut samples = vec![0.0f32; sample_count];
             control.processor.read_interleaved(&mut samples)?;
-            let pushed = callback.ring.push_interleaved(
-                &samples,
-                self.config.ring_buffer.drop_oldest_on_overflow,
-                self.signals.volume(),
-            );
+            let pushed = callback
+                .ring
+                .push_interleaved(&samples, self.config.ring_buffer.drop_oldest_on_overflow);
             control.append_timeline(pushed, prepared.media_time);
             Ok(pushed.into())
         }

--- a/crates/erika/src/apple.rs
+++ b/crates/erika/src/apple.rs
@@ -32,7 +32,7 @@ pub mod iosaudio {
 
     use crate::audio::{
         AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult, AudioRingBuffer,
-        AudioRingBufferConfig, AudioRingBufferStats, apply_volume, normalize_volume,
+        AudioRingBufferConfig, AudioRingBufferStats, apply_volume_ramp, normalize_volume,
     };
     use crate::ffmpeg::{PcmAudioFrame, PcmFormat, PcmSampleFormat};
 
@@ -145,6 +145,10 @@ pub mod iosaudio {
     struct CallbackState {
         buffer: Arc<Mutex<AudioRingBuffer>>,
         volume: Arc<AtomicU32>,
+        // Gain the previous callback ended on; only the serialized AudioQueue
+        // callback reads and writes it, so Relaxed ordering suffices.
+        last_applied_volume: AtomicU32,
+        channels: usize,
     }
 
     pub struct IosAudioQueueOutput {
@@ -177,6 +181,8 @@ pub mod iosaudio {
             let state = Box::new(CallbackState {
                 buffer: Arc::clone(&self.buffer),
                 volume: Arc::clone(&self.volume),
+                last_applied_volume: AtomicU32::new(self.volume.load(Ordering::Relaxed)),
+                channels: format.channels.max(1) as usize,
             });
             let state = NonNull::new(Box::into_raw(state)).expect("Box::into_raw is non-null");
             let mut queue: AudioQueueRef = ptr::null_mut();
@@ -236,8 +242,12 @@ pub mod iosaudio {
         pub fn start(&mut self) -> Result<()> {
             let queue = self.queue.ok_or(IosAudioQueueOutputError::NotConfigured)?;
             if self.state != AudioOutputState::Paused {
+                let state = self
+                    .callback_state
+                    .ok_or(IosAudioQueueOutputError::NotConfigured)?;
                 for &buffer in &self.buffers {
-                    fill_audio_queue_buffer(queue, buffer, &self.buffer, &self.volume)?;
+                    // SAFETY: the callback state stays alive until dispose_queue.
+                    fill_audio_queue_buffer(queue, buffer, unsafe { state.as_ref() })?;
                 }
             }
             check_status(
@@ -379,14 +389,13 @@ pub mod iosaudio {
             return;
         }
         let state = unsafe { &*(user_data as *const CallbackState) };
-        let _ = fill_audio_queue_buffer(queue, audio_buffer, &state.buffer, &state.volume);
+        let _ = fill_audio_queue_buffer(queue, audio_buffer, state);
     }
 
     fn fill_audio_queue_buffer(
         queue: AudioQueueRef,
         audio_buffer: AudioQueueBufferRef,
-        ring_buffer: &Arc<Mutex<AudioRingBuffer>>,
-        volume: &Arc<AtomicU32>,
+        state: &CallbackState,
     ) -> Result<()> {
         if queue.is_null() || audio_buffer.is_null() {
             return Err(IosAudioQueueOutputError::NotConfigured);
@@ -400,7 +409,7 @@ pub mod iosaudio {
         let samples = unsafe {
             std::slice::from_raw_parts_mut(buffer.audio_data.cast::<f32>(), sample_count)
         };
-        match ring_buffer.lock() {
+        match state.buffer.lock() {
             Ok(mut ring) => {
                 if ring.read_interleaved(samples).is_err() {
                     samples.fill(0.0);
@@ -408,7 +417,14 @@ pub mod iosaudio {
             }
             Err(_) => samples.fill(0.0),
         }
-        apply_volume(samples, f32::from_bits(volume.load(Ordering::Relaxed)));
+        // Ramp from the gain the previous buffer ended on so an atomic volume
+        // step never lands as an audible discontinuity (zipper noise).
+        let from = f32::from_bits(state.last_applied_volume.load(Ordering::Relaxed));
+        let to = f32::from_bits(state.volume.load(Ordering::Relaxed));
+        apply_volume_ramp(samples, state.channels, from, to);
+        state
+            .last_applied_volume
+            .store(normalize_volume(to).to_bits(), Ordering::Relaxed);
         buffer.audio_data_byte_size = buffer.audio_data_bytes_capacity;
         check_status(
             unsafe { AudioQueueEnqueueBuffer(queue, audio_buffer, 0, ptr::null()) },
@@ -481,7 +497,7 @@ pub mod coreaudio {
 
     use crate::audio::{
         AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult, AudioReadResult,
-        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats, apply_volume,
+        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats, apply_volume_ramp,
         normalize_volume,
     };
     use crate::ffmpeg::{PcmAudioFrame, PcmFormat, PcmSampleFormat};
@@ -545,6 +561,7 @@ pub mod coreaudio {
                 &mut audio_unit,
                 Arc::clone(&self.buffer),
                 Arc::clone(&self.volume),
+                format.channels.max(1) as usize,
             )?;
             audio_unit.initialize()?;
             self.audio_unit = Some(audio_unit);
@@ -697,17 +714,22 @@ pub mod coreaudio {
         audio_unit: &mut AudioUnit,
         buffer: Arc<Mutex<AudioRingBuffer>>,
         volume: Arc<AtomicU32>,
+        channels: usize,
     ) -> Result<()> {
         type Args = render_callback::Args<data::Interleaved<f32>>;
+        // Owned by the render callback closure; CoreAudio serializes calls, so
+        // the gain the previous callback ended on needs no synchronization.
+        let mut last_applied_volume = f32::from_bits(volume.load(Ordering::Relaxed));
         audio_unit.set_render_callback(move |mut args: Args| {
             let read_result = buffer
                 .lock()
                 .map_err(|_| ())
                 .and_then(|mut buffer| buffer.read_interleaved(args.data.buffer).map_err(|_| ()))?;
-            apply_volume(
-                args.data.buffer,
-                f32::from_bits(volume.load(Ordering::Relaxed)),
-            );
+            // Ramp from the previous callback's gain so an atomic volume step
+            // never lands as an audible discontinuity (zipper noise).
+            let target = f32::from_bits(volume.load(Ordering::Relaxed));
+            apply_volume_ramp(args.data.buffer, channels, last_applied_volume, target);
+            last_applied_volume = normalize_volume(target);
             if read_result.underflow_frames > 0 {
                 args.flags
                     .insert(render_callback::ActionFlags::OUTPUT_IS_SILENCE);
@@ -735,6 +757,7 @@ pub mod coreaudio {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::audio::apply_volume;
 
         #[test]
         fn volume_is_clamped_and_applied_to_pcm_samples() {

--- a/crates/erika/src/apple.rs
+++ b/crates/erika/src/apple.rs
@@ -409,22 +409,28 @@ pub mod iosaudio {
         let samples = unsafe {
             std::slice::from_raw_parts_mut(buffer.audio_data.cast::<f32>(), sample_count)
         };
-        match state.buffer.lock() {
-            Ok(mut ring) => {
-                if ring.read_interleaved(samples).is_err() {
+        let audible_frames = match state.buffer.lock() {
+            Ok(mut ring) => match ring.read_interleaved(samples) {
+                Ok(read) => read.frames,
+                Err(_) => {
                     samples.fill(0.0);
+                    0
                 }
+            },
+            Err(_) => {
+                samples.fill(0.0);
+                0
             }
-            Err(_) => samples.fill(0.0),
-        }
+        };
         // Ramp from the gain the previous buffer ended on so an atomic volume
-        // step never lands as an audible discontinuity (zipper noise).
+        // step never lands as an audible discontinuity (zipper noise). Only the
+        // frames the ring actually supplied advance the ramp.
         let from = f32::from_bits(state.last_applied_volume.load(Ordering::Relaxed));
         let to = f32::from_bits(state.volume.load(Ordering::Relaxed));
-        apply_volume_ramp(samples, state.channels, from, to);
+        let reached = apply_volume_ramp(samples, state.channels, from, to, audible_frames);
         state
             .last_applied_volume
-            .store(normalize_volume(to).to_bits(), Ordering::Relaxed);
+            .store(reached.to_bits(), Ordering::Relaxed);
         buffer.audio_data_byte_size = buffer.audio_data_bytes_capacity;
         check_status(
             unsafe { AudioQueueEnqueueBuffer(queue, audio_buffer, 0, ptr::null()) },
@@ -726,10 +732,16 @@ pub mod coreaudio {
                 .map_err(|_| ())
                 .and_then(|mut buffer| buffer.read_interleaved(args.data.buffer).map_err(|_| ()))?;
             // Ramp from the previous callback's gain so an atomic volume step
-            // never lands as an audible discontinuity (zipper noise).
+            // never lands as an audible discontinuity (zipper noise). Only the
+            // frames the ring actually supplied advance the ramp.
             let target = f32::from_bits(volume.load(Ordering::Relaxed));
-            apply_volume_ramp(args.data.buffer, channels, last_applied_volume, target);
-            last_applied_volume = normalize_volume(target);
+            last_applied_volume = apply_volume_ramp(
+                args.data.buffer,
+                channels,
+                last_applied_volume,
+                target,
+                read_result.frames,
+            );
             if read_result.underflow_frames > 0 {
                 args.flags
                     .insert(render_callback::ActionFlags::OUTPUT_IS_SILENCE);

--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -861,33 +861,58 @@ pub fn apply_volume(samples: &mut [f32], volume: f32) {
     }
 }
 
-/// Applies a linear per-frame gain ramp from `from` to `to` across `samples`.
+/// Applies a linear per-frame gain ramp from `from` to `to` across `samples`,
+/// returning the gain the ramp actually reached.
 ///
 /// Volume changes are atomic steps on the control side; multiplying a whole
 /// buffer by the new value produces an audible discontinuity (zipper noise).
-/// Realtime read callbacks instead ramp from the gain they last applied to the
-/// current target, then remember the target for the next callback. All
-/// channels of a frame share one gain step, the last frame lands on `to`, and
-/// `from == to` degrades to a constant [`apply_volume`].
-pub fn apply_volume_ramp(samples: &mut [f32], channels: usize, from: f32, to: f32) {
+/// Realtime read callbacks instead ramp from the gain they last applied toward
+/// the current target, then carry the returned gain into the next callback.
+/// All channels of a frame share one gain step and `from == to` degrades to a
+/// constant [`apply_volume`].
+///
+/// `audible_frames` is how many leading frames actually carry audio. The ramp
+/// is always *planned* across the full buffer so its slope does not depend on
+/// how much the ring could supply, but a short read only advances part of that
+/// plan and only that part is reported back. Ramping across a zero-filled
+/// underflow tail and then recording `to` as applied would put the next
+/// callback at a gain the audible samples never reached, recreating the very
+/// discontinuity this exists to avoid.
+pub fn apply_volume_ramp(
+    samples: &mut [f32],
+    channels: usize,
+    from: f32,
+    to: f32,
+    audible_frames: usize,
+) -> f32 {
     let from = normalize_volume(from);
     let to = normalize_volume(to);
     let channels = channels.max(1);
     let frames = samples.len() / channels;
     if frames == 0 || from == to {
         apply_volume(samples, to);
-        return;
+        return to;
+    }
+    let audible_frames = audible_frames.min(frames);
+    if audible_frames == 0 {
+        return from;
     }
     let span = to - from;
     let frame_count = frames as f32;
-    for (index, frame) in samples.chunks_exact_mut(channels).enumerate() {
+    for (index, frame) in samples
+        .chunks_exact_mut(channels)
+        .take(audible_frames)
+        .enumerate()
+    {
         let gain = from + span * ((index + 1) as f32 / frame_count);
         for sample in frame {
             *sample *= gain;
         }
     }
-    // A trailing partial frame cannot ramp; give it the final gain.
-    apply_volume(&mut samples[frames * channels..], to);
+    let reached = from + span * (audible_frames as f32 / frame_count);
+    // A trailing partial frame cannot ramp; give it the gain we reached.
+    apply_volume(&mut samples[frames * channels..], reached);
+    reached
 }
 
 fn offset_pts_scaled(
@@ -1025,39 +1050,68 @@ mod tests {
     #[test]
     fn volume_ramp_interpolates_per_frame_and_lands_on_target() {
         let mut samples = [1.0f32; 8];
-        apply_volume_ramp(&mut samples, 2, 0.0, 1.0);
+        let reached = apply_volume_ramp(&mut samples, 2, 0.0, 1.0, 4);
         assert_eq!(samples, [0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1.0, 1.0]);
+        assert_eq!(reached, 1.0);
     }
 
     #[test]
     fn volume_ramp_with_equal_endpoints_is_constant_gain() {
         let mut samples = [1.0f32, -0.5, 0.25, 0.0];
-        apply_volume_ramp(&mut samples, 2, 0.5, 0.5);
+        let reached = apply_volume_ramp(&mut samples, 2, 0.5, 0.5, 2);
         assert_eq!(samples, [0.5, -0.25, 0.125, 0.0]);
+        assert_eq!(reached, 0.5);
     }
 
     #[test]
     fn volume_ramp_is_monotonic_and_clamps_invalid_endpoints() {
         let mut samples = [1.0f32; 32];
-        apply_volume_ramp(&mut samples, 1, 2.0, -1.0);
+        let reached = apply_volume_ramp(&mut samples, 1, 2.0, -1.0, 32);
 
         for pair in samples.windows(2) {
             assert!(pair[1] <= pair[0], "ramp regressed: {pair:?}");
         }
         assert_eq!(samples[0], 1.0 - 1.0 / 32.0);
         assert_eq!(samples[31], 0.0);
+        assert_eq!(reached, 0.0);
+    }
+
+    #[test]
+    fn volume_ramp_stops_at_the_underflow_boundary() {
+        // Four frames requested, one supplied: the audible frame takes the
+        // first ramp step and the zero-filled tail is left alone, so the next
+        // callback resumes from 0.875 rather than jumping straight to 0.5.
+        let mut samples = [1.0f32, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let reached = apply_volume_ramp(&mut samples, 2, 1.0, 0.5, 1);
+
+        assert_eq!(samples[0], 0.875);
+        assert_eq!(samples[1], 0.875);
+        assert_eq!(reached, 0.875);
+        assert!(
+            samples[2..].iter().all(|sample| *sample == 0.0),
+            "underflow tail must stay silent: {samples:?}"
+        );
+    }
+
+    #[test]
+    fn volume_ramp_makes_no_progress_without_audible_frames() {
+        let mut samples = [0.0f32; 8];
+        let reached = apply_volume_ramp(&mut samples, 2, 1.0, 0.5, 0);
+        assert_eq!(reached, 1.0);
+        assert!(samples.iter().all(|sample| *sample == 0.0));
     }
 
     #[test]
     fn volume_ramp_handles_empty_buffers_and_partial_frames() {
         let mut empty: [f32; 0] = [];
-        apply_volume_ramp(&mut empty, 2, 0.0, 1.0);
+        assert_eq!(apply_volume_ramp(&mut empty, 2, 0.0, 1.0, 0), 1.0);
 
         // One full stereo frame plus a trailing partial frame: a single frame
         // lands directly on the target and the tail takes the same gain.
         let mut samples = [1.0f32, 1.0, 1.0];
-        apply_volume_ramp(&mut samples, 2, 0.0, 0.5);
+        let reached = apply_volume_ramp(&mut samples, 2, 0.0, 0.5, 1);
         assert_eq!(samples, [0.5, 0.5, 0.5]);
+        assert_eq!(reached, 0.5);
     }
 
     #[test]

--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicI32, AtomicU8, AtomicU64, Ordering};
 use std::time::Duration;
 
 use soundtouch::{Setting, SoundTouch};
@@ -114,6 +115,153 @@ pub struct AudioOutputRuntimeStats {
     pub recovery_count: u64,
     pub recovery_failures: u64,
     pub transition_sequence: u64,
+}
+
+/// Exponential backoff schedule for audio device-loss recovery attempts.
+///
+/// Platform backends drive the schedule from their render/callback threads;
+/// the schedule itself is platform independent so it stays unit testable on
+/// any host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RecoveryBackoff {
+    initial_delay: Duration,
+    max_attempts: u32,
+    attempts: u32,
+}
+
+impl RecoveryBackoff {
+    pub fn new(initial_delay: Duration, max_attempts: u32) -> Self {
+        Self {
+            initial_delay,
+            max_attempts,
+            attempts: 0,
+        }
+    }
+
+    /// Returns the delay to wait before the next recovery attempt, doubling
+    /// on every call, or `None` once the attempt budget is exhausted.
+    pub fn next_delay(&mut self) -> Option<Duration> {
+        if self.attempts >= self.max_attempts {
+            return None;
+        }
+        let exponent = self.attempts.min(31);
+        self.attempts += 1;
+        Some(self.initial_delay.saturating_mul(1u32 << exponent))
+    }
+
+    pub fn attempts(&self) -> u32 {
+        self.attempts
+    }
+
+    pub fn is_exhausted(&self) -> bool {
+        self.attempts >= self.max_attempts
+    }
+
+    pub fn reset(&mut self) {
+        self.attempts = 0;
+    }
+}
+
+const RECOVERY_STATE_STABLE: u8 = 0;
+const RECOVERY_STATE_DISCONNECTED: u8 = 1;
+const RECOVERY_STATE_RECOVERING: u8 = 2;
+const RECOVERY_STATE_FAILED: u8 = 3;
+
+fn decode_recovery_state(state: u8) -> AudioRecoveryState {
+    match state {
+        RECOVERY_STATE_DISCONNECTED => AudioRecoveryState::Disconnected,
+        RECOVERY_STATE_RECOVERING => AudioRecoveryState::Recovering,
+        RECOVERY_STATE_FAILED => AudioRecoveryState::Failed,
+        _ => AudioRecoveryState::Stable,
+    }
+}
+
+/// Lock-free publication of audio device-loss recovery progress.
+///
+/// A backend's render thread records state transitions while control threads
+/// read [`RecoverySignals::snapshot`] for
+/// [`AudioOutputBackend::runtime_stats`]. The transitions mirror the AAudio
+/// recovery state machine in `android.rs`.
+#[derive(Debug, Default)]
+pub struct RecoverySignals {
+    recovery_state: AtomicU8,
+    last_error_code: AtomicI32,
+    recovery_attempts: AtomicU64,
+    recovery_count: AtomicU64,
+    recovery_failures: AtomicU64,
+    transition_sequence: AtomicU64,
+}
+
+impl RecoverySignals {
+    pub fn mark_disconnected(&self, error_code: i32) -> AudioOutputRuntimeStats {
+        self.last_error_code.store(error_code, Ordering::Relaxed);
+        self.recovery_state
+            .store(RECOVERY_STATE_DISCONNECTED, Ordering::Release);
+        self.transition_sequence.fetch_add(1, Ordering::Release);
+        self.snapshot()
+    }
+
+    pub fn begin_recovery(&self) -> AudioOutputRuntimeStats {
+        self.recovery_attempts.fetch_add(1, Ordering::Relaxed);
+        self.recovery_state
+            .store(RECOVERY_STATE_RECOVERING, Ordering::Release);
+        self.transition_sequence.fetch_add(1, Ordering::Release);
+        self.snapshot()
+    }
+
+    /// Commits a successful recovery. Returns `None` when the state moved on
+    /// concurrently (for example a fresh disconnect landed before the commit),
+    /// in which case the caller must keep the newer state visible.
+    pub fn recovery_succeeded(&self) -> Option<AudioOutputRuntimeStats> {
+        if self
+            .recovery_state
+            .compare_exchange(
+                RECOVERY_STATE_RECOVERING,
+                RECOVERY_STATE_STABLE,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            return None;
+        }
+        self.recovery_count.fetch_add(1, Ordering::Relaxed);
+        self.transition_sequence.fetch_add(1, Ordering::Release);
+        Some(self.snapshot())
+    }
+
+    pub fn recovery_failed(&self, error_code: i32) -> AudioOutputRuntimeStats {
+        self.last_error_code.store(error_code, Ordering::Relaxed);
+        self.recovery_failures.fetch_add(1, Ordering::Relaxed);
+        self.recovery_state
+            .store(RECOVERY_STATE_FAILED, Ordering::Release);
+        self.transition_sequence.fetch_add(1, Ordering::Release);
+        self.snapshot()
+    }
+
+    pub fn reset(&self) {
+        self.last_error_code.store(0, Ordering::Relaxed);
+        self.recovery_state
+            .store(RECOVERY_STATE_STABLE, Ordering::Release);
+        self.transition_sequence.fetch_add(1, Ordering::Release);
+    }
+
+    pub fn snapshot(&self) -> AudioOutputRuntimeStats {
+        loop {
+            let sequence_before = self.transition_sequence.load(Ordering::Acquire);
+            let snapshot = AudioOutputRuntimeStats {
+                recovery_state: decode_recovery_state(self.recovery_state.load(Ordering::Acquire)),
+                last_error_code: self.last_error_code.load(Ordering::Relaxed),
+                recovery_attempts: self.recovery_attempts.load(Ordering::Relaxed),
+                recovery_count: self.recovery_count.load(Ordering::Relaxed),
+                recovery_failures: self.recovery_failures.load(Ordering::Relaxed),
+                transition_sequence: sequence_before,
+            };
+            if sequence_before == self.transition_sequence.load(Ordering::Acquire) {
+                return snapshot;
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -713,6 +861,35 @@ pub fn apply_volume(samples: &mut [f32], volume: f32) {
     }
 }
 
+/// Applies a linear per-frame gain ramp from `from` to `to` across `samples`.
+///
+/// Volume changes are atomic steps on the control side; multiplying a whole
+/// buffer by the new value produces an audible discontinuity (zipper noise).
+/// Realtime read callbacks instead ramp from the gain they last applied to the
+/// current target, then remember the target for the next callback. All
+/// channels of a frame share one gain step, the last frame lands on `to`, and
+/// `from == to` degrades to a constant [`apply_volume`].
+pub fn apply_volume_ramp(samples: &mut [f32], channels: usize, from: f32, to: f32) {
+    let from = normalize_volume(from);
+    let to = normalize_volume(to);
+    let channels = channels.max(1);
+    let frames = samples.len() / channels;
+    if frames == 0 || from == to {
+        apply_volume(samples, to);
+        return;
+    }
+    let span = to - from;
+    let frame_count = frames as f32;
+    for (index, frame) in samples.chunks_exact_mut(channels).enumerate() {
+        let gain = from + span * ((index + 1) as f32 / frame_count);
+        for sample in frame {
+            *sample *= gain;
+        }
+    }
+    // A trailing partial frame cannot ramp; give it the final gain.
+    apply_volume(&mut samples[frames * channels..], to);
+}
+
 fn offset_pts_scaled(
     pts: Duration,
     frames: usize,
@@ -843,6 +1020,116 @@ mod tests {
         assert_eq!(output.volume(), 0.0);
         output.set_volume(f32::NAN);
         assert_eq!(output.volume(), 1.0);
+    }
+
+    #[test]
+    fn volume_ramp_interpolates_per_frame_and_lands_on_target() {
+        let mut samples = [1.0f32; 8];
+        apply_volume_ramp(&mut samples, 2, 0.0, 1.0);
+        assert_eq!(samples, [0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn volume_ramp_with_equal_endpoints_is_constant_gain() {
+        let mut samples = [1.0f32, -0.5, 0.25, 0.0];
+        apply_volume_ramp(&mut samples, 2, 0.5, 0.5);
+        assert_eq!(samples, [0.5, -0.25, 0.125, 0.0]);
+    }
+
+    #[test]
+    fn volume_ramp_is_monotonic_and_clamps_invalid_endpoints() {
+        let mut samples = [1.0f32; 32];
+        apply_volume_ramp(&mut samples, 1, 2.0, -1.0);
+
+        for pair in samples.windows(2) {
+            assert!(pair[1] <= pair[0], "ramp regressed: {pair:?}");
+        }
+        assert_eq!(samples[0], 1.0 - 1.0 / 32.0);
+        assert_eq!(samples[31], 0.0);
+    }
+
+    #[test]
+    fn volume_ramp_handles_empty_buffers_and_partial_frames() {
+        let mut empty: [f32; 0] = [];
+        apply_volume_ramp(&mut empty, 2, 0.0, 1.0);
+
+        // One full stereo frame plus a trailing partial frame: a single frame
+        // lands directly on the target and the tail takes the same gain.
+        let mut samples = [1.0f32, 1.0, 1.0];
+        apply_volume_ramp(&mut samples, 2, 0.0, 0.5);
+        assert_eq!(samples, [0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn recovery_backoff_doubles_until_attempts_are_exhausted() {
+        let mut backoff = RecoveryBackoff::new(Duration::from_millis(200), 5);
+
+        let delays: Vec<_> = std::iter::from_fn(|| backoff.next_delay()).collect();
+
+        assert_eq!(
+            delays,
+            [200, 400, 800, 1600, 3200].map(Duration::from_millis)
+        );
+        assert!(backoff.is_exhausted());
+        assert_eq!(backoff.attempts(), 5);
+
+        backoff.reset();
+        assert!(!backoff.is_exhausted());
+        assert_eq!(backoff.next_delay(), Some(Duration::from_millis(200)));
+    }
+
+    #[test]
+    fn recovery_signals_track_disconnect_recover_cycle() {
+        let signals = RecoverySignals::default();
+        assert_eq!(
+            signals.snapshot().recovery_state,
+            AudioRecoveryState::Stable
+        );
+
+        let stats = signals.mark_disconnected(-77);
+        assert_eq!(stats.recovery_state, AudioRecoveryState::Disconnected);
+        assert_eq!(stats.last_error_code, -77);
+
+        let stats = signals.begin_recovery();
+        assert_eq!(stats.recovery_state, AudioRecoveryState::Recovering);
+        assert_eq!(stats.recovery_attempts, 1);
+
+        let stats = signals
+            .recovery_succeeded()
+            .expect("recovering commits to stable");
+        assert_eq!(stats.recovery_state, AudioRecoveryState::Stable);
+        assert_eq!(stats.recovery_count, 1);
+
+        // A success must not commit when a fresh disconnect superseded it.
+        signals.mark_disconnected(-78);
+        assert!(signals.recovery_succeeded().is_none());
+        assert_eq!(
+            signals.snapshot().recovery_state,
+            AudioRecoveryState::Disconnected
+        );
+
+        signals.begin_recovery();
+        let stats = signals.recovery_failed(-79);
+        assert_eq!(stats.recovery_state, AudioRecoveryState::Failed);
+        assert_eq!(stats.recovery_failures, 1);
+        assert_eq!(stats.last_error_code, -79);
+
+        signals.reset();
+        let stats = signals.snapshot();
+        assert_eq!(stats.recovery_state, AudioRecoveryState::Stable);
+        assert_eq!(stats.last_error_code, 0);
+    }
+
+    #[test]
+    fn recovery_signals_snapshot_sequence_advances_per_transition() {
+        let signals = RecoverySignals::default();
+        let initial = signals.snapshot().transition_sequence;
+
+        signals.mark_disconnected(-1);
+        signals.begin_recovery();
+        signals.recovery_succeeded();
+
+        assert_eq!(signals.snapshot().transition_sequence, initial + 3);
     }
 
     #[test]

--- a/crates/erika/src/audio/spsc.rs
+++ b/crates/erika/src/audio/spsc.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 
-use super::{AudioPushResult, AudioRingBufferStats};
+use super::{AudioPushResult, AudioRingBufferStats, apply_volume_ramp, normalize_volume};
 
 const EMPTY_POSITION: u64 = u64::MAX;
 
@@ -32,18 +32,25 @@ impl PcmSpscSlot {
 /// sample copies, zero filling, and atomic counter updates. Slot
 /// versions prevent a producer-side drop-oldest overwrite from exposing a torn
 /// multi-channel frame to the realtime consumer.
+///
+/// Samples are stored at source gain. Volume is applied on the consumer side
+/// as a per-callback linear ramp from the last applied gain to the current
+/// target, so a control-thread volume step neither rewrites queued slots nor
+/// produces an audible discontinuity (zipper noise).
 pub(crate) struct PcmSpscRing {
     capacity_frames: usize,
     channels: usize,
     slots: Box<[PcmSpscSlot]>,
-    source_samples: Box<[AtomicU32]>,
-    output_samples: Box<[AtomicU32]>,
+    samples: Box<[AtomicU32]>,
     read_position: AtomicU64,
     write_position: AtomicU64,
     written_frames: AtomicU64,
     read_frames: AtomicU64,
     dropped_frames: AtomicU64,
     underflow_frames: AtomicU64,
+    target_volume: AtomicU32,
+    // Only the single consumer reads and writes this between its callbacks.
+    last_applied_volume: AtomicU32,
 }
 
 impl PcmSpscRing {
@@ -56,11 +63,7 @@ impl PcmSpscRing {
             .map(|_| PcmSpscSlot::empty())
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        let source_samples = (0..sample_capacity)
-            .map(|_| AtomicU32::new(0.0f32.to_bits()))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        let output_samples = (0..sample_capacity)
+        let samples = (0..sample_capacity)
             .map(|_| AtomicU32::new(0.0f32.to_bits()))
             .collect::<Vec<_>>()
             .into_boxed_slice();
@@ -68,14 +71,15 @@ impl PcmSpscRing {
             capacity_frames,
             channels,
             slots,
-            source_samples,
-            output_samples,
+            samples,
             read_position: AtomicU64::new(0),
             write_position: AtomicU64::new(0),
             written_frames: AtomicU64::new(0),
             read_frames: AtomicU64::new(0),
             dropped_frames: AtomicU64::new(0),
             underflow_frames: AtomicU64::new(0),
+            target_volume: AtomicU32::new(1.0f32.to_bits()),
+            last_applied_volume: AtomicU32::new(1.0f32.to_bits()),
         })
     }
 
@@ -91,7 +95,6 @@ impl PcmSpscRing {
         &self,
         input: &[f32],
         drop_oldest_on_overflow: bool,
-        volume: f32,
     ) -> PcmSpscPushResult {
         let original_frames = input.len() / self.channels;
         let mut input_offset_frames = 0usize;
@@ -127,11 +130,8 @@ impl PcmSpscRing {
             let input_base = input_frame * self.channels;
             let output_base = slot_index * self.channels;
             for channel in 0..self.channels {
-                let sample = input[input_base + channel];
-                self.source_samples[output_base + channel]
-                    .store(sample.to_bits(), Ordering::Relaxed);
-                self.output_samples[output_base + channel]
-                    .store((sample * volume).to_bits(), Ordering::Relaxed);
+                self.samples[output_base + channel]
+                    .store(input[input_base + channel].to_bits(), Ordering::Relaxed);
             }
             slot.position.store(position, Ordering::Relaxed);
             slot.version.fetch_add(1, Ordering::Release);
@@ -181,9 +181,8 @@ impl PcmSpscRing {
             }
             let sample_base = slot_index * self.channels;
             for channel in 0..self.channels {
-                output[output_base + channel] = f32::from_bits(
-                    self.output_samples[sample_base + channel].load(Ordering::Relaxed),
-                );
+                output[output_base + channel] =
+                    f32::from_bits(self.samples[sample_base + channel].load(Ordering::Relaxed));
             }
             let version_after = slot.version.load(Ordering::Acquire);
             let read_floor = self.read_position.load(Ordering::Acquire);
@@ -199,6 +198,14 @@ impl PcmSpscRing {
             Ordering::AcqRel,
         );
 
+        // Ramp from the previous callback's gain to the current target so a
+        // control-thread volume step never lands as an audible discontinuity.
+        let from = f32::from_bits(self.last_applied_volume.load(Ordering::Relaxed));
+        let to = f32::from_bits(self.target_volume.load(Ordering::Relaxed));
+        apply_volume_ramp(output, self.channels, from, to);
+        self.last_applied_volume
+            .store(normalize_volume(to).to_bits(), Ordering::Relaxed);
+
         let underflow_frames = requested_frames.saturating_sub(valid_frames);
         self.read_frames
             .fetch_add(valid_frames as u64, Ordering::Relaxed);
@@ -212,28 +219,22 @@ impl PcmSpscRing {
         self.read_position.store(write, Ordering::Release);
     }
 
+    /// Publishes a new gain target for the consumer-side ramp. Queued samples
+    /// are left untouched; the next `read_interleaved` ramps toward the target
+    /// without disturbing slots the realtime reader may be copying.
     pub(crate) fn set_volume(&self, volume: f32) {
-        let read = self.read_position.load(Ordering::Acquire);
-        let write = self.write_position.load(Ordering::Acquire);
-        let frames = write.saturating_sub(read).min(self.capacity_frames as u64) as usize;
-        for frame_index in 0..frames {
-            let position = read.saturating_add(frame_index as u64);
-            let slot_index = position as usize % self.capacity_frames;
-            let slot = &self.slots[slot_index];
-            if slot.position.load(Ordering::Acquire) != position {
-                continue;
-            }
-            slot.version.fetch_add(1, Ordering::AcqRel);
-            let sample_base = slot_index * self.channels;
-            for channel in 0..self.channels {
-                let sample = f32::from_bits(
-                    self.source_samples[sample_base + channel].load(Ordering::Relaxed),
-                );
-                self.output_samples[sample_base + channel]
-                    .store((sample * volume).to_bits(), Ordering::Relaxed);
-            }
-            slot.version.fetch_add(1, Ordering::Release);
-        }
+        self.target_volume
+            .store(normalize_volume(volume).to_bits(), Ordering::Relaxed);
+    }
+
+    /// Sets the gain target and the ramp origin together, so the next read
+    /// applies `volume` as a constant instead of ramping toward it from the
+    /// previous gain. Only call while the consumer is not running (for example
+    /// when seeding a freshly created ring before the stream starts).
+    pub(crate) fn snap_volume(&self, volume: f32) {
+        let bits = normalize_volume(volume).to_bits();
+        self.target_volume.store(bits, Ordering::Relaxed);
+        self.last_applied_volume.store(bits, Ordering::Relaxed);
     }
 
     pub(crate) fn stats(&self) -> AudioRingBufferStats {
@@ -270,7 +271,10 @@ mod tests {
     #[test]
     fn ring_reads_interleaved_frames_and_zero_fills_underflow() {
         let ring = PcmSpscRing::new(4, 2).unwrap();
-        let pushed = ring.push_interleaved(&[0.1, 0.2, 0.3, 0.4], true, 0.5);
+        // Seed both ramp endpoints so this test asserts steady-state
+        // amplitudes rather than the transition slope.
+        ring.snap_volume(0.5);
+        let pushed = ring.push_interleaved(&[0.1, 0.2, 0.3, 0.4], true);
         let mut output = [1.0; 6];
 
         let read = ring.read_interleaved(&mut output);
@@ -284,8 +288,8 @@ mod tests {
     #[test]
     fn ring_drops_oldest_complete_frames_on_overflow() {
         let ring = PcmSpscRing::new(2, 2).unwrap();
-        ring.push_interleaved(&[1.0, 10.0, 2.0, 20.0], true, 1.0);
-        let pushed = ring.push_interleaved(&[3.0, 30.0], true, 1.0);
+        ring.push_interleaved(&[1.0, 10.0, 2.0, 20.0], true);
+        let pushed = ring.push_interleaved(&[3.0, 30.0], true);
         let mut output = [0.0; 4];
 
         ring.read_interleaved(&mut output);
@@ -303,7 +307,7 @@ mod tests {
         let producer = thread::spawn(move || {
             for value in 1..=FRAMES {
                 let sample = value as f32;
-                producer_ring.push_interleaved(&[sample, -sample], true, 1.0);
+                producer_ring.push_interleaved(&[sample, -sample], true);
             }
         });
 
@@ -322,14 +326,55 @@ mod tests {
     }
 
     #[test]
-    fn volume_changes_rescale_already_queued_frames_off_callback() {
+    fn set_volume_leaves_queued_samples_untouched() {
         let ring = PcmSpscRing::new(2, 2).unwrap();
-        ring.push_interleaved(&[1.0, -1.0, 0.5, -0.5], true, 1.0);
+        ring.push_interleaved(&[1.0, -1.0, 0.5, -0.5], true);
+        let versions_before: Vec<u64> = ring
+            .slots
+            .iter()
+            .map(|slot| slot.version.load(Ordering::Acquire))
+            .collect();
+        let samples_before: Vec<u32> = ring
+            .samples
+            .iter()
+            .map(|sample| sample.load(Ordering::Relaxed))
+            .collect();
 
         ring.set_volume(0.25);
+
+        let versions_after: Vec<u64> = ring
+            .slots
+            .iter()
+            .map(|slot| slot.version.load(Ordering::Acquire))
+            .collect();
+        let samples_after: Vec<u32> = ring
+            .samples
+            .iter()
+            .map(|sample| sample.load(Ordering::Relaxed))
+            .collect();
+        assert_eq!(versions_before, versions_after);
+        assert_eq!(samples_before, samples_after);
+        assert_eq!(
+            f32::from_bits(ring.target_volume.load(Ordering::Relaxed)),
+            0.25
+        );
+    }
+
+    #[test]
+    fn volume_step_ramps_across_the_next_read_and_then_holds() {
+        let ring = PcmSpscRing::new(8, 1).unwrap();
+        ring.push_interleaved(&[1.0; 8], true);
+
+        ring.set_volume(0.5);
         let mut output = [0.0; 4];
         ring.read_interleaved(&mut output);
 
-        assert_eq!(output, [0.25, -0.25, 0.125, -0.125]);
+        // The first callback after the step ramps monotonically down to the
+        // target instead of applying it as a discontinuity.
+        assert_eq!(output, [0.875, 0.75, 0.625, 0.5]);
+
+        // Subsequent callbacks apply the settled gain as a constant.
+        ring.read_interleaved(&mut output);
+        assert_eq!(output, [0.5, 0.5, 0.5, 0.5]);
     }
 }

--- a/crates/erika/src/audio/spsc.rs
+++ b/crates/erika/src/audio/spsc.rs
@@ -202,9 +202,11 @@ impl PcmSpscRing {
         // control-thread volume step never lands as an audible discontinuity.
         let from = f32::from_bits(self.last_applied_volume.load(Ordering::Relaxed));
         let to = f32::from_bits(self.target_volume.load(Ordering::Relaxed));
-        apply_volume_ramp(output, self.channels, from, to);
+        // Only the leading `candidate_frames` carry ring data; the rest of the
+        // buffer was zero-filled above and must not consume ramp progress.
+        let reached = apply_volume_ramp(output, self.channels, from, to, candidate_frames);
         self.last_applied_volume
-            .store(normalize_volume(to).to_bits(), Ordering::Relaxed);
+            .store(reached.to_bits(), Ordering::Relaxed);
 
         let underflow_frames = requested_frames.saturating_sub(valid_frames);
         self.read_frames

--- a/crates/erika/src/windows.rs
+++ b/crates/erika/src/windows.rs
@@ -449,30 +449,33 @@ pub mod wasapi {
             for command in commands.try_iter() {
                 match command {
                     WasapiRenderCommand::Start => {
-                        if !playing {
-                            match &render_state {
-                                Some(state) => {
-                                    if let Err(error) = state.client_start() {
-                                        on_device_error(
-                                            error,
-                                            &mut render_state,
-                                            &mut recovery_plan,
-                                            &mut next_recovery_at,
-                                        )?;
-                                    }
-                                }
-                                None => {
-                                    // A fresh Start re-arms an exhausted
-                                    // recovery schedule and retries at once.
-                                    if next_recovery_at.is_none() {
-                                        recovery_plan.reset();
-                                        let _ = recovery_plan.next_step();
-                                        next_recovery_at = Some(Instant::now());
-                                    }
+                        match &render_state {
+                            Some(state) => {
+                                if !playing && let Err(error) = state.client_start() {
+                                    on_device_error(
+                                        error,
+                                        &mut render_state,
+                                        &mut recovery_plan,
+                                        &mut next_recovery_at,
+                                    )?;
                                 }
                             }
-                            playing = true;
+                            None => {
+                                // A fresh Start re-arms an exhausted recovery
+                                // schedule and retries at once. This must not
+                                // be gated on `!playing`: a device loss leaves
+                                // the logical state playing, so an exhausted
+                                // schedule would otherwise stay disarmed and
+                                // strand playback silent until the caller
+                                // paused first.
+                                if next_recovery_at.is_none() {
+                                    recovery_plan.reset();
+                                    let _ = recovery_plan.next_step();
+                                    next_recovery_at = Some(Instant::now());
+                                }
+                            }
                         }
+                        playing = true;
                     }
                     WasapiRenderCommand::Pause => {
                         if playing {
@@ -551,17 +554,14 @@ pub mod wasapi {
 
             if playing && let Some(state) = &mut render_state {
                 let target_volume = f32::from_bits(volume.load(Ordering::Relaxed));
-                if let Err(error) =
-                    state.render_available_frames(&buffer, last_applied_volume, target_volume)
-                {
-                    on_device_error(
+                match state.render_available_frames(&buffer, last_applied_volume, target_volume) {
+                    Ok(reached) => last_applied_volume = reached,
+                    Err(error) => on_device_error(
                         error,
                         &mut render_state,
                         &mut recovery_plan,
                         &mut next_recovery_at,
-                    )?;
-                } else {
-                    last_applied_volume = normalize_volume(target_volume);
+                    )?,
                 }
             }
             thread::sleep(RENDER_POLL_INTERVAL);
@@ -615,23 +615,27 @@ pub mod wasapi {
                 .map_err(|error| wasapi_error("IAudioClient::Reset", error))
         }
 
+        /// Renders whatever the endpoint has room for, returning the gain the
+        /// volume ramp actually reached so the next pass resumes from there.
         fn render_available_frames(
             &mut self,
             buffer: &Arc<Mutex<AudioRingBuffer>>,
             from_volume: f32,
             to_volume: f32,
-        ) -> Result<()> {
+        ) -> Result<f32> {
             let padding = unsafe { self.client.GetCurrentPadding() }
                 .map_err(|error| wasapi_error("IAudioClient::GetCurrentPadding", error))?;
             let frames = self.buffer_frames.saturating_sub(padding);
             if frames == 0 {
-                return Ok(());
+                // Nothing was written, so the ramp made no progress.
+                return Ok(normalize_volume(from_volume));
             }
 
             let data = unsafe { self.render_client.GetBuffer(frames) }
                 .map_err(|error| wasapi_error("IAudioRenderClient::GetBuffer", error))?;
             let sample_count = frames as usize * self.channels;
             let mut silent = false;
+            let mut reached_volume = normalize_volume(from_volume);
             let result = (|| {
                 let output = unsafe { slice::from_raw_parts_mut(data.cast::<f32>(), sample_count) };
                 let read_result = {
@@ -642,7 +646,14 @@ pub mod wasapi {
                 };
                 // Ramp from the gain the previous pass ended on so an atomic
                 // volume step never lands as a discontinuity (zipper noise).
-                apply_volume_ramp(output, self.channels, from_volume, to_volume);
+                // Only the frames the ring supplied advance the ramp.
+                reached_volume = apply_volume_ramp(
+                    output,
+                    self.channels,
+                    from_volume,
+                    to_volume,
+                    read_result.frames,
+                );
                 silent = read_result.frames == 0;
                 Ok(())
             })();
@@ -654,7 +665,7 @@ pub mod wasapi {
             };
             let release_result = unsafe { self.render_client.ReleaseBuffer(frames, release_flags) }
                 .map_err(|error| wasapi_error("IAudioRenderClient::ReleaseBuffer", error));
-            result.and(release_result)
+            result.and(release_result).map(|()| reached_volume)
         }
     }
 

--- a/crates/erika/src/windows.rs
+++ b/crates/erika/src/windows.rs
@@ -6,14 +6,15 @@ pub mod wasapi {
         atomic::{AtomicU32, Ordering},
     };
     use std::thread::{self, JoinHandle};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use crossbeam_channel::{Receiver, Sender};
     use thiserror::Error;
 
     use crate::audio::{
-        AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult, AudioReadResult,
-        AudioRingBuffer, AudioRingBufferConfig, AudioRingBufferStats, apply_volume,
+        AudioClockSnapshot, AudioOutputBackend, AudioOutputRuntimeStats, AudioOutputState,
+        AudioPushResult, AudioReadResult, AudioRingBuffer, AudioRingBufferConfig,
+        AudioRingBufferStats, RecoveryBackoff, RecoverySignals, apply_volume, apply_volume_ramp,
         normalize_volume,
     };
     use crate::ffmpeg::{PcmAudioFrame, PcmFormat, PcmSampleFormat};
@@ -30,14 +31,75 @@ pub mod wasapi {
     const WAVE_FORMAT_IEEE_FLOAT: u16 = 3;
     const WASAPI_BUFFER_DURATION_HNS: i64 = 1_000_000;
     const RENDER_POLL_INTERVAL: Duration = Duration::from_millis(5);
+    const RECOVERY_INITIAL_DELAY: Duration = Duration::from_millis(200);
+    const RECOVERY_MAX_ATTEMPTS: u32 = 5;
+
+    // Device-loss class HRESULTs that warrant rebuilding the client against the
+    // (possibly new) default endpoint instead of tearing the render thread down.
+    const AUDCLNT_E_DEVICE_INVALIDATED: i32 = 0x8889_0004_u32 as i32;
+    const AUDCLNT_E_DEVICE_IN_USE: i32 = 0x8889_000A_u32 as i32;
+    const AUDCLNT_E_ENDPOINT_CREATE_FAILED: i32 = 0x8889_000F_u32 as i32;
+    const AUDCLNT_E_SERVICE_NOT_RUNNING: i32 = 0x8889_0010_u32 as i32;
+    const AUDCLNT_E_RESOURCES_INVALIDATED: i32 = 0x8889_0026_u32 as i32;
+    /// HRESULT_FROM_WIN32(ERROR_DEVICE_NOT_CONNECTED)
+    const E_DEVICE_NOT_CONNECTED: i32 = 0x8007_048F_u32 as i32;
+
+    fn is_device_loss_hresult(code: i32) -> bool {
+        matches!(
+            code,
+            AUDCLNT_E_DEVICE_INVALIDATED
+                | AUDCLNT_E_DEVICE_IN_USE
+                | AUDCLNT_E_ENDPOINT_CREATE_FAILED
+                | AUDCLNT_E_SERVICE_NOT_RUNNING
+                | AUDCLNT_E_RESOURCES_INVALIDATED
+                | E_DEVICE_NOT_CONNECTED
+        )
+    }
+
+    /// What the render thread should do after a device loss or a failed reopen.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum RecoveryStep {
+        RetryAfter(Duration),
+        GiveUp,
+    }
+
+    /// Retry schedule for rebuilding the WASAPI client after a device loss.
+    ///
+    /// A thin wrapper over the host-testable [`RecoveryBackoff`] in `audio.rs`
+    /// (`lib.rs` only compiles this module on Windows, so the platform-neutral
+    /// schedule and its unit tests live there).
+    #[derive(Debug)]
+    struct RenderRecoveryPlan {
+        backoff: RecoveryBackoff,
+    }
+
+    impl RenderRecoveryPlan {
+        fn new() -> Self {
+            Self {
+                backoff: RecoveryBackoff::new(RECOVERY_INITIAL_DELAY, RECOVERY_MAX_ATTEMPTS),
+            }
+        }
+
+        fn next_step(&mut self) -> RecoveryStep {
+            match self.backoff.next_delay() {
+                Some(delay) => RecoveryStep::RetryAfter(delay),
+                None => RecoveryStep::GiveUp,
+            }
+        }
+
+        fn reset(&mut self) {
+            self.backoff.reset();
+        }
+    }
 
     #[derive(Debug, Error)]
     pub enum WasapiAudioOutputError {
         #[error("audio error: {0}")]
         Audio(#[from] crate::audio::AudioError),
-        #[error("WASAPI {operation} failed: {message}")]
+        #[error("WASAPI {operation} failed with HRESULT 0x{code:08X}: {message}")]
         Wasapi {
             operation: &'static str,
+            code: i32,
             message: String,
         },
         #[error("WASAPI output buffer is not configured")]
@@ -76,6 +138,7 @@ pub mod wasapi {
         render_thread: Option<WasapiRenderThread>,
         buffer: Arc<Mutex<AudioRingBuffer>>,
         volume: Arc<AtomicU32>,
+        signals: Arc<RecoverySignals>,
     }
 
     impl WasapiAudioOutput {
@@ -86,16 +149,19 @@ pub mod wasapi {
                 render_thread: None,
                 buffer: Arc::new(Mutex::new(AudioRingBuffer::new(config.ring_buffer))),
                 volume: Arc::new(AtomicU32::new(1.0f32.to_bits())),
+                signals: Arc::new(RecoverySignals::default()),
             }
         }
 
         pub fn configure(&mut self, format: PcmFormat) -> Result<()> {
             stop_render_thread(&mut self.render_thread);
             configure_buffer(&self.buffer, format)?;
+            self.signals.reset();
             let render_thread = WasapiRenderThread::spawn(
                 format,
                 Arc::clone(&self.buffer),
                 Arc::clone(&self.volume),
+                Arc::clone(&self.signals),
             )?;
             self.render_thread = Some(render_thread);
             self.format = Some(format);
@@ -177,6 +243,10 @@ pub mod wasapi {
             Ok(buffer.clock_snapshot())
         }
 
+        pub fn runtime_stats(&self) -> AudioOutputRuntimeStats {
+            self.signals.snapshot()
+        }
+
         pub fn format(&self) -> Option<PcmFormat> {
             self.format
         }
@@ -245,6 +315,10 @@ pub mod wasapi {
         fn clock_snapshot(&self) -> Option<AudioClockSnapshot> {
             self.clock_snapshot().ok()
         }
+
+        fn runtime_stats(&self) -> AudioOutputRuntimeStats {
+            WasapiAudioOutput::runtime_stats(self)
+        }
     }
 
     struct WasapiRenderThread {
@@ -257,19 +331,22 @@ pub mod wasapi {
             format: PcmFormat,
             buffer: Arc<Mutex<AudioRingBuffer>>,
             volume: Arc<AtomicU32>,
+            signals: Arc<RecoverySignals>,
         ) -> Result<Self> {
             let (commands_tx, commands_rx) = crossbeam_channel::unbounded();
             let (init_tx, init_rx) = crossbeam_channel::bounded(1);
             let worker = thread::Builder::new()
                 .name("erika-wasapi-render".to_string())
                 .spawn(move || {
-                    let result = run_render_thread(format, buffer, volume, commands_rx, init_tx);
+                    let result =
+                        run_render_thread(format, buffer, volume, signals, commands_rx, init_tx);
                     if let Err(error) = result {
                         eprintln!("erika WASAPI render thread stopped: {error}");
                     }
                 })
                 .map_err(|error| WasapiAudioOutputError::Wasapi {
                     operation: "thread spawn",
+                    code: 0,
                     message: error.to_string(),
                 })?;
 
@@ -317,14 +394,14 @@ pub mod wasapi {
         format: PcmFormat,
         buffer: Arc<Mutex<AudioRingBuffer>>,
         volume: Arc<AtomicU32>,
+        signals: Arc<RecoverySignals>,
         commands: Receiver<WasapiRenderCommand>,
         init_tx: Sender<Result<()>>,
     ) -> Result<()> {
-        let result = initialize_render_client(format);
-        let mut render_state = match result {
+        let mut render_state = match initialize_render_client(format) {
             Ok(state) => {
                 let _ = init_tx.send(Ok(()));
-                state
+                Some(state)
             }
             Err(error) => {
                 let _ = init_tx.send(Err(error));
@@ -333,42 +410,185 @@ pub mod wasapi {
         };
 
         let mut playing = false;
+        // Gain the previous render pass ended on; the ring buffer stays alive
+        // across device-loss rebuilds, so the ramp continues seamlessly too.
+        let mut last_applied_volume = f32::from_bits(volume.load(Ordering::Relaxed));
+        let mut recovery_plan = RenderRecoveryPlan::new();
+        let mut next_recovery_at: Option<Instant> = None;
+
+        // Losing the default endpoint (unplugged headphones, default device
+        // switch) must not kill this thread: the producer keeps pushing into
+        // the ring buffer and expects playback to resume on the new default
+        // device. Device-loss HRESULTs therefore drop the client and drive the
+        // recovery schedule below; only non-recoverable errors still propagate.
+        let on_device_error = |error: WasapiAudioOutputError,
+                               render_state: &mut Option<WasapiRenderState>,
+                               recovery_plan: &mut RenderRecoveryPlan,
+                               next_recovery_at: &mut Option<Instant>|
+         -> Result<()> {
+            let Some(code) = device_loss_code(&error) else {
+                return Err(error);
+            };
+            *render_state = None;
+            signals.mark_disconnected(code);
+            recovery_plan.reset();
+            match recovery_plan.next_step() {
+                RecoveryStep::RetryAfter(delay) => {
+                    *next_recovery_at = Some(Instant::now() + delay);
+                }
+                RecoveryStep::GiveUp => {
+                    signals.recovery_failed(code);
+                    *next_recovery_at = None;
+                }
+            }
+            eprintln!("erika WASAPI device lost (HRESULT 0x{code:08X}): {error}");
+            Ok(())
+        };
+
         loop {
             for command in commands.try_iter() {
                 match command {
                     WasapiRenderCommand::Start => {
                         if !playing {
-                            render_state.client_start()?;
+                            match &render_state {
+                                Some(state) => {
+                                    if let Err(error) = state.client_start() {
+                                        on_device_error(
+                                            error,
+                                            &mut render_state,
+                                            &mut recovery_plan,
+                                            &mut next_recovery_at,
+                                        )?;
+                                    }
+                                }
+                                None => {
+                                    // A fresh Start re-arms an exhausted
+                                    // recovery schedule and retries at once.
+                                    if next_recovery_at.is_none() {
+                                        recovery_plan.reset();
+                                        let _ = recovery_plan.next_step();
+                                        next_recovery_at = Some(Instant::now());
+                                    }
+                                }
+                            }
                             playing = true;
                         }
                     }
                     WasapiRenderCommand::Pause => {
                         if playing {
-                            render_state.client_stop()?;
+                            if let Some(state) = &render_state
+                                && let Err(error) = state.client_stop()
+                            {
+                                on_device_error(
+                                    error,
+                                    &mut render_state,
+                                    &mut recovery_plan,
+                                    &mut next_recovery_at,
+                                )?;
+                            }
                             playing = false;
                         }
                     }
                     WasapiRenderCommand::Stop => {
-                        if playing {
-                            render_state.client_stop()?;
-                            playing = false;
+                        if let Some(state) = &render_state {
+                            let result = if playing {
+                                state.client_stop().and_then(|()| state.client_reset())
+                            } else {
+                                state.client_reset()
+                            };
+                            if let Err(error) = result {
+                                on_device_error(
+                                    error,
+                                    &mut render_state,
+                                    &mut recovery_plan,
+                                    &mut next_recovery_at,
+                                )?;
+                            }
                         }
-                        render_state.client_reset()?;
+                        playing = false;
                     }
                     WasapiRenderCommand::Shutdown => {
-                        if playing {
-                            let _ = render_state.client_stop();
+                        if playing && let Some(state) = &render_state {
+                            let _ = state.client_stop();
                         }
                         return Ok(());
                     }
                 }
             }
 
-            if playing {
-                render_state.render_available_frames(&buffer, &volume)?;
+            if render_state.is_none()
+                && let Some(deadline) = next_recovery_at
+                && Instant::now() >= deadline
+            {
+                signals.begin_recovery();
+                match reopen_render_client(format, playing) {
+                    Ok(state) => {
+                        render_state = Some(state);
+                        next_recovery_at = None;
+                        recovery_plan.reset();
+                        signals.recovery_succeeded();
+                    }
+                    Err(error) => {
+                        let code = error_hresult(&error);
+                        match recovery_plan.next_step() {
+                            RecoveryStep::RetryAfter(delay) => {
+                                // Budget remains: report Disconnected and try
+                                // again after the backed-off delay.
+                                signals.mark_disconnected(code);
+                                next_recovery_at = Some(Instant::now() + delay);
+                            }
+                            RecoveryStep::GiveUp => {
+                                // Budget exhausted: stay Failed until a new
+                                // Start command re-arms the schedule.
+                                signals.recovery_failed(code);
+                                next_recovery_at = None;
+                            }
+                        }
+                        eprintln!("erika WASAPI device recovery failed: {error}");
+                    }
+                }
+            }
+
+            if playing && let Some(state) = &mut render_state {
+                let target_volume = f32::from_bits(volume.load(Ordering::Relaxed));
+                if let Err(error) =
+                    state.render_available_frames(&buffer, last_applied_volume, target_volume)
+                {
+                    on_device_error(
+                        error,
+                        &mut render_state,
+                        &mut recovery_plan,
+                        &mut next_recovery_at,
+                    )?;
+                } else {
+                    last_applied_volume = normalize_volume(target_volume);
+                }
             }
             thread::sleep(RENDER_POLL_INTERVAL);
         }
+    }
+
+    /// Rebuilds the client against the current default endpoint after a device
+    /// loss and, when playback was active, restarts it immediately. The ring
+    /// buffer and volume are untouched so queued audio survives the swap.
+    fn reopen_render_client(format: PcmFormat, playing: bool) -> Result<WasapiRenderState> {
+        let state = initialize_render_client(format)?;
+        if playing {
+            state.client_start()?;
+        }
+        Ok(state)
+    }
+
+    fn error_hresult(error: &WasapiAudioOutputError) -> i32 {
+        match error {
+            WasapiAudioOutputError::Wasapi { code, .. } => *code,
+            _ => 0,
+        }
+    }
+
+    fn device_loss_code(error: &WasapiAudioOutputError) -> Option<i32> {
+        let code = error_hresult(error);
+        is_device_loss_hresult(code).then_some(code)
     }
 
     struct WasapiRenderState {
@@ -398,7 +618,8 @@ pub mod wasapi {
         fn render_available_frames(
             &mut self,
             buffer: &Arc<Mutex<AudioRingBuffer>>,
-            volume: &Arc<AtomicU32>,
+            from_volume: f32,
+            to_volume: f32,
         ) -> Result<()> {
             let padding = unsafe { self.client.GetCurrentPadding() }
                 .map_err(|error| wasapi_error("IAudioClient::GetCurrentPadding", error))?;
@@ -419,7 +640,9 @@ pub mod wasapi {
                         .map_err(|_| WasapiAudioOutputError::LockPoisoned)?;
                     buffer.read_interleaved(output)?
                 };
-                apply_volume(output, f32::from_bits(volume.load(Ordering::Relaxed)));
+                // Ramp from the gain the previous pass ended on so an atomic
+                // volume step never lands as a discontinuity (zipper noise).
+                apply_volume_ramp(output, self.channels, from_volume, to_volume);
                 silent = read_result.frames == 0;
                 Ok(())
             })();
@@ -544,6 +767,7 @@ pub mod wasapi {
     ) -> WasapiAudioOutputError {
         WasapiAudioOutputError::Wasapi {
             operation,
+            code: error.code().0,
             message: error.to_string(),
         }
     }


### PR DESCRIPTION
## Summary

Fixes two platform-layer audio defects: WASAPI output died permanently when the audio device disappeared, and volume changes were applied as audible step discontinuities on all platforms.

## Defect 1: WASAPI render-thread death on device loss

Any failed HRESULT inside the render loop — typically `AUDCLNT_E_DEVICE_INVALIDATED` when headphones unplug or the default device changes — propagated out through `?` and terminated the render thread. The producer side kept pushing into the ring buffer with no consumer, so playback went permanently silent until the host tore down and reconfigured the output. `WasapiAudioOutput` also never implemented `runtime_stats`, so the recovery state reported to hosts was a constant `Stable` even while dead.

The render thread now classifies device-loss HRESULTs (six variants), retains the ring buffer and volume state, and rebuilds the default-device `IAudioClient`/`IAudioRenderClient` under exponential backoff (200 ms base, `Failed` after five attempts; a subsequent `Start` re-arms recovery). `runtime_stats` is implemented, so hosts observe `Recovering`/`Failed` transitions. The platform-independent pieces — the `RecoveryBackoff` schedule and `RecoverySignals` atomic state publication — live in `audio.rs`, mirroring the existing Android recovery design and unit-testable on any host; `windows.rs` keeps only a thin platform wrapper plus the HRESULT classification.

## Defect 2: stepped volume (zipper noise), plus an Android O(n) rewrite

`apply_volume` multiplied each callback buffer by a single scalar that changed atomically between callbacks, producing a gain discontinuity every ~10–20 ms while dragging a volume slider — classic zipper noise. The Android path was worse: `PcmSpscRing::set_volume` rewrote every queued sample in place, an O(queue) pass racing the real-time reader, which discards any frame it catches mid-write (odd sequence number), causing audible dropouts during volume drags.

Gain is now linearly interpolated across each output callback (`apply_volume_ramp`) on CoreAudio, AudioQueue, and WASAPI, with the last applied gain carried between callbacks. The Android ring applies the ramp on the consumer side; `set_volume` only updates the atomic target and never touches queued data. Ring configuration snaps both ramp endpoints so a fresh stream does not fade in from a stale gain. Public `set_volume` signatures are unchanged.

## Testing

- 11 new unit tests: ramp endpoint/monotonicity/degenerate-case properties, backoff schedule, recovery state transitions, and SPSC assertions that queued samples are untouched and a volume step ramps across exactly the next read then holds
- `cargo test -p erika --lib`: 321 passed
- The `cfg(windows)` code was cross-checked from this host via `cargo check`/`clippy --target x86_64-pc-windows-gnu` (mingw-w64 toolchain, including `--tests`); `windows.rs` compiles clean with zero warnings. The msvc target could not be checked locally due to a transitive C dependency (`ring`) requiring Windows headers — Windows CI covers the real build
- `cargo clippy -p erika --lib` on the host: no new warnings; rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)