### PR TITLE
feat(media): expose track metadata and native debug HUD

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -188,6 +188,38 @@ impl Default for TrackSource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameRate {
+    pub numerator: u32,
+    pub denominator: u32,
+}
+
+impl FrameRate {
+    pub fn new(numerator: u32, denominator: u32) -> Option<Self> {
+        if numerator == 0 || denominator == 0 {
+            return None;
+        }
+        let divisor = greatest_common_divisor(numerator, denominator);
+        Some(Self {
+            numerator: numerator / divisor,
+            denominator: denominator / divisor,
+        })
+    }
+
+    pub fn frames_per_second(&self) -> f64 {
+        f64::from(self.numerator) / f64::from(self.denominator)
+    }
+}
+
+fn greatest_common_divisor(mut left: u32, mut right: u32) -> u32 {
+    while right != 0 {
+        let remainder = left % right;
+        left = right;
+        right = remainder;
+    }
+    left
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrackInfo {
     pub id: i64,
     pub kind: TrackKind,
@@ -202,6 +234,8 @@ pub struct TrackInfo {
     pub sample_format: Option<String>,
     pub profile: Option<String>,
     pub level: Option<i32>,
+    pub bit_rate: Option<u64>,
+    pub frame_rate: Option<FrameRate>,
     pub selected: bool,
     pub source: TrackSource,
     pub can_remove: bool,
@@ -223,6 +257,8 @@ impl TrackInfo {
             sample_format: None,
             profile: None,
             level: None,
+            bit_rate: None,
+            frame_rate: None,
             selected: false,
             source: TrackSource::Embedded,
             can_remove: false,

--- a/crates/erika/src/debug_hud.rs
+++ b/crates/erika/src/debug_hud.rs
@@ -1,0 +1,448 @@
+use std::time::{Duration, Instant};
+
+use ab_glyph::{Font, FontArc, Glyph, PxScale, ScaleFont, point};
+
+use crate::NIPAPLAY_FALLBACK_FONT;
+use crate::subtitle::SubtitleBitmapPlane;
+
+const REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+const FONT_SIZE: f32 = 22.0;
+const LINE_HEIGHT: u32 = 29;
+const PADDING: u32 = 14;
+const MAX_WIDTH: u32 = 820;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DebugHudSnapshot {
+    pub codec: Option<String>,
+    pub width: u32,
+    pub height: u32,
+    pub bit_rate: Option<u64>,
+    pub nominal_fps: Option<f64>,
+    pub pixel_format: Option<String>,
+    pub profile: Option<String>,
+    pub player_state: String,
+    pub media_time: Duration,
+    pub duration: Option<Duration>,
+    pub playback_rate: f64,
+    pub surface_width: u32,
+    pub surface_height: u32,
+    pub decoded_video_frames: u64,
+    pub rendered_video_frames: u64,
+    pub dropped_video_frames: u64,
+    pub hardware_video_frames: u64,
+    pub software_video_frames: u64,
+    pub zero_copy_video_frames: u64,
+    pub direct_zero_copy_video_frames: u64,
+    pub shared_handle_video_frames: u64,
+    pub cpu_video_frame_fallbacks: u64,
+    pub import_failures: u64,
+    pub render_failures: u64,
+    pub render_duration: Duration,
+    pub gpu_duration: Duration,
+    pub audio_queued_frames: usize,
+    pub audio_queued_duration: Option<Duration>,
+    pub audio_underflow_frames: u64,
+    pub audio_codec: Option<String>,
+    pub audio_sample_rate: u32,
+    pub audio_channels: u32,
+    pub audio_recovery_state: String,
+    pub hdr_output_active: bool,
+    pub output_encoding: String,
+    pub output_format: String,
+    pub output_headroom: f32,
+    pub output_fallback: String,
+    pub danmaku_items: usize,
+}
+
+#[derive(Debug)]
+pub struct DebugHud {
+    enabled: bool,
+    font: Option<FontArc>,
+    last_refresh: Option<Instant>,
+    previous_sample: Option<(Instant, u64, u64)>,
+    plane: Option<SubtitleBitmapPlane>,
+}
+
+impl DebugHud {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            font: FontArc::try_from_slice(NIPAPLAY_FALLBACK_FONT).ok(),
+            last_refresh: None,
+            previous_sample: None,
+            plane: None,
+        }
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        if self.enabled == enabled {
+            return;
+        }
+        self.enabled = enabled;
+        self.last_refresh = None;
+        self.previous_sample = None;
+        self.plane = None;
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn update(
+        &mut self,
+        now: Instant,
+        viewport_width: u32,
+        viewport_height: u32,
+        snapshot: DebugHudSnapshot,
+    ) -> Option<&SubtitleBitmapPlane> {
+        if !self.enabled || viewport_width == 0 || viewport_height == 0 {
+            return None;
+        }
+        if self
+            .last_refresh
+            .is_some_and(|last| now.saturating_duration_since(last) < REFRESH_INTERVAL)
+        {
+            return self.plane.as_ref();
+        }
+
+        let (decoded_fps, rendered_fps) = self.sample_fps(now, &snapshot);
+        let lines = hud_lines(&snapshot, decoded_fps, rendered_fps);
+        self.plane = self
+            .font
+            .as_ref()
+            .and_then(|font| render_lines(font, &lines, viewport_width, viewport_height));
+        self.last_refresh = Some(now);
+        self.plane.as_ref()
+    }
+
+    fn sample_fps(&mut self, now: Instant, snapshot: &DebugHudSnapshot) -> (f64, f64) {
+        let rates = self.previous_sample.and_then(|(last, decoded, rendered)| {
+            let elapsed = now.saturating_duration_since(last).as_secs_f64();
+            (elapsed > 0.0).then(|| {
+                (
+                    snapshot.decoded_video_frames.saturating_sub(decoded) as f64 / elapsed,
+                    snapshot.rendered_video_frames.saturating_sub(rendered) as f64 / elapsed,
+                )
+            })
+        });
+        self.previous_sample = Some((
+            now,
+            snapshot.decoded_video_frames,
+            snapshot.rendered_video_frames,
+        ));
+        rates.unwrap_or((0.0, 0.0))
+    }
+}
+
+impl Default for DebugHud {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn hud_lines(snapshot: &DebugHudSnapshot, decoded_fps: f64, rendered_fps: f64) -> Vec<String> {
+    let codec = snapshot
+        .codec
+        .as_deref()
+        .unwrap_or("unknown")
+        .to_uppercase();
+    let nominal_fps = snapshot
+        .nominal_fps
+        .map(|fps| format!("{fps:.2}"))
+        .unwrap_or_else(|| "n/a".to_string());
+    let bit_rate = snapshot
+        .bit_rate
+        .map(format_bit_rate)
+        .unwrap_or_else(|| "n/a".to_string());
+    let decode_path = if snapshot.hardware_video_frames > snapshot.software_video_frames {
+        "hardware"
+    } else if snapshot.software_video_frames > 0 {
+        "software"
+    } else {
+        "pending"
+    };
+    let pixel_format = snapshot.pixel_format.as_deref().unwrap_or("unknown");
+    let profile = snapshot.profile.as_deref().unwrap_or("unknown");
+    let audio_codec = snapshot.audio_codec.as_deref().unwrap_or("unknown");
+    let audio_queue_ms = snapshot
+        .audio_queued_duration
+        .map(|duration| duration.as_secs_f64() * 1000.0)
+        .unwrap_or(0.0);
+    vec![
+        format!(
+            "ERIKA HUD  {codec}  {}x{}  {nominal_fps} fps  {bit_rate}",
+            snapshot.width, snapshot.height
+        ),
+        format!(
+            "State {}  Time {} / {}  Speed {:.2}x  Surface {}x{}",
+            snapshot.player_state,
+            format_duration(snapshot.media_time),
+            snapshot
+                .duration
+                .map(format_duration)
+                .unwrap_or_else(|| "--:--".to_string()),
+            snapshot.playback_rate,
+            snapshot.surface_width,
+            snapshot.surface_height
+        ),
+        format!("Video profile {profile}  Format {pixel_format}  Path {decode_path}"),
+        format!(
+            "Decode {decoded_fps:5.1} fps ({})  Render {rendered_fps:5.1} fps ({})  Drop {}",
+            snapshot.decoded_video_frames,
+            snapshot.rendered_video_frames,
+            snapshot.dropped_video_frames,
+        ),
+        format!(
+            "Zero-copy {}  Direct {}  Shared {}  CPU fallback {}",
+            snapshot.zero_copy_video_frames,
+            snapshot.direct_zero_copy_video_frames,
+            snapshot.shared_handle_video_frames,
+            snapshot.cpu_video_frame_fallbacks,
+        ),
+        format!(
+            "Render {:5.2} ms  GPU {:5.2} ms  Import fail {}  Render fail {}",
+            snapshot.render_duration.as_secs_f64() * 1000.0,
+            snapshot.gpu_duration.as_secs_f64() * 1000.0,
+            snapshot.import_failures,
+            snapshot.render_failures,
+        ),
+        format!(
+            "Audio {audio_codec}  {} Hz  {} ch  Queue {} / {:.1} ms  Underflow {}  {}",
+            snapshot.audio_sample_rate,
+            snapshot.audio_channels,
+            snapshot.audio_queued_frames,
+            audio_queue_ms,
+            snapshot.audio_underflow_frames,
+            snapshot.audio_recovery_state,
+        ),
+        format!(
+            "Output {}  {}  Headroom {:.2}x  HDR {}  Fallback {}  Danmaku {}",
+            snapshot.output_encoding,
+            snapshot.output_format,
+            snapshot.output_headroom,
+            if snapshot.hdr_output_active {
+                "on"
+            } else {
+                "off"
+            },
+            snapshot.output_fallback,
+            snapshot.danmaku_items,
+        ),
+    ]
+}
+
+fn format_duration(duration: Duration) -> String {
+    let total_seconds = duration.as_secs();
+    let hours = total_seconds / 3_600;
+    let minutes = total_seconds % 3_600 / 60;
+    let seconds = total_seconds % 60;
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+fn format_bit_rate(bit_rate: u64) -> String {
+    if bit_rate >= 1_000_000 {
+        format!("{:.2} Mbps", bit_rate as f64 / 1_000_000.0)
+    } else if bit_rate >= 1_000 {
+        format!("{:.1} Kbps", bit_rate as f64 / 1_000.0)
+    } else {
+        format!("{bit_rate} bps")
+    }
+}
+
+fn render_lines(
+    font: &FontArc,
+    lines: &[String],
+    viewport_width: u32,
+    viewport_height: u32,
+) -> Option<SubtitleBitmapPlane> {
+    let width = MAX_WIDTH.min(viewport_width.saturating_sub(PADDING * 2));
+    let height = (PADDING * 2 + LINE_HEIGHT * lines.len() as u32)
+        .min(viewport_height.saturating_sub(PADDING * 2));
+    if width == 0 || height == 0 {
+        return None;
+    }
+    let mut rgba = vec![0u8; width as usize * height as usize * 4];
+    for pixel in rgba.chunks_exact_mut(4) {
+        pixel.copy_from_slice(&[8, 10, 14, 190]);
+    }
+    let scale = PxScale::from(FONT_SIZE);
+    let scaled = font.as_scaled(scale);
+    for (line_index, line) in lines.iter().enumerate() {
+        let mut cursor = PADDING as f32;
+        let baseline = PADDING as f32 + FONT_SIZE + line_index as f32 * LINE_HEIGHT as f32;
+        let mut previous = None;
+        for character in line.chars() {
+            let glyph_id = scaled.glyph_id(character);
+            if let Some(previous) = previous {
+                cursor += scaled.kern(previous, glyph_id);
+            }
+            let glyph = Glyph {
+                id: glyph_id,
+                scale,
+                position: point(cursor, baseline),
+            };
+            if let Some(outlined) = font.outline_glyph(glyph) {
+                let bounds = outlined.px_bounds();
+                outlined.draw(|x, y, coverage| {
+                    let px = bounds.min.x.floor() as i32 + x as i32;
+                    let py = bounds.min.y.floor() as i32 + y as i32;
+                    if px < 0 || py < 0 || px >= width as i32 || py >= height as i32 {
+                        return;
+                    }
+                    let index = (py as usize * width as usize + px as usize) * 4;
+                    blend_source_over(&mut rgba[index..index + 4], [238, 244, 255], coverage);
+                });
+            }
+            cursor += scaled.h_advance(glyph_id);
+            previous = Some(glyph_id);
+            if cursor >= width.saturating_sub(PADDING) as f32 {
+                break;
+            }
+        }
+    }
+    Some(SubtitleBitmapPlane::new(
+        PADDING as i32,
+        PADDING as i32,
+        width,
+        height,
+        rgba,
+    ))
+}
+
+fn blend_source_over(destination: &mut [u8], source_rgb: [u8; 3], coverage: f32) {
+    let source_alpha = coverage.clamp(0.0, 1.0);
+    if source_alpha <= 0.0 {
+        return;
+    }
+    let destination_alpha = f32::from(destination[3]) / 255.0;
+    let output_alpha = source_alpha + destination_alpha * (1.0 - source_alpha);
+    for channel in 0..3 {
+        let source = f32::from(source_rgb[channel]) / 255.0;
+        let destination_color = f32::from(destination[channel]) / 255.0;
+        let output = (source * source_alpha
+            + destination_color * destination_alpha * (1.0 - source_alpha))
+            / output_alpha;
+        destination[channel] = (output.clamp(0.0, 1.0) * 255.0).round() as u8;
+    }
+    destination[3] = (output_alpha * 255.0).round() as u8;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ab_glyph::{Font, FontArc};
+
+    use crate::NIPAPLAY_FALLBACK_FONT;
+
+    fn snapshot(decoded: u64, rendered: u64) -> DebugHudSnapshot {
+        DebugHudSnapshot {
+            codec: Some("hevc".to_string()),
+            width: 3840,
+            height: 2160,
+            bit_rate: Some(18_000_000),
+            nominal_fps: Some(30_000.0 / 1_001.0),
+            pixel_format: Some("yuv420p10le".to_string()),
+            profile: Some("Main 10".to_string()),
+            player_state: "playing".to_string(),
+            media_time: Duration::from_secs(62),
+            duration: Some(Duration::from_secs(3_725)),
+            playback_rate: 1.25,
+            surface_width: 1920,
+            surface_height: 1080,
+            decoded_video_frames: decoded,
+            rendered_video_frames: rendered,
+            dropped_video_frames: 2,
+            hardware_video_frames: 10,
+            software_video_frames: 0,
+            zero_copy_video_frames: 9,
+            direct_zero_copy_video_frames: 8,
+            shared_handle_video_frames: 1,
+            cpu_video_frame_fallbacks: 2,
+            import_failures: 3,
+            render_failures: 4,
+            render_duration: Duration::from_micros(800),
+            gpu_duration: Duration::from_micros(500),
+            audio_queued_frames: 512,
+            audio_queued_duration: Some(Duration::from_millis(12)),
+            audio_underflow_frames: 1,
+            audio_codec: Some("aac".to_string()),
+            audio_sample_rate: 48_000,
+            audio_channels: 2,
+            audio_recovery_state: "stable".to_string(),
+            hdr_output_active: true,
+            output_encoding: "hdr10-pq".to_string(),
+            output_format: "10bit-unorm".to_string(),
+            output_headroom: 4.0,
+            output_fallback: "none".to_string(),
+            danmaku_items: 16,
+        }
+    }
+
+    #[test]
+    fn hud_is_disabled_by_default_and_reuses_cached_plane() {
+        let mut hud = DebugHud::new();
+        let now = Instant::now();
+        assert!(hud.update(now, 1920, 1080, snapshot(1, 1)).is_none());
+        hud.set_enabled(true);
+        let first = hud.update(now, 1920, 1080, snapshot(1, 1)).cloned();
+        let second = hud
+            .update(now + Duration::from_millis(100), 1920, 1080, snapshot(5, 5))
+            .cloned();
+        assert!(first.is_some());
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn hud_text_contains_media_and_runtime_metrics() {
+        let lines = hud_lines(&snapshot(30, 29), 30.0, 29.0);
+        assert!(lines[0].contains("HEVC"));
+        assert!(lines[0].contains("3840x2160"));
+        assert!(lines[0].contains("18.00 Mbps"));
+        assert!(lines[1].contains("01:02 / 1:02:05"));
+        assert!(lines[2].contains("yuv420p10le"));
+        assert!(lines[3].contains("Decode  30.0 fps"));
+        assert!(lines[4].contains("Direct 8"));
+        assert!(lines[5].contains("Import fail 3"));
+        assert!(lines[6].contains("AAC".to_lowercase().as_str()));
+        assert!(lines[6].contains("Underflow 1"));
+        assert!(lines[7].contains("hdr10-pq"));
+        assert!(lines[7].contains("Danmaku 16"));
+    }
+
+    #[test]
+    fn larger_hud_allocates_all_diagnostic_rows() {
+        let font = FontArc::try_from_slice(NIPAPLAY_FALLBACK_FONT).unwrap();
+        let lines = hud_lines(&snapshot(30, 29), 30.0, 29.0);
+        let plane = render_lines(&font, &lines, 1920, 1080).unwrap();
+        assert_eq!(plane.width, MAX_WIDTH);
+        assert_eq!(plane.height, PADDING * 2 + LINE_HEIGHT * 8);
+        assert_eq!(FONT_SIZE, 22.0);
+    }
+
+    #[test]
+    fn bundled_font_contains_hud_ascii_glyphs() {
+        let font = FontArc::try_from_slice(NIPAPLAY_FALLBACK_FONT).unwrap();
+        for character in "ERIKA HUD Decode Render Path Zero-copy GPU Audio 0123456789.-/".chars() {
+            if character.is_whitespace() {
+                continue;
+            }
+            assert_ne!(font.glyph_id(character).0, 0, "missing glyph {character:?}");
+        }
+    }
+
+    #[test]
+    fn antialiased_glyph_coverage_blends_over_background() {
+        let mut low = [8, 10, 14, 190];
+        let mut full = low;
+        blend_source_over(&mut low, [238, 244, 255], 0.1);
+        blend_source_over(&mut full, [238, 244, 255], 1.0);
+        assert!(low[0] < full[0]);
+        assert!(low[3] < full[3]);
+        assert_eq!(full, [238, 244, 255, 255]);
+    }
+}

--- a/crates/erika/src/debug_hud.rs
+++ b/crates/erika/src/debug_hud.rs
@@ -20,6 +20,15 @@ pub struct DebugHudSnapshot {
     pub nominal_fps: Option<f64>,
     pub pixel_format: Option<String>,
     pub profile: Option<String>,
+    pub decoder_requested_backend: Option<String>,
+    pub decoder_previous_backend: Option<String>,
+    pub decoder_active_backend: Option<String>,
+    pub decoder_codec: Option<String>,
+    pub decoder_pixel_format: Option<String>,
+    pub decoder_line_sizes: Option<[i32; 4]>,
+    pub decoder_fallback_count: u64,
+    pub decoder_stage: Option<String>,
+    pub decoder_reason: Option<String>,
     pub player_state: String,
     pub media_time: Duration,
     pub duration: Option<Duration>,
@@ -163,6 +172,29 @@ fn hud_lines(snapshot: &DebugHudSnapshot, decoded_fps: f64, rendered_fps: f64) -
     };
     let pixel_format = snapshot.pixel_format.as_deref().unwrap_or("unknown");
     let profile = snapshot.profile.as_deref().unwrap_or("unknown");
+    let decoder_requested = snapshot
+        .decoder_requested_backend
+        .as_deref()
+        .unwrap_or("pending");
+    let decoder_previous = snapshot
+        .decoder_previous_backend
+        .as_deref()
+        .unwrap_or("none");
+    let decoder_active = snapshot
+        .decoder_active_backend
+        .as_deref()
+        .unwrap_or("pending");
+    let decoder_codec = snapshot.decoder_codec.as_deref().unwrap_or("unknown");
+    let decoder_pixel_format = snapshot
+        .decoder_pixel_format
+        .as_deref()
+        .unwrap_or("unknown");
+    let decoder_line_sizes = snapshot
+        .decoder_line_sizes
+        .map(|sizes| format!("{}/{}/{}/{}", sizes[0], sizes[1], sizes[2], sizes[3]))
+        .unwrap_or_else(|| "n/a".to_string());
+    let decoder_stage = snapshot.decoder_stage.as_deref().unwrap_or("pending");
+    let decoder_reason = snapshot.decoder_reason.as_deref().unwrap_or("none");
     let audio_codec = snapshot.audio_codec.as_deref().unwrap_or("unknown");
     let audio_queue_ms = snapshot
         .audio_queued_duration
@@ -186,6 +218,17 @@ fn hud_lines(snapshot: &DebugHudSnapshot, decoded_fps: f64, rendered_fps: f64) -
             snapshot.surface_height
         ),
         format!("Video profile {profile}  Format {pixel_format}  Path {decode_path}"),
+        format!(
+            "Decoder requested {decoder_requested}  Previous {decoder_previous}  Active {decoder_active}",
+        ),
+        format!(
+            "Decoder codec {decoder_codec}  Format {decoder_pixel_format}  Lines {decoder_line_sizes}",
+        ),
+        format!(
+            "Decoder fallback {}  Stage {}",
+            snapshot.decoder_fallback_count, decoder_stage,
+        ),
+        format!("Decoder reason {}", truncate_decoder_reason(decoder_reason)),
         format!(
             "Decode {decoded_fps:5.1} fps ({})  Render {rendered_fps:5.1} fps ({})  Drop {}",
             snapshot.decoded_video_frames,
@@ -229,6 +272,17 @@ fn hud_lines(snapshot: &DebugHudSnapshot, decoded_fps: f64, rendered_fps: f64) -
             snapshot.danmaku_items,
         ),
     ]
+}
+
+fn truncate_decoder_reason(reason: &str) -> String {
+    const MAX_CHARS: usize = 72;
+    let mut chars = reason.chars();
+    let prefix = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{prefix}...")
+    } else {
+        prefix
+    }
 }
 
 fn format_duration(duration: Duration) -> String {
@@ -348,6 +402,15 @@ mod tests {
             nominal_fps: Some(30_000.0 / 1_001.0),
             pixel_format: Some("yuv420p10le".to_string()),
             profile: Some("Main 10".to_string()),
+            decoder_requested_backend: Some("videotoolbox".to_string()),
+            decoder_previous_backend: Some("videotoolbox".to_string()),
+            decoder_active_backend: Some("software".to_string()),
+            decoder_codec: Some("hevc".to_string()),
+            decoder_pixel_format: Some("yuv420p10le".to_string()),
+            decoder_line_sizes: Some([7680, 3840, 3840, 0]),
+            decoder_fallback_count: 1,
+            decoder_stage: Some("runtime_to_software".to_string()),
+            decoder_reason: Some("hardware import failed".to_string()),
             player_state: "playing".to_string(),
             media_time: Duration::from_secs(62),
             duration: Some(Duration::from_secs(3_725)),
@@ -405,13 +468,17 @@ mod tests {
         assert!(lines[0].contains("18.00 Mbps"));
         assert!(lines[1].contains("01:02 / 1:02:05"));
         assert!(lines[2].contains("yuv420p10le"));
-        assert!(lines[3].contains("Decode  30.0 fps"));
-        assert!(lines[4].contains("Direct 8"));
-        assert!(lines[5].contains("Import fail 3"));
-        assert!(lines[6].contains("AAC".to_lowercase().as_str()));
-        assert!(lines[6].contains("Underflow 1"));
-        assert!(lines[7].contains("hdr10-pq"));
-        assert!(lines[7].contains("Danmaku 16"));
+        assert!(lines[3].contains("requested videotoolbox"));
+        assert!(lines[3].contains("Active software"));
+        assert!(lines[4].contains("Lines 7680/3840/3840/0"));
+        assert!(lines[5].contains("runtime_to_software"));
+        assert!(lines[7].contains("Decode  30.0 fps"));
+        assert!(lines[8].contains("Direct 8"));
+        assert!(lines[9].contains("Import fail 3"));
+        assert!(lines[10].contains("aac"));
+        assert!(lines[10].contains("Underflow 1"));
+        assert!(lines[11].contains("hdr10-pq"));
+        assert!(lines[11].contains("Danmaku 16"));
     }
 
     #[test]
@@ -420,7 +487,7 @@ mod tests {
         let lines = hud_lines(&snapshot(30, 29), 30.0, 29.0);
         let plane = render_lines(&font, &lines, 1920, 1080).unwrap();
         assert_eq!(plane.width, MAX_WIDTH);
-        assert_eq!(plane.height, PADDING * 2 + LINE_HEIGHT * 8);
+        assert_eq!(plane.height, PADDING * 2 + LINE_HEIGHT * lines.len() as u32);
         assert_eq!(FONT_SIZE, 22.0);
     }
 

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use crate::core::{ColorPrimaries, TrackInfo, TrackKind, TransferFunction, VideoParams};
+use crate::core::{ColorPrimaries, FrameRate, TrackInfo, TrackKind, TransferFunction, VideoParams};
 use crate::renderer::pipeline::{
     Chromaticity, ColorRange, ContentLightMetadata, HdrMetadata, MasteringDisplayMetadata,
     MatrixCoefficients,
@@ -3241,8 +3241,12 @@ fn inspect_format_context(
         track.title = metadata_value(unsafe { (*stream).metadata }, "title");
         track.language = metadata_value(unsafe { (*stream).metadata }, "language");
         track.codec = codec.clone();
+        track.bit_rate = u64::try_from(unsafe { (*codecpar).bit_rate })
+            .ok()
+            .filter(|bit_rate| *bit_rate > 0);
 
         if kind == TrackKind::Video {
+            track.frame_rate = unsafe { stream_frame_rate(stream) };
             let probe = unsafe { video_probe(&track, codecpar) };
             track.width = probe.params.width;
             track.height = probe.params.height;
@@ -3339,6 +3343,17 @@ unsafe fn codec_name(codec_id: sys::AVCodecID) -> Option<String> {
             .to_string_lossy()
             .into_owned(),
     )
+}
+
+unsafe fn stream_frame_rate(stream: *const sys::AVStream) -> Option<FrameRate> {
+    let average = unsafe { (*stream).avg_frame_rate };
+    frame_rate_from_av(average).or_else(|| frame_rate_from_av(unsafe { (*stream).r_frame_rate }))
+}
+
+fn frame_rate_from_av(value: sys::AVRational) -> Option<FrameRate> {
+    let numerator = u32::try_from(value.num).ok()?;
+    let denominator = u32::try_from(value.den).ok()?;
+    FrameRate::new(numerator, denominator)
 }
 
 unsafe fn video_probe(track: &TrackInfo, codecpar: *const sys::AVCodecParameters) -> VideoProbe {
@@ -4072,6 +4087,23 @@ mod tests {
     }
 
     #[test]
+    fn playback_fixture_exposes_video_technical_metadata() {
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata/playback/playback-fixture.mkv");
+        let probe = probe_path(path).unwrap();
+        let video = probe
+            .tracks
+            .iter()
+            .find(|track| track.kind == TrackKind::Video)
+            .unwrap();
+
+        assert_eq!(video.codec.as_deref(), Some("mpeg4"));
+        assert_eq!((video.width, video.height), (160, 90));
+        assert_eq!(video.bit_rate, None);
+        assert_eq!(video.frame_rate, FrameRate::new(30, 1));
+    }
+
+    #[test]
     fn time_base_converts_packet_timestamps() {
         let timestamp = PacketTimestamp {
             raw: 24,
@@ -4732,6 +4764,17 @@ mod tests {
 
     fn rational(num: i32, den: i32) -> sys::AVRational {
         sys::AVRational { num, den }
+    }
+
+    #[test]
+    fn frame_rate_normalizes_positive_rationals() {
+        assert_eq!(
+            frame_rate_from_av(rational(60_000, 2_002)),
+            FrameRate::new(30_000, 1_001)
+        );
+        assert_eq!(frame_rate_from_av(rational(0, 1)), None);
+        assert_eq!(frame_rate_from_av(rational(30, 0)), None);
+        assert_eq!(frame_rate_from_av(rational(-30, 1)), None);
     }
 
     fn assert_close(actual: f32, expected: f32) {

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -3306,7 +3306,11 @@ fn infer_single_video_bit_rate(tracks: &mut [TrackInfo], container_bit_rate: Opt
         .iter()
         .enumerate()
         .filter(|(index, track)| {
-            *index != video_index && matches!(track.kind, TrackKind::Video | TrackKind::Audio)
+            *index != video_index
+                && matches!(
+                    track.kind,
+                    TrackKind::Video | TrackKind::Audio | TrackKind::Subtitle
+                )
         })
         .map(|(_, track)| track.bit_rate)
         .collect::<Option<Vec<_>>>();
@@ -4155,6 +4159,17 @@ mod tests {
         infer_single_video_bit_rate(&mut tracks, Some(1_128_000));
 
         assert_eq!(tracks[0].bit_rate, Some(1_000_000));
+
+        let mut subtitle = TrackInfo::embedded(2, TrackKind::Subtitle);
+        subtitle.bit_rate = Some(128_000);
+        let mut tracks = vec![video.clone(), audio.clone(), subtitle.clone()];
+        infer_single_video_bit_rate(&mut tracks, Some(1_256_000));
+        assert_eq!(tracks[0].bit_rate, Some(1_000_000));
+
+        subtitle.bit_rate = None;
+        let mut tracks = vec![video.clone(), audio.clone(), subtitle];
+        infer_single_video_bit_rate(&mut tracks, Some(1_256_000));
+        assert_eq!(tracks[0].bit_rate, None);
 
         audio.bit_rate = None;
         let mut tracks = vec![video.clone(), audio];

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -3246,7 +3246,7 @@ fn inspect_format_context(
             .filter(|bit_rate| *bit_rate > 0);
 
         if kind == TrackKind::Video {
-            track.frame_rate = unsafe { stream_frame_rate(stream) };
+            track.frame_rate = unsafe { stream_frame_rate(raw, stream) };
             let probe = unsafe { video_probe(&track, codecpar) };
             track.width = probe.params.width;
             track.height = probe.params.height;
@@ -3269,6 +3269,11 @@ fn inspect_format_context(
         tracks.push(track);
     }
 
+    let container_bit_rate = u64::try_from(unsafe { (*raw).bit_rate })
+        .ok()
+        .filter(|bit_rate| *bit_rate > 0);
+    infer_single_video_bit_rate(&mut tracks, container_bit_rate);
+
     (
         MediaProbe {
             uri: uri.to_string(),
@@ -3281,6 +3286,34 @@ fn inspect_format_context(
         },
         stream_time_bases,
     )
+}
+
+fn infer_single_video_bit_rate(tracks: &mut [TrackInfo], container_bit_rate: Option<u64>) {
+    let Some(container_bit_rate) = container_bit_rate else {
+        return;
+    };
+    let mut video_indexes = tracks
+        .iter()
+        .enumerate()
+        .filter_map(|(index, track)| (track.kind == TrackKind::Video).then_some(index));
+    let Some(video_index) = video_indexes.next() else {
+        return;
+    };
+    if video_indexes.next().is_some() || tracks[video_index].bit_rate.is_some() {
+        return;
+    }
+    let other_media_bit_rates = tracks
+        .iter()
+        .enumerate()
+        .filter(|(index, track)| {
+            *index != video_index && matches!(track.kind, TrackKind::Video | TrackKind::Audio)
+        })
+        .map(|(_, track)| track.bit_rate)
+        .collect::<Option<Vec<_>>>();
+    tracks[video_index].bit_rate = other_media_bit_rates
+        .and_then(|values| values.into_iter().try_fold(0_u64, u64::checked_add))
+        .and_then(|other_bit_rate| container_bit_rate.checked_sub(other_bit_rate))
+        .filter(|value| *value > 0);
 }
 
 fn check(code: i32, operation: &'static str) -> Result<()> {
@@ -3345,9 +3378,18 @@ unsafe fn codec_name(codec_id: sys::AVCodecID) -> Option<String> {
     )
 }
 
-unsafe fn stream_frame_rate(stream: *const sys::AVStream) -> Option<FrameRate> {
+unsafe fn stream_frame_rate(
+    format: *const sys::AVFormatContext,
+    stream: *const sys::AVStream,
+) -> Option<FrameRate> {
     let average = unsafe { (*stream).avg_frame_rate };
-    frame_rate_from_av(average).or_else(|| frame_rate_from_av(unsafe { (*stream).r_frame_rate }))
+    frame_rate_from_av(average)
+        .or_else(|| frame_rate_from_av(unsafe { (*stream).r_frame_rate }))
+        .or_else(|| {
+            frame_rate_from_av(unsafe {
+                sys::av_guess_frame_rate(format.cast_mut(), stream.cast_mut(), ptr::null_mut())
+            })
+        })
 }
 
 fn frame_rate_from_av(value: sys::AVRational) -> Option<FrameRate> {
@@ -4101,6 +4143,28 @@ mod tests {
         assert_eq!((video.width, video.height), (160, 90));
         assert_eq!(video.bit_rate, None);
         assert_eq!(video.frame_rate, FrameRate::new(30, 1));
+    }
+
+    #[test]
+    fn video_bit_rate_inference_requires_unambiguous_track_metadata() {
+        let mut video = TrackInfo::embedded(0, TrackKind::Video);
+        let mut audio = TrackInfo::embedded(1, TrackKind::Audio);
+        audio.bit_rate = Some(128_000);
+        let mut tracks = vec![video.clone(), audio.clone()];
+
+        infer_single_video_bit_rate(&mut tracks, Some(1_128_000));
+
+        assert_eq!(tracks[0].bit_rate, Some(1_000_000));
+
+        audio.bit_rate = None;
+        let mut tracks = vec![video.clone(), audio];
+        infer_single_video_bit_rate(&mut tracks, Some(1_128_000));
+        assert_eq!(tracks[0].bit_rate, None);
+
+        video.bit_rate = Some(900_000);
+        let mut tracks = vec![video, TrackInfo::embedded(2, TrackKind::Video)];
+        infer_single_video_bit_rate(&mut tracks, Some(1_128_000));
+        assert_eq!(tracks[1].bit_rate, None);
     }
 
     #[test]

--- a/crates/erika/src/lib.rs
+++ b/crates/erika/src/lib.rs
@@ -4,6 +4,7 @@ pub mod apple;
 pub mod audio;
 pub mod core;
 pub mod danmaku;
+pub mod debug_hud;
 pub mod ffmpeg;
 pub mod overlay;
 pub mod playback;

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -37,6 +37,7 @@ use crate::danmaku::{
     DanmakuRenderPlan, DanmakuSession, DanmakuTimeline, DanmakuTrackInfo, DanmakuTrackSource,
     DanmakuViewport, DfmLayoutEngine, DfmPreparedLayout,
 };
+use crate::debug_hud::{DebugHud, DebugHudSnapshot};
 use crate::ffmpeg::DecoderBackend;
 use crate::overlay::{OverlayFrame, OverlayTimeline, OverlayViewport};
 #[cfg(any(target_os = "windows", target_os = "android"))]
@@ -229,6 +230,7 @@ pub struct PresenterRuntime {
     last_audio_runtime_stats: AudioOutputRuntimeStats,
     playback_rate: f64,
     current_overlay: Option<OverlayFrame>,
+    debug_hud: DebugHud,
     current_danmaku: Option<DanmakuRenderPlan>,
     current_danmaku_prepared: Option<CurrentDanmakuPrepared>,
     rejected_video_import_route: Option<RejectedVideoImportRoute>,
@@ -526,6 +528,7 @@ impl PresenterRuntime {
             last_audio_runtime_stats: AudioOutputRuntimeStats::default(),
             playback_rate: 1.0,
             current_overlay: None,
+            debug_hud: DebugHud::new(),
             current_danmaku: None,
             current_danmaku_prepared: None,
             rejected_video_import_route: None,
@@ -682,6 +685,14 @@ impl PresenterRuntime {
 
     pub fn volume(&self) -> f64 {
         self.audio_output.volume() as f64
+    }
+
+    pub fn set_debug_hud_enabled(&mut self, enabled: bool) {
+        self.debug_hud.set_enabled(enabled);
+    }
+
+    pub fn debug_hud_enabled(&self) -> bool {
+        self.debug_hud.enabled()
     }
 
     pub fn set_subtitle_scale(&mut self, scale: f64) {
@@ -889,8 +900,43 @@ impl PresenterRuntime {
             plan_items,
         );
 
+        let hud_snapshot = self.debug_hud_snapshot();
+        let hud_viewport = self
+            .current_overlay
+            .as_ref()
+            .map(|overlay| overlay.viewport)
+            .or_else(|| {
+                self.current_surface_metrics.map(|metrics| {
+                    OverlayViewport::new(
+                        metrics.physical_extent.width,
+                        metrics.physical_extent.height,
+                    )
+                })
+            });
+        let hud_plane = hud_viewport.and_then(|viewport| {
+            self.debug_hud
+                .update(
+                    Instant::now(),
+                    viewport.width,
+                    viewport.height,
+                    hud_snapshot,
+                )
+                .cloned()
+        });
+        let mut render_overlay = self.current_overlay.clone();
+        if let Some(plane) = hud_plane {
+            let viewport = hud_viewport.expect("HUD requires a viewport");
+            let overlay = render_overlay.get_or_insert_with(|| OverlayFrame {
+                pts: self.current_media_time,
+                viewport,
+                subtitle_planes: Vec::new(),
+                subtitle_alpha_planes: Vec::new(),
+                subtitle_changed: false,
+            });
+            overlay.subtitle_planes.push(plane);
+        }
         let context = RenderFrameContext::new(self.current_media_time, self.current_generation)
-            .overlay(self.current_overlay.as_ref())
+            .overlay(render_overlay.as_ref())
             .danmaku(self.current_danmaku.as_ref())
             .output_size(
                 self.current_surface_metrics
@@ -969,6 +1015,77 @@ impl PresenterRuntime {
             ));
         }
         Ok(self.stats)
+    }
+
+    fn debug_hud_snapshot(&self) -> DebugHudSnapshot {
+        let selected = self.player.track_selection().video.and_then(|selected| {
+            self.player
+                .tracks()
+                .into_iter()
+                .find(|track| track.id == selected)
+        });
+        let selected_audio = self.player.track_selection().audio.and_then(|selected| {
+            self.player
+                .tracks()
+                .into_iter()
+                .find(|track| track.id == selected)
+        });
+        let renderer = self.renderer.runtime_stats();
+        let clock = self.audio_output.clock_snapshot();
+        let output = self.renderer.output_status();
+        let audio_runtime = self.audio_output.runtime_stats();
+        let surface = self.current_surface_metrics;
+        DebugHudSnapshot {
+            codec: selected.as_ref().and_then(|track| track.codec.clone()),
+            width: selected.as_ref().map_or(0, |track| track.width),
+            height: selected.as_ref().map_or(0, |track| track.height),
+            bit_rate: selected.as_ref().and_then(|track| track.bit_rate),
+            nominal_fps: selected
+                .as_ref()
+                .and_then(|track| track.frame_rate.as_ref())
+                .map(|rate| rate.frames_per_second()),
+            pixel_format: selected
+                .as_ref()
+                .and_then(|track| track.pixel_format.clone()),
+            profile: selected.as_ref().and_then(|track| track.profile.clone()),
+            player_state: format!("{:?}", self.player.state()).to_lowercase(),
+            media_time: self.current_media_time,
+            duration: self.player.duration(),
+            playback_rate: self.playback_rate,
+            surface_width: surface.map_or(0, |metrics| metrics.physical_extent.width),
+            surface_height: surface.map_or(0, |metrics| metrics.physical_extent.height),
+            decoded_video_frames: self.stats.decoded_video_frames,
+            rendered_video_frames: self.stats.rendered_video_frames,
+            dropped_video_frames: self.stats.video_frame_backpressure_drops,
+            hardware_video_frames: renderer.hardware_video_frames,
+            software_video_frames: renderer.software_video_frames,
+            zero_copy_video_frames: renderer.zero_copy_video_frames,
+            direct_zero_copy_video_frames: renderer.direct_zero_copy_video_frames,
+            shared_handle_video_frames: renderer.shared_handle_video_frames,
+            cpu_video_frame_fallbacks: renderer.cpu_video_frame_fallbacks,
+            import_failures: self.stats.import_failures,
+            render_failures: self.stats.render_failures,
+            render_duration: self.last_render_duration,
+            gpu_duration: renderer.last_gpu_duration,
+            audio_queued_frames: clock.map_or(0, |snapshot| snapshot.queued_frames),
+            audio_queued_duration: clock.and_then(|snapshot| snapshot.queued_duration),
+            audio_underflow_frames: clock.map_or(0, |snapshot| snapshot.underflow_frames),
+            audio_codec: selected_audio
+                .as_ref()
+                .and_then(|track| track.codec.clone()),
+            audio_sample_rate: selected_audio.as_ref().map_or(0, |track| track.sample_rate),
+            audio_channels: selected_audio.as_ref().map_or(0, |track| track.channels),
+            audio_recovery_state: audio_runtime.recovery_state.as_str().to_string(),
+            hdr_output_active: renderer.hdr10_output_active,
+            output_encoding: output.active_encoding.label().to_string(),
+            output_format: output.surface_format.label().to_string(),
+            output_headroom: output.active_headroom,
+            output_fallback: output.fallback_reason.label().to_string(),
+            danmaku_items: self
+                .current_danmaku
+                .as_ref()
+                .map_or(0, |plan| plan.items.len()),
+        }
     }
 
     pub fn capture_frame_rgba(&mut self, width: u32, height: u32) -> Result<Option<Vec<u8>>> {

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -30,7 +30,7 @@ use crate::core::{
     AudioOutputEvent, MediaRequest, PlatformSurface, Player, PlayerAudioFrame, PlayerConfig,
     PlayerSubtitleFrame, PlayerVideoFrame, RenderFrameContext, RendererBackend,
     RendererBackendPreference, RendererRuntimeStats, SurfaceMetrics, TrackInfo, TrackSelection,
-    VideoFrameImportFailure,
+    VideoDecoderEvent, VideoFrameImportFailure,
 };
 use crate::danmaku::{
     DANMAKU_DEBUG_BUCKETS, DanmakuDebugBucket, DanmakuLayoutConfig, DanmakuPreparedStats,
@@ -223,12 +223,14 @@ pub struct PresenterRuntime {
     video_frames: Receiver<PlayerVideoFrame>,
     audio_frames: Receiver<PlayerAudioFrame>,
     subtitle_frames: Receiver<PlayerSubtitleFrame>,
+    player_events: Receiver<crate::core::PlayerEvent>,
     audio_output: Box<dyn AudioOutputBackend>,
     audio_configured: bool,
     audio_started: bool,
     last_audio_clock_report: Option<AudioClockReportState>,
     last_audio_runtime_stats: AudioOutputRuntimeStats,
     playback_rate: f64,
+    latest_video_decoder: Option<VideoDecoderEvent>,
     current_overlay: Option<OverlayFrame>,
     debug_hud: DebugHud,
     current_danmaku: Option<DanmakuRenderPlan>,
@@ -506,6 +508,7 @@ impl PresenterRuntime {
         let video_frames = player.subscribe_video_frames();
         let audio_frames = player.subscribe_audio_frames();
         let subtitle_frames = player.subscribe_subtitle_frames();
+        let player_events = player.subscribe();
         let mut danmaku_session = config
             .danmaku
             .map(DanmakuSession::from_timeline)
@@ -521,12 +524,14 @@ impl PresenterRuntime {
             video_frames,
             audio_frames,
             subtitle_frames,
+            player_events,
             audio_output: build_audio_output(config.audio),
             audio_configured: false,
             audio_started: false,
             last_audio_clock_report: None,
             last_audio_runtime_stats: AudioOutputRuntimeStats::default(),
             playback_rate: 1.0,
+            latest_video_decoder: None,
             current_overlay: None,
             debug_hud: DebugHud::new(),
             current_danmaku: None,
@@ -597,6 +602,7 @@ impl PresenterRuntime {
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
         self.drain_pending_player_frames();
         self.current_generation = self.current_generation.saturating_add(1).max(1);
+        self.latest_video_decoder = None;
         let result = self.player.open(media);
         // Player::open joins the previous producer before returning, so this
         // second drain deterministically removes anything it emitted between
@@ -654,6 +660,7 @@ impl PresenterRuntime {
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
         self.drain_pending_player_frames();
+        self.latest_video_decoder = None;
         let result = self.player.close();
         // Shutdown is joined at this point; no producer can refill a receiver.
         self.drain_pending_player_frames();
@@ -858,6 +865,7 @@ impl PresenterRuntime {
     pub fn render_tick(&mut self, time_seconds: f64) -> Result<PresenterStats> {
         let tick_started = Instant::now();
         let pump_started = Instant::now();
+        self.refresh_video_decoder_status();
 
         let subtitle_started = Instant::now();
         self.pump_subtitles();
@@ -1035,6 +1043,7 @@ impl PresenterRuntime {
         let output = self.renderer.output_status();
         let audio_runtime = self.audio_output.runtime_stats();
         let surface = self.current_surface_metrics;
+        let decoder = self.latest_video_decoder.as_ref();
         DebugHudSnapshot {
             codec: selected.as_ref().and_then(|track| track.codec.clone()),
             width: selected.as_ref().map_or(0, |track| track.width),
@@ -1048,6 +1057,18 @@ impl PresenterRuntime {
                 .as_ref()
                 .and_then(|track| track.pixel_format.clone()),
             profile: selected.as_ref().and_then(|track| track.profile.clone()),
+            decoder_requested_backend: decoder
+                .map(|event| event.requested_backend.as_str().to_string()),
+            decoder_previous_backend: decoder
+                .and_then(|event| event.previous_backend)
+                .map(|backend| backend.as_str().to_string()),
+            decoder_active_backend: decoder.map(|event| event.active_backend.as_str().to_string()),
+            decoder_codec: decoder.and_then(|event| event.codec.clone()),
+            decoder_pixel_format: decoder.and_then(|event| event.pixel_format.clone()),
+            decoder_line_sizes: decoder.and_then(|event| event.line_sizes),
+            decoder_fallback_count: decoder.map_or(0, |event| event.fallback_count),
+            decoder_stage: decoder.map(|event| event.stage.clone()),
+            decoder_reason: decoder.and_then(|event| event.reason.clone()),
             player_state: format!("{:?}", self.player.state()).to_lowercase(),
             media_time: self.current_media_time,
             duration: self.player.duration(),
@@ -1085,6 +1106,14 @@ impl PresenterRuntime {
                 .current_danmaku
                 .as_ref()
                 .map_or(0, |plan| plan.items.len()),
+        }
+    }
+
+    fn refresh_video_decoder_status(&mut self) {
+        while let Ok(event) = self.player_events.try_recv() {
+            if let crate::core::PlayerEvent::VideoDecoderChanged(event) = event {
+                self.latest_video_decoder = Some(event);
+            }
         }
     }
 

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -908,43 +908,51 @@ impl PresenterRuntime {
             plan_items,
         );
 
-        let hud_snapshot = self.debug_hud_snapshot();
-        let hud_viewport = self
-            .current_overlay
-            .as_ref()
-            .map(|overlay| overlay.viewport)
-            .or_else(|| {
-                self.current_surface_metrics.map(|metrics| {
-                    OverlayViewport::new(
-                        metrics.physical_extent.width,
-                        metrics.physical_extent.height,
+        let hud_overlay = if self.debug_hud.enabled() {
+            let hud_snapshot = self.debug_hud_snapshot();
+            let hud_viewport = self
+                .current_overlay
+                .as_ref()
+                .map(|overlay| overlay.viewport)
+                .or_else(|| {
+                    self.current_surface_metrics.map(|metrics| {
+                        OverlayViewport::new(
+                            metrics.physical_extent.width,
+                            metrics.physical_extent.height,
+                        )
+                    })
+                });
+            let hud_plane = hud_viewport.and_then(|viewport| {
+                self.debug_hud
+                    .update(
+                        Instant::now(),
+                        viewport.width,
+                        viewport.height,
+                        hud_snapshot,
                     )
-                })
+                    .cloned()
             });
-        let hud_plane = hud_viewport.and_then(|viewport| {
-            self.debug_hud
-                .update(
-                    Instant::now(),
-                    viewport.width,
-                    viewport.height,
-                    hud_snapshot,
-                )
-                .cloned()
-        });
-        let mut render_overlay = self.current_overlay.clone();
-        if let Some(plane) = hud_plane {
-            let viewport = hud_viewport.expect("HUD requires a viewport");
-            let overlay = render_overlay.get_or_insert_with(|| OverlayFrame {
-                pts: self.current_media_time,
-                viewport,
-                subtitle_planes: Vec::new(),
-                subtitle_alpha_planes: Vec::new(),
-                subtitle_changed: false,
-            });
-            overlay.subtitle_planes.push(plane);
-        }
+            hud_plane.map(|plane| {
+                let viewport = hud_viewport.expect("HUD requires a viewport");
+                let mut overlay = self
+                    .current_overlay
+                    .clone()
+                    .unwrap_or_else(|| OverlayFrame {
+                        pts: self.current_media_time,
+                        viewport,
+                        subtitle_planes: Vec::new(),
+                        subtitle_alpha_planes: Vec::new(),
+                        subtitle_changed: false,
+                    });
+                overlay.subtitle_planes.push(plane);
+                overlay
+            })
+        } else {
+            None
+        };
+        let render_overlay = hud_overlay.as_ref().or(self.current_overlay.as_ref());
         let context = RenderFrameContext::new(self.current_media_time, self.current_generation)
-            .overlay(render_overlay.as_ref())
+            .overlay(render_overlay)
             .danmaku(self.current_danmaku.as_ref())
             .output_size(
                 self.current_surface_metrics
@@ -1026,18 +1034,14 @@ impl PresenterRuntime {
     }
 
     fn debug_hud_snapshot(&self) -> DebugHudSnapshot {
-        let selected = self.player.track_selection().video.and_then(|selected| {
-            self.player
-                .tracks()
-                .into_iter()
-                .find(|track| track.id == selected)
-        });
-        let selected_audio = self.player.track_selection().audio.and_then(|selected| {
-            self.player
-                .tracks()
-                .into_iter()
-                .find(|track| track.id == selected)
-        });
+        let selection = self.player.track_selection();
+        let tracks = self.player.tracks();
+        let selected = selection
+            .video
+            .and_then(|selected| tracks.iter().find(|track| track.id == selected));
+        let selected_audio = selection
+            .audio
+            .and_then(|selected| tracks.iter().find(|track| track.id == selected));
         let renderer = self.renderer.runtime_stats();
         let clock = self.audio_output.clock_snapshot();
         let output = self.renderer.output_status();

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -270,6 +270,9 @@ typedef struct ErikaTrackInfo {
   char *sample_format;
   char *profile;
   int32_t level;
+  uint64_t bit_rate;
+  uint32_t frame_rate_numerator;
+  uint32_t frame_rate_denominator;
 } ErikaTrackInfo;
 
 typedef struct ErikaEvent {
@@ -502,6 +505,9 @@ ErikaStatus erika_presenter_danmaku_tracks(
     uintptr_t *out_len);
 ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *handle);
 ErikaStatus erika_presenter_set_danmaku_enabled(
+    ErikaPresenterHandle *handle,
+    bool enabled);
+ErikaStatus erika_presenter_set_debug_hud_enabled(
     ErikaPresenterHandle *handle,
     bool enabled);
 ErikaStatus erika_presenter_set_danmaku_config(

--- a/crates/erika_capi/src/android_jni.rs
+++ b/crates/erika_capi/src/android_jni.rs
@@ -780,6 +780,11 @@ unsafe fn invoke_presenter(
             Ok(output_status_to_json(status_value))
         }
         "getPresenterStats" => Ok(stats_to_json(presenter.latest_stats)),
+        "setDebugHudEnabled" => {
+            let enabled =
+                optional_bool(args, "enabled").ok_or_else(|| "enabled is required".to_string())?;
+            status_value(unsafe { erika_presenter_set_debug_hud_enabled(handle, enabled) })
+        }
         "addExternalSubtitle" => {
             let uri = required_string(args, "uri")?;
             let uri_c = c_string(uri, "uri")?;
@@ -975,6 +980,9 @@ unsafe fn presenter_tracks_json(handle: *mut ErikaPresenterHandle) -> Result<Val
                 "sampleFormat": unsafe { borrowed_c_string(track.sample_format) },
                 "profile": unsafe { borrowed_c_string(track.profile) },
                 "level": track.level,
+                "bitRate": track.bit_rate,
+                "frameRateNumerator": track.frame_rate_numerator,
+                "frameRateDenominator": track.frame_rate_denominator,
             });
             unsafe { erika_track_info_free(track) };
             value

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -248,6 +248,9 @@ pub struct ErikaTrackInfo {
     pub sample_format: *mut c_char,
     pub profile: *mut c_char,
     pub level: i32,
+    pub bit_rate: u64,
+    pub frame_rate_numerator: u32,
+    pub frame_rate_denominator: u32,
 }
 
 impl Default for ErikaTrackInfo {
@@ -269,6 +272,9 @@ impl Default for ErikaTrackInfo {
             sample_format: std::ptr::null_mut(),
             profile: std::ptr::null_mut(),
             level: 0,
+            bit_rate: 0,
+            frame_rate_numerator: 0,
+            frame_rate_denominator: 0,
         }
     }
 }
@@ -2097,6 +2103,23 @@ pub unsafe extern "C" fn erika_presenter_set_danmaku_enabled(
     target_os = "android"
 ))]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_debug_hud_enabled(
+    handle: *mut ErikaPresenterHandle,
+    enabled: bool,
+) -> ErikaStatus {
+    with_presenter_mut(handle, |handle| {
+        handle.presenter.set_debug_hud_enabled(enabled);
+        ErikaStatus::Ok
+    })
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "windows",
+    target_os = "android"
+))]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_set_danmaku_config(
     handle: *mut ErikaPresenterHandle,
     config: ErikaDanmakuConfig,
@@ -3226,6 +3249,17 @@ fn track_info_to_c(track: &TrackInfo) -> ErikaTrackInfo {
         sample_format: option_string_to_c(track.sample_format.as_deref()),
         profile: option_string_to_c(track.profile.as_deref()),
         level: track.level.unwrap_or(0),
+        bit_rate: track.bit_rate.unwrap_or(0),
+        frame_rate_numerator: track
+            .frame_rate
+            .as_ref()
+            .map(|rate| rate.numerator)
+            .unwrap_or(0),
+        frame_rate_denominator: track
+            .frame_rate
+            .as_ref()
+            .map(|rate| rate.denominator)
+            .unwrap_or(0),
     }
 }
 
@@ -3577,6 +3611,8 @@ mod tests {
         track.title = Some("Signs".to_string());
         track.language = Some("jpn".to_string());
         track.codec = Some("ass".to_string());
+        track.bit_rate = Some(8_000_000);
+        track.frame_rate = erika::FrameRate::new(30_000, 1_001);
 
         let mut c_track = track_info_to_c(&track);
 
@@ -3597,6 +3633,9 @@ mod tests {
             unsafe { CStr::from_ptr(c_track.codec).to_str().unwrap() },
             "ass"
         );
+        assert_eq!(c_track.bit_rate, 8_000_000);
+        assert_eq!(c_track.frame_rate_numerator, 30_000);
+        assert_eq!(c_track.frame_rate_denominator, 1_001);
 
         unsafe { erika_track_info_free(&mut c_track) };
         assert!(c_track.title.is_null());
@@ -3945,6 +3984,34 @@ mod tests {
             unsafe { erika_presenter_set_volume(handle, f64::NAN) },
             ErikaStatus::Ok
         );
+        unsafe { erika_presenter_destroy(handle) };
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "windows",
+        target_os = "android"
+    ))]
+    #[test]
+    fn c_presenter_toggles_debug_hud() {
+        assert_eq!(
+            unsafe { erika_presenter_set_debug_hud_enabled(std::ptr::null_mut(), true) },
+            ErikaStatus::NullPointer
+        );
+
+        let handle = erika_presenter_create();
+        assert!(!handle.is_null());
+        assert_eq!(
+            unsafe { erika_presenter_set_debug_hud_enabled(handle, true) },
+            ErikaStatus::Ok
+        );
+        assert!(unsafe { &*handle }.presenter.debug_hud_enabled());
+        assert_eq!(
+            unsafe { erika_presenter_set_debug_hud_enabled(handle, false) },
+            ErikaStatus::Ok
+        );
+        assert!(!unsafe { &*handle }.presenter.debug_hud_enabled());
         unsafe { erika_presenter_destroy(handle) };
     }
 

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -306,8 +306,11 @@ ErikaStatus erika_presenter_tracks(ErikaPresenterHandle *, ErikaTrackInfo *out_t
 `ErikaTrackInfo` の `codec`、`width`、`height`、`pixel_format`、`profile`、`level` は
 track metadata です。`bit_rate` の単位は bit/s、`frame_rate_numerator` /
 `frame_rate_denominator` は video track の有理 frame rate です。`0` は unknown を表します。
-これらは open または track change 時に probe される平均/nominal 値であり、瞬間 bitrate や
-real-time render FPS ではありません。
+frame rate は average frame rate、`r_frame_rate`、FFmpeg guessed frame rate の順に probe されます。
+bitrate は track 自身の parameter を優先し、単一 video track の bitrate がなく、container total と
+他の全 audio track bitrate が既知の場合のみ、container bitrate から audio bitrate を引いて推定します。
+どちらも瞬間 bitrate や real-time render FPS ではなく、推定 bitrate には container overhead や
+non-audio stream が含まれる場合があります。
 
 ### 弾幕（ダンマク）
 

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -303,6 +303,12 @@ ErikaStatus erika_presenter_tracks(ErikaPresenterHandle *, ErikaTrackInfo *out_t
 
 `ErikaHandle` のトラック関数と同じ意味論です。
 
+`ErikaTrackInfo` の `codec`、`width`、`height`、`pixel_format`、`profile`、`level` は
+track metadata です。`bit_rate` の単位は bit/s、`frame_rate_numerator` /
+`frame_rate_denominator` は video track の有理 frame rate です。`0` は unknown を表します。
+これらは open または track change 時に probe される平均/nominal 値であり、瞬間 bitrate や
+real-time render FPS ではありません。
+
 ### 弾幕（ダンマク）
 
 ```c
@@ -317,6 +323,7 @@ ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *, in
 ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
 ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *);
 ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *, bool enabled);
+ErikaStatus erika_presenter_set_debug_hud_enabled(ErikaPresenterHandle *, bool enabled);
 ErikaStatus erika_presenter_set_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig config);
 ErikaStatus erika_presenter_set_danmaku_config_ptr(ErikaPresenterHandle *, const ErikaDanmakuConfig *config);
 ErikaStatus erika_presenter_get_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig *out_config);
@@ -332,6 +339,13 @@ XML（`*_file`、パス/URL）または JSON（`*_json`、インライン）。`
 値渡しを避ける）、`get_danmaku_config` で読み戻します。レイアウトエンジンは
 [danmaku_architecture.md](danmaku_architecture.md) を参照。
 `set_danmaku_block_words_json` はフィルタ用の文字列 JSON 配列を取ります。
+
+`set_debug_hud_enabled` は default で off です。on にすると Presenter は native video
+composition に diagnostic HUD を描画します。HUD は track technical metadata、
+playback state、decoded/rendered FPS、decode/zero-copy counters、render/audio state、HDR
+output、danmaku item count を表示します。video frame がある時だけ表示され、host による
+stats polling は不要で、`ErikaPresenterStats` にも書き込みません。off-screen
+`capture_frame_rgba` は HUD を含みません。
 
 ### Surface とプレゼンテーション
 
@@ -473,7 +487,8 @@ free(rgba);
 - **`ErikaTrackCounts`** / **`ErikaTrackSelection`** —— 種別ごとの件数 / 選択 id
   （`-1` = 無し）。
 - **`ErikaTrackInfo`** —— トラックごとの全メタデータ。6 つの `char*` フィールドは
-  呼び出し側の所有（`erika_track_info_free` で解放）。
+  caller が所有（`erika_track_info_free` で解放）。video track はさらに `bit_rate`
+  （bit/s）と `frame_rate_numerator` / `frame_rate_denominator`（`0` = unknown）を持ちます。
 - **`ErikaEvent`** —— 構造体による tagged union：`kind` がどのフィールドが有効かを選ぶ
   （`state`、`duration_micros`、`position_micros`、`buffering`、`video`、`tracks`）。
   `Error` イベントは `status` がコードを運ぶ。

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -178,9 +178,13 @@ the subtitle track id `-1` disables subtitles.
 `ErikaTrackInfo` exposes track metadata through `codec`, `width`, `height`,
 `pixel_format`, `profile`, and `level`. `bit_rate` is in bit/s, while
 `frame_rate_numerator` / `frame_rate_denominator` retain a video track's rational
-frame rate; `0` means the corresponding value is unknown. These values are
-probed when media opens or tracks change and represent average or nominal
-metadata, not instantaneous bitrate or rendered FPS.
+frame rate; `0` means the corresponding value is unknown. Frame rate is probed
+in average-frame-rate, `r_frame_rate`, then FFmpeg-guessed-frame-rate order.
+Bitrate prefers the track's own parameters; only a single video track with no
+bitrate and known container total plus every other audio-track bitrate is
+estimated as container bitrate minus audio bitrates. Neither value is an
+instantaneous bitrate or rendered FPS; an estimated bitrate can include
+container overhead or non-audio streams.
 
 ### State and events
 

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -175,6 +175,13 @@ void        erika_track_info_free(ErikaTrackInfo *track);
 the currently selected video/audio/subtitle track ids (`-1` for none). Selecting
 the subtitle track id `-1` disables subtitles.
 
+`ErikaTrackInfo` exposes track metadata through `codec`, `width`, `height`,
+`pixel_format`, `profile`, and `level`. `bit_rate` is in bit/s, while
+`frame_rate_numerator` / `frame_rate_denominator` retain a video track's rational
+frame rate; `0` means the corresponding value is unknown. These values are
+probed when media opens or tracks change and represent average or nominal
+metadata, not instantaneous bitrate or rendered FPS.
+
 ### State and events
 
 ```c
@@ -332,6 +339,7 @@ ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *, in
 ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
 ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *);
 ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *, bool enabled);
+ErikaStatus erika_presenter_set_debug_hud_enabled(ErikaPresenterHandle *, bool enabled);
 ErikaStatus erika_presenter_set_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig config);
 ErikaStatus erika_presenter_set_danmaku_config_ptr(ErikaPresenterHandle *, const ErikaDanmakuConfig *config);
 ErikaStatus erika_presenter_get_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig *out_config);
@@ -347,6 +355,14 @@ tracks. `set_danmaku_config` / `_ptr` apply the full `ErikaDanmakuConfig` (the
 `_ptr` variant avoids passing the struct by value); `get_danmaku_config` reads
 it back. See [danmaku_architecture.md](danmaku_architecture.md) for the layout
 engine. `set_danmaku_block_words_json` takes a JSON array of strings to filter.
+
+`set_debug_hud_enabled` is off by default. When enabled, the Presenter draws a
+native diagnostic HUD in the video composition. It shows track
+technical metadata, playback state, decoded/rendered FPS, decode and zero-copy
+route counters, render/audio state, HDR output, and danmaku item count. The HUD
+only appears when a video frame exists, does not require host-side stats polling,
+and does not populate `ErikaPresenterStats`. Off-screen `capture_frame_rgba`
+captures exclude the HUD.
 
 ### Surface and presentation
 
@@ -492,7 +508,9 @@ free(rgba);
 - **`ErikaTrackCounts`** / **`ErikaTrackSelection`** — per-kind counts / selected
   ids (`-1` = none).
 - **`ErikaTrackInfo`** — full per-track metadata; the six `char*` fields are
-  owned by the caller (free via `erika_track_info_free`).
+  owned by the caller (free via `erika_track_info_free`). Video tracks additionally
+  expose `bit_rate` (bit/s) and `frame_rate_numerator` /
+  `frame_rate_denominator` (`0` = unknown).
 - **`ErikaEvent`** — a tagged union-by-struct: `kind` selects which fields are
   meaningful (`state`, `duration_micros`, `position_micros`, `buffering`,
   `video`, `tracks`); `status` carries the code for `Error` events.

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -161,8 +161,10 @@ void        erika_track_info_free(ErikaTrackInfo *track);
 
 `ErikaTrackInfo` 的 `codec`、`width`、`height`、`pixel_format`、`profile`、`level` 是轨道
 元数据。`bit_rate` 的单位为 bit/s，`frame_rate_numerator` / `frame_rate_denominator` 是视频
-轨的有理帧率；`0` 表示对应值未知。它们在 open 或轨道变化时探测，属于平均或标称值，
-不是播放中的瞬时码率或实时渲染 FPS。
+轨的有理帧率；`0` 表示对应值未知。帧率按平均帧率、`r_frame_rate`、FFmpeg 估算帧率的顺序
+探测。码率优先用轨自身参数；只在单视频轨缺少码率、容器总码率与所有其它音频轨码率均已知时，
+才以“容器总码率减去音频轨码率”估算。两者都不是播放中的瞬时码率或实时渲染 FPS，码率估算值
+还可能包含封装开销或其它非音频流。
 
 ### 状态与事件
 

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -159,6 +159,11 @@ void        erika_track_info_free(ErikaTrackInfo *track);
 `erika_tracks` 遵循计数数组惯用法。`erika_track_selection` 报告当前选中的
 视频/音频/字幕轨 id（`-1` 表示无）。选择字幕轨 id `-1` 即关闭字幕。
 
+`ErikaTrackInfo` 的 `codec`、`width`、`height`、`pixel_format`、`profile`、`level` 是轨道
+元数据。`bit_rate` 的单位为 bit/s，`frame_rate_numerator` / `frame_rate_denominator` 是视频
+轨的有理帧率；`0` 表示对应值未知。它们在 open 或轨道变化时探测，属于平均或标称值，
+不是播放中的瞬时码率或实时渲染 FPS。
+
 ### 状态与事件
 
 ```c
@@ -304,6 +309,7 @@ ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *, in
 ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
 ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *);
 ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *, bool enabled);
+ErikaStatus erika_presenter_set_debug_hud_enabled(ErikaPresenterHandle *, bool enabled);
 ErikaStatus erika_presenter_set_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig config);
 ErikaStatus erika_presenter_set_danmaku_config_ptr(ErikaPresenterHandle *, const ErikaDanmakuConfig *config);
 ErikaStatus erika_presenter_get_danmaku_config(ErikaPresenterHandle *, ErikaDanmakuConfig *out_config);
@@ -318,6 +324,11 @@ ErikaStatus erika_presenter_set_danmaku_block_words_json(ErikaPresenterHandle *,
 传结构体）；`get_danmaku_config` 读回。布局引擎见
 [danmaku_architecture.md](danmaku_architecture.md)。`set_danmaku_block_words_json`
 接受一个字符串 JSON 数组用于过滤。
+
+`set_debug_hud_enabled` 默认关闭。开启后 Presenter 在原生视频合成中绘制诊断 HUD，显示轨道
+技术信息、播放状态、实时解码/渲染 FPS、解码/零拷贝路径、渲染和音频状态、
+HDR 输出以及弹幕数量。HUD 只在已有视频帧时显示；其统计不要求调用方轮询，也不会写入
+`ErikaPresenterStats`。`capture_frame_rgba` 的离屏截图不包含 HUD。
 
 ### Surface 与呈现
 
@@ -453,7 +464,8 @@ free(rgba);
 - **`ErikaTrackCounts`** / **`ErikaTrackSelection`** —— 各类轨道计数 / 选中 id
   （`-1` = 无）。
 - **`ErikaTrackInfo`** —— 完整的每轨元数据；六个 `char*` 字段归调用方所有（用
-  `erika_track_info_free` 释放）。
+  `erika_track_info_free` 释放）。视频轨还包含 `bit_rate`（bit/s）和
+  `frame_rate_numerator` / `frame_rate_denominator`（`0` = unknown）。
 - **`ErikaEvent`** —— 用结构体表达的 tagged union：`kind` 决定哪些字段有意义
   （`state`、`duration_micros`、`position_micros`、`buffering`、`video`、`tracks`）；
   `Error` 事件由 `status` 携带状态码。

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -173,10 +173,14 @@ track には `codec`、`width`、`height`、`pixelFormat`、`profile`、`level`�
 `frameRateNumerator`、`frameRateDenominator` が含まれ、audio track にはさらに
 `sampleRate`、`channels`、`sampleFormat` が含まれます。
 
-- `bitRate` の単位は bit/s で、container/codec が提供する平均または nominal な track
-  metadata です。取得できない場合は `null` であり、瞬間 bitrate ではありません。
+- `bitRate` の単位は bit/s です。video track 自身の codec parameter を優先し、単一の
+  video track に bitrate がなく、container total と他の全 audio track bitrate が既知の場合のみ、
+  container bitrate から audio bitrate を引いて推定します。取得できない場合は `null` です。
+  瞬間 bitrate ではなく、推定値には container overhead や非 audio stream が含まれる場合があります。
 - `frameRateNumerator` / `frameRateDenominator` は `30000/1001` などの有理数を保持します。
-  `framesPerSecond` は Dart の convenience getter です。VFR media でも平均または宣言値です。
+  probe 順序は average frame rate、`r_frame_rate`、FFmpeg guessed frame rate です。
+  `framesPerSecond` は Dart の convenience getter であり、VFR media では平均、宣言、または
+  推定値です。
 - `TracksChanged` と `TrackSelectionChanged` event には完全な `trackList` が含まれます。
   event 後に `tracks()` を再度呼んで current snapshot を取得することもできます。
 

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -138,6 +138,13 @@ final status = await player.getUpscalerStatus();
 
 // Track management
 final tracks = await player.tracks();
+for (final track in tracks) {
+  if (track.kind == ErikaTrackKind.video && track.selected) {
+    print('${track.codec} ${track.width}x${track.height}');
+    print('${track.bitRate} bps / ${track.framesPerSecond} fps');
+    break;
+  }
+}
 await player.selectAudioTrack(trackId);
 await player.selectSubtitleTrack(trackId);
 await player.addExternalSubtitle('/path/to/subtitle.srt');
@@ -147,6 +154,10 @@ await player.loadDanmakuFile('/path/to/danmaku.xml');
 await player.addDanmakuTrackJson(jsonString, name: 'source', offset: Duration.zero);
 await player.setDanmakuConfig(fontSize: 30, displayArea: 0.5);
 
+// Native diagnostics HUD (disabled by default)
+await player.setDebugHudEnabled(true);
+final presenterStats = await player.getPresenterStats();
+
 // Events
 player.events.listen((event) {
   // event.kind, event.state, event.position, event.duration, ...
@@ -154,6 +165,32 @@ player.events.listen((event) {
 
 await player.dispose();
 ```
+
+## メディアトラック情報
+
+`tracks()` は embedded/external の各トラックについて `ErikaTrackInfo` を返します。video
+track には `codec`、`width`、`height`、`pixelFormat`、`profile`、`level`、`bitRate`、
+`frameRateNumerator`、`frameRateDenominator` が含まれ、audio track にはさらに
+`sampleRate`、`channels`、`sampleFormat` が含まれます。
+
+- `bitRate` の単位は bit/s で、container/codec が提供する平均または nominal な track
+  metadata です。取得できない場合は `null` であり、瞬間 bitrate ではありません。
+- `frameRateNumerator` / `frameRateDenominator` は `30000/1001` などの有理数を保持します。
+  `framesPerSecond` は Dart の convenience getter です。VFR media でも平均または宣言値です。
+- `TracksChanged` と `TrackSelectionChanged` event には完全な `trackList` が含まれます。
+  event 後に `tracks()` を再度呼んで current snapshot を取得することもできます。
+
+## ネイティブ Debug HUD
+
+`setDebugHudEnabled(true)` は native video composition に診断 HUD を描画します。Dart
+を通じて render せず、Flutter widget tree も変更しません。既定では off で、development、
+performance analysis、device 上の diagnosis 用です。
+
+HUD は codec/resolution/bitrate/frame rate、playback position/rate、decoded/rendered FPS、
+decode route、zero-copy/fallback counters、CPU/GPU render time、audio queue/underflow、HDR
+output negotiation、danmaku item count を表示します。FPS は隣接 sample window の差分であり、
+その他の frame/failure counter は presenter lifetime 中の累積値です。HUD は
+`screenshot()` の off-screen capture には含まれません。
 
 ## Neural Upscaler Status
 

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -167,6 +167,13 @@ final status = await player.getUpscalerStatus();
 
 // Track management
 final tracks = await player.tracks();
+for (final track in tracks) {
+  if (track.kind == ErikaTrackKind.video && track.selected) {
+    print('${track.codec} ${track.width}x${track.height}');
+    print('${track.bitRate} bps / ${track.framesPerSecond} fps');
+    break;
+  }
+}
 await player.selectAudioTrack(trackId);
 await player.selectSubtitleTrack(trackId);
 await player.addExternalSubtitle('/path/to/subtitle.srt');
@@ -176,6 +183,10 @@ await player.loadDanmakuFile('/path/to/danmaku.xml');
 await player.addDanmakuTrackJson(jsonString, name: 'source', offset: Duration.zero);
 await player.setDanmakuConfig(fontSize: 30, displayArea: 0.5);
 
+// Native diagnostics HUD (disabled by default)
+await player.setDebugHudEnabled(true);
+final presenterStats = await player.getPresenterStats();
+
 // Events
 player.events.listen((event) {
   // event.kind, event.state, event.position, event.duration, ...
@@ -183,6 +194,49 @@ player.events.listen((event) {
 
 await player.dispose();
 ```
+
+## Media Track Information
+
+`tracks()` returns an `ErikaTrackInfo` for every embedded or external track. A video track
+provides `codec`, `width`, `height`, `pixelFormat`, `profile`, `level`, `bitRate`,
+`frameRateNumerator`, and `frameRateDenominator`; audio tracks additionally provide
+`sampleRate`, `channels`, and `sampleFormat`.
+
+- `bitRate` is in bit/s and comes from the container/codec's average or nominal track metadata.
+  It is `null` when unavailable and is not an instantaneous runtime bitrate.
+- `frameRateNumerator` / `frameRateDenominator` retain the rational value, preventing values
+  such as `30000/1001` from being truncated. `framesPerSecond` is a Dart convenience getter;
+  for variable-frame-rate media it remains an average or declared value.
+- `TracksChanged` and `TrackSelectionChanged` events include the complete `trackList`. Hosts may
+  also call `tracks()` again after either event to obtain a current snapshot.
+
+```dart
+player.events.listen((event) {
+  if (event.kind == ErikaEventKind.tracksChanged) {
+    for (final track in event.trackList) {
+      if (track.kind == ErikaTrackKind.video && track.selected) {
+        print(track.toMap());
+        break;
+      }
+    }
+  }
+});
+```
+
+## Native Debug HUD
+
+`setDebugHudEnabled(true)` makes Erika draw a diagnostic HUD in the native video composition. It
+does not render through Dart or alter the Flutter widget hierarchy. It is off by
+default and intended for development, performance analysis, and on-device diagnosis.
+
+The low-frequency HUD snapshot includes track codec/resolution/bitrate/frame rate, playback
+position and rate, decoded and rendered FPS, hardware/software decode route, zero-copy/fallback
+counters, CPU/GPU render times, audio queue and underflow, HDR output negotiation, and danmaku
+item count. FPS is derived from adjacent sampling windows; frame and failure counters are
+cumulative for the presenter lifetime. The HUD is excluded from `screenshot()` off-screen captures.
+
+For a custom UI, use `getPresenterStats()` to retrieve the latest native display-tick snapshot. It
+does not drive the HUD, and its freshness depends on an attached surface and active display loop.
 
 ## Neural Upscaler Status
 

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -202,11 +202,15 @@ provides `codec`, `width`, `height`, `pixelFormat`, `profile`, `level`, `bitRate
 `frameRateNumerator`, and `frameRateDenominator`; audio tracks additionally provide
 `sampleRate`, `channels`, and `sampleFormat`.
 
-- `bitRate` is in bit/s and comes from the container/codec's average or nominal track metadata.
-  It is `null` when unavailable and is not an instantaneous runtime bitrate.
+- `bitRate` is in bit/s. Erika prefers the video track's own codec parameters; only when there is
+  one video track with no bitrate and the container total plus every other audio-track bitrate are
+  known does it estimate video bitrate as container bitrate minus audio bitrates. It is `null` when
+  unavailable, is not an instantaneous runtime bitrate, and an estimate can include container
+  overhead or non-audio streams.
 - `frameRateNumerator` / `frameRateDenominator` retain the rational value, preventing values
-  such as `30000/1001` from being truncated. `framesPerSecond` is a Dart convenience getter;
-  for variable-frame-rate media it remains an average or declared value.
+  such as `30000/1001` from being truncated. The probe order is average frame rate,
+  `r_frame_rate`, then FFmpeg's guessed frame rate. `framesPerSecond` is a Dart convenience
+  getter; for variable-frame-rate media it remains an average, declared, or guessed value.
 - `TracksChanged` and `TrackSelectionChanged` events include the complete `trackList`. Hosts may
   also call `tracks()` again after either event to obtain a current snapshot.
 

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -169,10 +169,12 @@ await player.dispose();
 `frameRateDenominator` 可用于媒体详情页；音频轨道还包含 `sampleRate`、`channels` 和
 `sampleFormat`。
 
-- `bitRate` 单位为 bit/s；它来自容器/编码参数的平均或标称轨道码率。未知时为 `null`，不是
-  实时瞬时码率。
+- `bitRate` 单位为 bit/s。优先使用视频轨自身的编码参数；仅在单视频轨缺少该值、容器总码率
+  和所有其它音频轨码率均已知时，才以“容器总码率减去音频轨码率”估算。未知时为 `null`；它不是
+  实时瞬时码率，估算值也可能包含封装开销或其它非音频流的影响。
 - `frameRateNumerator` / `frameRateDenominator` 保留原始有理数，避免把 `30000/1001` 截断。
-  `framesPerSecond` 是 Dart 的便利 getter；对可变帧率内容它仍是平均或声明值，而非每帧更新值。
+  探测顺序为平均帧率、`r_frame_rate` 和 FFmpeg 的估算帧率；`framesPerSecond` 是 Dart 的便利
+  getter。对可变帧率内容它仍是平均、声明或估算值，而非每帧更新值。
 - `TracksChanged` 和 `TrackSelectionChanged` 事件的 `trackList` 会附带完整轨道列表。也可以在
   收到事件后再次调用 `tracks()` 获取当前快照。
 

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -134,6 +134,13 @@ final status = await player.getUpscalerStatus();
 
 // Track management
 final tracks = await player.tracks();
+for (final track in tracks) {
+  if (track.kind == ErikaTrackKind.video && track.selected) {
+    print('${track.codec} ${track.width}x${track.height}');
+    print('${track.bitRate} bps / ${track.framesPerSecond} fps');
+    break;
+  }
+}
 await player.selectAudioTrack(trackId);
 await player.selectSubtitleTrack(trackId);
 await player.addExternalSubtitle('/path/to/subtitle.srt');
@@ -143,6 +150,10 @@ await player.loadDanmakuFile('/path/to/danmaku.xml');
 await player.addDanmakuTrackJson(jsonString, name: 'source', offset: Duration.zero);
 await player.setDanmakuConfig(fontSize: 30, displayArea: 0.5);
 
+// Native diagnostics HUD (disabled by default)
+await player.setDebugHudEnabled(true);
+final presenterStats = await player.getPresenterStats();
+
 // Events
 player.events.listen((event) {
   // event.kind, event.state, event.position, event.duration, ...
@@ -150,6 +161,46 @@ player.events.listen((event) {
 
 await player.dispose();
 ```
+
+## 媒体轨道信息
+
+`tracks()` 返回每条嵌入或外挂轨道的 `ErikaTrackInfo`。视频轨道的 `codec`、`width`、
+`height`、`pixelFormat`、`profile`、`level`、`bitRate`、`frameRateNumerator` 和
+`frameRateDenominator` 可用于媒体详情页；音频轨道还包含 `sampleRate`、`channels` 和
+`sampleFormat`。
+
+- `bitRate` 单位为 bit/s；它来自容器/编码参数的平均或标称轨道码率。未知时为 `null`，不是
+  实时瞬时码率。
+- `frameRateNumerator` / `frameRateDenominator` 保留原始有理数，避免把 `30000/1001` 截断。
+  `framesPerSecond` 是 Dart 的便利 getter；对可变帧率内容它仍是平均或声明值，而非每帧更新值。
+- `TracksChanged` 和 `TrackSelectionChanged` 事件的 `trackList` 会附带完整轨道列表。也可以在
+  收到事件后再次调用 `tracks()` 获取当前快照。
+
+```dart
+player.events.listen((event) {
+  if (event.kind == ErikaEventKind.tracksChanged) {
+    for (final track in event.trackList) {
+      if (track.kind == ErikaTrackKind.video && track.selected) {
+        print(track.toMap());
+        break;
+      }
+    }
+  }
+});
+```
+
+## 原生调试 HUD
+
+`setDebugHudEnabled(true)` 让 Erika 在原生视频合成中绘制诊断 HUD；它不经过 Dart 渲染，
+也不会改变 Flutter widget 层级。默认关闭，适合开发、性能分析和问题截图前的现场观察。
+
+HUD 以低频快照显示轨道编码/分辨率/码率/帧率、播放位置与倍速、实时解码与渲染 FPS、硬件或
+软件解码路径、零拷贝/回退计数、CPU/GPU 渲染耗时、音频队列与 underflow、HDR 输出协商和
+弹幕数量。实时 FPS 是相邻统计采样窗口的增量；其它帧数和失败数为 presenter 生命周期内的
+累计计数。HUD 不包含在 `screenshot()` 返回的离屏截图中。
+
+如需自行设计 UI，使用 `getPresenterStats()` 获取最近一次原生显示 tick 的统计快照；它不是
+HUD 的驱动机制，数据新鲜度取决于已挂载 surface 的显示循环。
 
 ## Neural Upscaler Status
 

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
@@ -1723,6 +1723,7 @@ class ErikaFlutterPlugin :
             "getUpscalerStatus",
             "getOutputStatus",
             "getPresenterStats",
+            "setDebugHudEnabled",
             "addExternalSubtitle",
             "removeSubtitleTrack",
             "loadDanmakuFile",

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
@@ -1705,6 +1705,7 @@ class ErikaFlutterPlugin :
             "clearDanmaku",
             "setDanmakuEnabled",
             "setDanmakuConfig",
+            "setDebugHudEnabled",
             "selectAudioTrack",
             "selectSubtitleTrack",
         )

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -405,6 +405,8 @@ private final class ErikaNativeLibrary {
   typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
   typealias CaptureFrameRgbaFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, UnsafeMutableRawPointer?, Int) -> Int32
   typealias PollEventFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias LastErrorMessageFn = @convention(c) () -> UnsafeMutablePointer<CChar>?
+  typealias StringFreeFn = @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
 
   static let shared = try? ErikaNativeLibrary()
 
@@ -454,6 +456,8 @@ private final class ErikaNativeLibrary {
   let renderTick: RenderTickFn
   let captureFrameRgba: CaptureFrameRgbaFn?
   let pollEvent: PollEventFn
+  let lastErrorMessage: LastErrorMessageFn
+  let stringFree: StringFreeFn
 
   private let libraryHandle: UnsafeMutableRawPointer
   let path: String
@@ -513,6 +517,8 @@ private final class ErikaNativeLibrary {
     renderTick = try Self.load("erika_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
     captureFrameRgba = Self.loadOptional("erika_presenter_capture_frame_rgba", from: libraryHandle, as: CaptureFrameRgbaFn.self)
     pollEvent = try Self.load("erika_presenter_poll_event", from: libraryHandle, as: PollEventFn.self)
+    lastErrorMessage = try Self.load("erika_last_error_message", from: libraryHandle, as: LastErrorMessageFn.self)
+    stringFree = try Self.load("erika_string_free", from: libraryHandle, as: StringFreeFn.self)
   }
 
   private static func openLibrary() throws -> (handle: UnsafeMutableRawPointer, path: String) {
@@ -575,6 +581,14 @@ private final class ErikaNativeLibrary {
       return createWithOutputMode(config.outputMode, config.edrHeadroom)
     }
     return create()
+  }
+
+  func currentEventMessage() -> String? {
+    guard let pointer = lastErrorMessage() else {
+      return nil
+    }
+    defer { stringFree(pointer) }
+    return String(validatingUTF8: pointer)
   }
 }
 
@@ -1020,7 +1034,10 @@ private final class ErikaPlayerHost {
             "video params player=\(id) width=\(event.video.width) height=\(event.video.height) primaries=\(event.video.primaries) transfer=\(event.video.transfer)"
           )
         }
-        sendEvent(event.toFlutterMap(playerId: id, host: self))
+        let message = event.kind == 9 || event.kind == 11 || event.kind == 12
+          ? library.currentEventMessage()
+          : nil
+        sendEvent(event.toFlutterMap(playerId: id, host: self, structuredMessage: message))
         continue
       }
       if status != 5 {
@@ -2106,7 +2123,11 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
 }
 
 private extension ErikaEventC {
-  func toFlutterMap(playerId: Int64, host: ErikaPlayerHost? = nil) -> [String: Any] {
+  func toFlutterMap(
+    playerId: Int64,
+    host: ErikaPlayerHost? = nil,
+    structuredMessage: String? = nil
+  ) -> [String: Any] {
     var map: [String: Any] = [
       "playerId": playerId,
       "kind": Int(kind),
@@ -2134,6 +2155,17 @@ private extension ErikaEventC {
         "audio": -1,
         "subtitle": -1,
       ]
+    }
+    if let structuredMessage,
+       let data = structuredMessage.data(using: .utf8),
+       let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      if kind == 11 {
+        map["decoder"] = payload
+      } else if kind == 12 {
+        map["audio"] = payload
+      } else if kind == 9 {
+        map["error"] = structuredMessage
+      }
     }
     return map
   }

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -175,6 +175,9 @@ private struct ErikaTrackInfoC {
   var sampleFormat: UnsafeMutablePointer<CChar>?
   var profile: UnsafeMutablePointer<CChar>?
   var level: Int32 = 0
+  var bitRate: UInt64 = 0
+  var frameRateNumerator: UInt32 = 0
+  var frameRateDenominator: UInt32 = 0
 }
 
 private struct ErikaPresenterConfigC {
@@ -375,6 +378,7 @@ private final class ErikaNativeLibrary {
   ) -> Int32
   typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
+  typealias SetDebugHudEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
   typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
   typealias GetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuFontFn = @convention(c) (
@@ -435,6 +439,7 @@ private final class ErikaNativeLibrary {
   let danmakuTracks: TracksFn?
   let clearDanmaku: ClearDanmakuFn?
   let setDanmakuEnabled: SetDanmakuEnabledFn?
+  let setDebugHudEnabled: SetDebugHudEnabledFn?
   let setDanmakuConfig: SetDanmakuConfigFn?
   let getDanmakuConfig: GetDanmakuConfigFn?
   let setDanmakuFont: SetDanmakuFontFn?
@@ -493,6 +498,7 @@ private final class ErikaNativeLibrary {
     danmakuTracks = Self.loadOptional("erika_presenter_danmaku_tracks", from: libraryHandle, as: TracksFn.self)
     clearDanmaku = Self.loadOptional("erika_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
     setDanmakuEnabled = Self.loadOptional("erika_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
+    setDebugHudEnabled = Self.loadOptional("erika_presenter_set_debug_hud_enabled", from: libraryHandle, as: SetDebugHudEnabledFn.self)
     setDanmakuConfig = Self.loadOptional("erika_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
     getDanmakuConfig = Self.loadOptional("erika_presenter_get_danmaku_config", from: libraryHandle, as: GetDanmakuConfigFn.self)
     setDanmakuFont = Self.loadOptional("erika_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
@@ -825,6 +831,13 @@ private final class ErikaPlayerHost {
     }
     try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
     currentDanmakuConfig.enabled = enabled ? 1 : 0
+  }
+
+  func setDebugHudEnabled(_ enabled: Bool) throws {
+    guard let setEnabled = library.setDebugHudEnabled else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_debug_hud_enabled")
+    }
+    try check(setEnabled(handle, enabled), operation: "set_debug_hud_enabled")
   }
 
   func danmakuConfigSnapshot() -> ErikaDanmakuConfigC {
@@ -1491,6 +1504,10 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "getPresenterStats":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).presenterStats())
+      case "setDebugHudEnabled":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDebugHudEnabled(boolValue(args["enabled"]) ?? false)
+        result(nil)
       case "addExternalSubtitle":
         let args = try dictionaryArgs(call.arguments)
         guard let uri = args["uri"] as? String, !uri.isEmpty else {
@@ -2221,6 +2238,9 @@ private extension ErikaTrackInfoC {
       "sampleFormat": sampleFormat.map { String(cString: $0) } as Any,
       "profile": profile.map { String(cString: $0) } as Any,
       "level": Int(level),
+      "bitRate": Int64(clamping: bitRate),
+      "frameRateNumerator": Int(frameRateNumerator),
+      "frameRateDenominator": Int(frameRateDenominator),
     ]
   }
 }

--- a/packages/erika_flutter/lib/src/erika_event.dart
+++ b/packages/erika_flutter/lib/src/erika_event.dart
@@ -244,6 +244,9 @@ class ErikaTrackInfo {
     this.sampleFormat,
     this.profile,
     this.level = 0,
+    this.bitRate,
+    this.frameRateNumerator = 0,
+    this.frameRateDenominator = 0,
   });
 
   factory ErikaTrackInfo.fromMap(Map<dynamic, dynamic> map) {
@@ -264,6 +267,9 @@ class ErikaTrackInfo {
       sampleFormat: map['sampleFormat'] as String?,
       profile: map['profile'] as String?,
       level: _asInt(map['level']),
+      bitRate: _asPositiveInt(map['bitRate']),
+      frameRateNumerator: _asInt(map['frameRateNumerator']),
+      frameRateDenominator: _asInt(map['frameRateDenominator']),
     );
   }
 
@@ -283,6 +289,16 @@ class ErikaTrackInfo {
   final String? sampleFormat;
   final String? profile;
   final int level;
+  final int? bitRate;
+  final int frameRateNumerator;
+  final int frameRateDenominator;
+
+  double? get framesPerSecond {
+    if (frameRateNumerator <= 0 || frameRateDenominator <= 0) {
+      return null;
+    }
+    return frameRateNumerator / frameRateDenominator;
+  }
 
   Map<String, Object?> toMap() {
     return <String, Object?>{
@@ -302,6 +318,9 @@ class ErikaTrackInfo {
       'sampleFormat': sampleFormat,
       'profile': profile,
       'level': level,
+      'bitRate': bitRate,
+      'frameRateNumerator': frameRateNumerator,
+      'frameRateDenominator': frameRateDenominator,
     };
   }
 
@@ -316,6 +335,11 @@ class ErikaTrackInfo {
       return value.toInt();
     }
     return 0;
+  }
+
+  static int? _asPositiveInt(Object? value) {
+    final parsed = _asInt(value);
+    return parsed > 0 ? parsed : null;
   }
 
   static ErikaTrackKind _trackKindFromIndex(int index) {

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -813,6 +813,14 @@ class ErikaPlayer {
     return ErikaPresenterStats.fromMap(stats);
   }
 
+  Future<void> setDebugHudEnabled(bool enabled) async {
+    final playerId = await ensureCreated();
+    await _channel.invokeMethod<void>('setDebugHudEnabled', <String, Object?>{
+      'playerId': playerId,
+      'enabled': enabled,
+    });
+  }
+
   Future<Uint8List?> screenshot({int? viewId, int? width, int? height}) async {
     final playerId = await ensureCreated();
     return _channel.invokeMethod<Uint8List>('screenshot', <String, Object?>{

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -276,6 +276,8 @@ private final class ErikaNativeLibrary {
   typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
   typealias CaptureFrameRgbaFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, UnsafeMutableRawPointer?, Int) -> Int32
   typealias PollEventFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias LastErrorMessageFn = @convention(c) () -> UnsafeMutablePointer<CChar>?
+  typealias StringFreeFn = @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
 
   static let shared = try? ErikaNativeLibrary()
 
@@ -325,6 +327,8 @@ private final class ErikaNativeLibrary {
   let renderTick: RenderTickFn
   let captureFrameRgba: CaptureFrameRgbaFn?
   let pollEvent: PollEventFn
+  let lastErrorMessage: LastErrorMessageFn
+  let stringFree: StringFreeFn
 
   private let libraryHandle: UnsafeMutableRawPointer
 
@@ -378,6 +382,8 @@ private final class ErikaNativeLibrary {
     renderTick = try Self.load("erika_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
     captureFrameRgba = Self.loadOptional("erika_presenter_capture_frame_rgba", from: libraryHandle, as: CaptureFrameRgbaFn.self)
     pollEvent = try Self.load("erika_presenter_poll_event", from: libraryHandle, as: PollEventFn.self)
+    lastErrorMessage = try Self.load("erika_last_error_message", from: libraryHandle, as: LastErrorMessageFn.self)
+    stringFree = try Self.load("erika_string_free", from: libraryHandle, as: StringFreeFn.self)
   }
 
   deinit {
@@ -453,6 +459,14 @@ private final class ErikaNativeLibrary {
       return createWithOutputMode(config.outputMode, config.edrHeadroom)
     }
     return create()
+  }
+
+  func currentEventMessage() -> String? {
+    guard let pointer = lastErrorMessage() else {
+      return nil
+    }
+    defer { stringFree(pointer) }
+    return String(validatingUTF8: pointer)
   }
 }
 
@@ -910,7 +924,10 @@ private final class ErikaPlayerHost {
         library.pollEvent(handle, UnsafeMutableRawPointer(pointer))
       }
       if status == 0 {
-        sendEvent(event.toFlutterMap(playerId: id, host: self))
+        let message = event.kind == 9 || event.kind == 11 || event.kind == 12
+          ? library.currentEventMessage()
+          : nil
+        sendEvent(event.toFlutterMap(playerId: id, host: self, structuredMessage: message))
         continue
       }
       if status != 5 {
@@ -988,7 +1005,11 @@ private final class ErikaPlayerHost {
 }
 
 private extension ErikaEventC {
-  func toFlutterMap(playerId: Int64, host: ErikaPlayerHost? = nil) -> [String: Any] {
+  func toFlutterMap(
+    playerId: Int64,
+    host: ErikaPlayerHost? = nil,
+    structuredMessage: String? = nil
+  ) -> [String: Any] {
     var map: [String: Any] = [
       "playerId": playerId,
       "kind": Int(kind),
@@ -1016,6 +1037,17 @@ private extension ErikaEventC {
         "audio": -1,
         "subtitle": -1,
       ]
+    }
+    if let structuredMessage,
+       let data = structuredMessage.data(using: .utf8),
+       let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+      if kind == 11 {
+        map["decoder"] = payload
+      } else if kind == 12 {
+        map["audio"] = payload
+      } else if kind == 9 {
+        map["error"] = structuredMessage
+      }
     }
     return map
   }

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -47,6 +47,9 @@ private struct ErikaTrackInfoC {
   var sampleFormat: UnsafeMutablePointer<CChar>?
   var profile: UnsafeMutablePointer<CChar>?
   var level: Int32 = 0
+  var bitRate: UInt64 = 0
+  var frameRateNumerator: UInt32 = 0
+  var frameRateDenominator: UInt32 = 0
 }
 
 private struct ErikaPresenterConfigC {
@@ -246,6 +249,7 @@ private final class ErikaNativeLibrary {
   ) -> Int32
   typealias ClearDanmakuFn = @convention(c) (UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
+  typealias SetDebugHudEnabledFn = @convention(c) (UnsafeMutableRawPointer?, Bool) -> Int32
   typealias SetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeRawPointer?) -> Int32
   typealias GetDanmakuConfigFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SetDanmakuFontFn = @convention(c) (
@@ -306,6 +310,7 @@ private final class ErikaNativeLibrary {
   let danmakuTracks: TracksFn?
   let clearDanmaku: ClearDanmakuFn?
   let setDanmakuEnabled: SetDanmakuEnabledFn?
+  let setDebugHudEnabled: SetDebugHudEnabledFn?
   let setDanmakuConfig: SetDanmakuConfigFn?
   let getDanmakuConfig: GetDanmakuConfigFn?
   let setDanmakuFont: SetDanmakuFontFn?
@@ -358,6 +363,7 @@ private final class ErikaNativeLibrary {
     danmakuTracks = Self.loadOptional("erika_presenter_danmaku_tracks", from: libraryHandle, as: TracksFn.self)
     clearDanmaku = Self.loadOptional("erika_presenter_clear_danmaku", from: libraryHandle, as: ClearDanmakuFn.self)
     setDanmakuEnabled = Self.loadOptional("erika_presenter_set_danmaku_enabled", from: libraryHandle, as: SetDanmakuEnabledFn.self)
+    setDebugHudEnabled = Self.loadOptional("erika_presenter_set_debug_hud_enabled", from: libraryHandle, as: SetDebugHudEnabledFn.self)
     setDanmakuConfig = Self.loadOptional("erika_presenter_set_danmaku_config_ptr", from: libraryHandle, as: SetDanmakuConfigFn.self)
     getDanmakuConfig = Self.loadOptional("erika_presenter_get_danmaku_config", from: libraryHandle, as: GetDanmakuConfigFn.self)
     setDanmakuFont = Self.loadOptional("erika_presenter_set_danmaku_font", from: libraryHandle, as: SetDanmakuFontFn.self)
@@ -711,6 +717,13 @@ private final class ErikaPlayerHost {
     }
     try check(setEnabled(handle, enabled), operation: "set_danmaku_enabled")
     currentDanmakuConfig.enabled = enabled ? 1 : 0
+  }
+
+  func setDebugHudEnabled(_ enabled: Bool) throws {
+    guard let setEnabled = library.setDebugHudEnabled else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_debug_hud_enabled")
+    }
+    try check(setEnabled(handle, enabled), operation: "set_debug_hud_enabled")
   }
 
   func danmakuConfigSnapshot() -> ErikaDanmakuConfigC {
@@ -1111,6 +1124,9 @@ private extension ErikaTrackInfoC {
       "sampleFormat": sampleFormat.map { String(cString: $0) } as Any,
       "profile": profile.map { String(cString: $0) } as Any,
       "level": Int(level),
+      "bitRate": Int64(clamping: bitRate),
+      "frameRateNumerator": Int(frameRateNumerator),
+      "frameRateDenominator": Int(frameRateDenominator),
     ]
   }
 }
@@ -1521,6 +1537,10 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "getPresenterStats":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).presenterStats())
+      case "setDebugHudEnabled":
+        let args = try dictionaryArgs(call.arguments)
+        try playerHost(from: args).setDebugHudEnabled(boolValue(args["enabled"]) ?? false)
+        result(nil)
       case "addExternalSubtitle":
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -402,6 +402,28 @@ void main() {
     await player.dispose();
   });
 
+  test('debug HUD toggle is forwarded to native presenter', () async {
+    final player = ErikaPlayer();
+
+    await player.setDebugHudEnabled(true);
+    await player.setDebugHudEnabled(false);
+
+    final calls = playerCalls
+        .where((MethodCall call) => call.method == 'setDebugHudEnabled')
+        .toList();
+    expect(calls, hasLength(2));
+    expect(calls.first.arguments, <String, Object?>{
+      'playerId': 7,
+      'enabled': true,
+    });
+    expect(calls.last.arguments, <String, Object?>{
+      'playerId': 7,
+      'enabled': false,
+    });
+
+    await player.dispose();
+  });
+
   test('window overlay methods forward surface geometry', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(playerChannel, (MethodCall call) async {
@@ -1114,6 +1136,11 @@ void main() {
               'title': 'Main video',
               'language': null,
               'codec': 'hevc',
+              'width': 3840,
+              'height': 2160,
+              'bitRate': 18000000,
+              'frameRateNumerator': 30000,
+              'frameRateDenominator': 1001,
             },
             <String, Object?>{
               'id': 1000001,
@@ -1138,10 +1165,19 @@ void main() {
     expect(tracks.first.kind, ErikaTrackKind.video);
     expect(tracks.first.source, ErikaTrackSource.embedded);
     expect(tracks.first.selected, isTrue);
+    expect(tracks.first.codec, 'hevc');
+    expect(tracks.first.width, 3840);
+    expect(tracks.first.height, 2160);
+    expect(tracks.first.bitRate, 18000000);
+    expect(tracks.first.frameRateNumerator, 30000);
+    expect(tracks.first.frameRateDenominator, 1001);
+    expect(tracks.first.framesPerSecond, closeTo(29.970, 0.001));
     expect(tracks.last.kind, ErikaTrackKind.subtitle);
     expect(tracks.last.source, ErikaTrackSource.external);
     expect(tracks.last.canRemove, isTrue);
     expect(tracks.last.title, 'subs.srt');
+    expect(tracks.last.bitRate, isNull);
+    expect(tracks.last.framesPerSecond, isNull);
 
     await player.dispose();
   });

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -664,6 +664,7 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
                       uintptr_t*);
   using ClearDanmakuFn = ErikaStatus (*)(ErikaPresenterHandle*);
   using SetDanmakuEnabledFn = ErikaStatus (*)(ErikaPresenterHandle*, bool);
+  using SetDebugHudEnabledFn = ErikaStatus (*)(ErikaPresenterHandle*, bool);
   using SetDanmakuConfigFn =
       ErikaStatus (*)(ErikaPresenterHandle*, const ErikaDanmakuConfig*);
   using GetDanmakuConfigFn =
@@ -765,6 +766,7 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   DanmakuTracksFn danmaku_tracks = nullptr;
   ClearDanmakuFn clear_danmaku = nullptr;
   SetDanmakuEnabledFn set_danmaku_enabled = nullptr;
+  SetDebugHudEnabledFn set_debug_hud_enabled = nullptr;
   SetDanmakuConfigFn set_danmaku_config = nullptr;
   GetDanmakuConfigFn get_danmaku_config = nullptr;
   SetDanmakuFontFn set_danmaku_font = nullptr;
@@ -841,6 +843,8 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         LoadOptional<ClearDanmakuFn>("erika_presenter_clear_danmaku");
     set_danmaku_enabled = LoadOptional<SetDanmakuEnabledFn>(
         "erika_presenter_set_danmaku_enabled");
+    set_debug_hud_enabled = LoadOptional<SetDebugHudEnabledFn>(
+        "erika_presenter_set_debug_hud_enabled");
     set_danmaku_config = LoadOptional<SetDanmakuConfigFn>(
         "erika_presenter_set_danmaku_config_ptr");
     get_danmaku_config = LoadOptional<GetDanmakuConfigFn>(
@@ -1331,6 +1335,15 @@ struct ErikaFlutterPlugin::PlayerHost {
     current_danmaku_config.enabled = enabled;
   }
 
+  void SetDebugHudEnabled(bool enabled) {
+    if (library->set_debug_hud_enabled == nullptr) {
+      throw PluginError(
+          "Missing Erika C ABI symbol: erika_presenter_set_debug_hud_enabled");
+    }
+    Check(library->set_debug_hud_enabled(handle, enabled),
+          "set_debug_hud_enabled");
+  }
+
   void SetDanmakuConfig(const ErikaDanmakuConfig& config) {
     if (library->set_danmaku_config == nullptr) {
       throw PluginError("Missing Erika C ABI symbol: erika_presenter_set_danmaku_config_ptr");
@@ -1392,6 +1405,12 @@ struct ErikaFlutterPlugin::PlayerHost {
           {EncodableValue("profile"), NullableString(track.profile)},
           {EncodableValue("level"),
            EncodableValue(static_cast<int32_t>(track.level))},
+          {EncodableValue("bitRate"),
+           EncodableValue(static_cast<int64_t>(track.bit_rate))},
+          {EncodableValue("frameRateNumerator"),
+           EncodableValue(static_cast<int32_t>(track.frame_rate_numerator))},
+          {EncodableValue("frameRateDenominator"),
+           EncodableValue(static_cast<int32_t>(track.frame_rate_denominator))},
       }));
       library->free_track_info(&track);
     }
@@ -2149,6 +2168,9 @@ void ErikaFlutterPlugin::HandleMethodCall(
       result->Success(PlayerFromArgs(args).GetOutputStatus());
     } else if (method == "getPresenterStats") {
       result->Success(PlayerFromArgs(args).GetPresenterStats());
+    } else if (method == "setDebugHudEnabled") {
+      PlayerFromArgs(args).SetDebugHudEnabled(BoolArg(args, "enabled", false));
+      result->Success();
     } else if (method == "addExternalSubtitle") {
       const int64_t track_id =
           PlayerFromArgs(args).AddExternalSubtitle(RequiredString(args, "uri"));


### PR DESCRIPTION
## Summary

- Expose per-track bitrate and rational frame-rate metadata through Rust, C ABI, and Flutter.
- Add a native presenter debug HUD for on-device playback diagnostics.
- Improve FFmpeg metadata fallbacks and Apple Flutter structured diagnostic events.

## Media metadata

- Extend track metadata with:
  - `bitRate` / `bit_rate` in bit/s
  - `frameRateNumerator` / `frameRateDenominator`
  - Dart `framesPerSecond` convenience getter
- Preserve rational frame rates such as `30000/1001`.
- Probe frame rate in this order:
  1. `avg_frame_rate`
  2. `r_frame_rate`
  3. `av_guess_frame_rate`
- For one-video-track media with no stream bitrate, estimate video bitrate only when the container bitrate and every other audio-track bitrate are known:
  `container bitrate - sum(audio bitrates)`.

## Native debug HUD

- Add `erika_presenter_set_debug_hud_enabled`.
- Add `ErikaPlayer.setDebugHudEnabled(bool)` for Flutter.
- Support Android, iOS, macOS, and Windows bridges.
- Display media metadata, playback state, decode/render FPS, decode path, zero-copy counters, render/GPU timing, audio queue/underflow, output/HDR state, and danmaku count.
- Keep the HUD disabled by default.
- Exclude the HUD from off-screen screenshot captures.
- Request a render on Android when HUD state changes, including paused playback.

## Diagnostics delivery

- Forward structured decoder, audio-output, and error event payloads through the iOS/macOS Flutter bridges.
- Improve Flutter consumers' access to native diagnostic details.

## Documentation

- Document media metadata semantics, estimation limitations, frame-rate fallback order, HUD usage, and screenshot behavior in English, Simplified Chinese, and Japanese.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p erika -p erika_capi`
- `cargo check -p erika -p erika_capi`
- Flutter player tests
- Swift syntax validation for iOS and macOS plugin sources
- `git diff --check`