### PR TITLE
feat(presenter): isolate audio delay controls for redesign

### DIFF
--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -75,6 +75,7 @@ const DANMAKU_PREPARE_REFRESH_MARGIN: Duration = Duration::from_secs(4);
 const DANMAKU_PLAN_LOOKAHEAD: Duration = Duration::from_secs(8);
 const DANMAKU_PLAN_LOOKBACK_PADDING: Duration = Duration::from_secs(2);
 const DEFAULT_SUBTITLE_FONT_SCALE: f64 = 1.0;
+const AUDIO_DELAY_LIMIT_SECONDS: f64 = 10.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TransitionFramePolicy {
@@ -248,6 +249,7 @@ pub struct PresenterRuntime {
     current_surface_metrics: Option<SurfaceMetrics>,
     current_danmaku_viewport: Option<DanmakuViewport>,
     subtitle_font_scale: f64,
+    audio_delay: f64,
     subtitles: SubtitleFrameState,
     overlay: OverlayTimeline,
     render_test_pattern_when_idle: bool,
@@ -550,6 +552,7 @@ impl PresenterRuntime {
             current_surface_metrics: None,
             current_danmaku_viewport: None,
             subtitle_font_scale: DEFAULT_SUBTITLE_FONT_SCALE,
+            audio_delay: 0.0,
             subtitles: SubtitleFrameState::default(),
             overlay: config.overlay,
             render_test_pattern_when_idle: config.render_test_pattern_when_idle,
@@ -707,6 +710,18 @@ impl PresenterRuntime {
         }
         self.subtitle_font_scale = scale;
         self.refresh_current_overlay();
+    }
+
+    /// Sets the audio delay in seconds with mpv `audio-delay` semantics: a
+    /// positive value delays audio relative to the video. The value is
+    /// clamped to ±10 s and takes effect from the next decoded audio frame;
+    /// already-queued output is not rewritten.
+    pub fn set_audio_delay(&mut self, delay_seconds: f64) {
+        self.audio_delay = normalize_audio_delay(delay_seconds);
+    }
+
+    pub fn audio_delay(&self) -> f64 {
+        self.audio_delay
     }
 
     pub fn set_danmaku_timeline(&mut self, timeline: DanmakuTimeline) {
@@ -1965,6 +1980,14 @@ impl PresenterRuntime {
             self.audio_configured = true;
             self.last_audio_clock_report = None;
         }
+        let mut frame = frame;
+        // The audio clock is anchored on frame pts, so shifting the pts here
+        // delays (or advances) audio relative to the video while clock sync,
+        // subtitles, and danmaku follow automatically.
+        frame.frame.pts = frame
+            .frame
+            .pts
+            .map(|pts| shifted_audio_pts(pts, self.audio_delay));
         match self.audio_output.push(frame.frame) {
             Ok(_) => self.stats.pushed_audio_frames += 1,
             Err(error) => {
@@ -2155,6 +2178,31 @@ fn normalize_subtitle_font_scale(scale: f64) -> f64 {
         scale.clamp(0.25, 4.0)
     } else {
         DEFAULT_SUBTITLE_FONT_SCALE
+    }
+}
+
+fn normalize_audio_delay(delay_seconds: f64) -> f64 {
+    if delay_seconds.is_finite() {
+        delay_seconds.clamp(-AUDIO_DELAY_LIMIT_SECONDS, AUDIO_DELAY_LIMIT_SECONDS)
+    } else {
+        0.0
+    }
+}
+
+/// Maps a decoded audio frame's pts to its output pts for a given
+/// `audio-delay`. A positive delay pushes the audio clock forwards (`pts +
+/// delay`), which delays audio content relative to the video the clock
+/// drives; a negative delay pulls it backwards, clamping at zero.
+fn shifted_audio_pts(pts: Duration, delay_seconds: f64) -> Duration {
+    let delay = normalize_audio_delay(delay_seconds);
+    if delay == 0.0 {
+        return pts;
+    }
+    let magnitude = Duration::from_secs_f64(delay.abs());
+    if delay > 0.0 {
+        pts.saturating_add(magnitude)
+    } else {
+        pts.saturating_sub(magnitude)
     }
 }
 
@@ -3321,6 +3369,37 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         assert_eq!(presenter.volume(), 0.0);
         presenter.set_volume(f64::NAN);
         assert_eq!(presenter.volume(), 1.0);
+    }
+
+    #[test]
+    fn audio_pts_shift_follows_mpv_audio_delay_semantics() {
+        let pts = Duration::from_secs(10);
+
+        // Positive delay pushes audio content later than the video.
+        assert_eq!(shifted_audio_pts(pts, 2.0), Duration::from_secs(12));
+        assert_eq!(shifted_audio_pts(pts, -2.0), Duration::from_secs(8));
+        assert_eq!(shifted_audio_pts(pts, 0.0), pts);
+        // Underflow clamps at zero; delay magnitude clamps to ±10 s.
+        assert_eq!(
+            shifted_audio_pts(Duration::from_secs(1), -5.0),
+            Duration::ZERO
+        );
+        assert_eq!(shifted_audio_pts(pts, 1_000.0), Duration::from_secs(20));
+        assert_eq!(shifted_audio_pts(pts, f64::NAN), pts);
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn presenter_audio_delay_setter_clamps_range() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+
+        assert_eq!(presenter.audio_delay(), 0.0);
+        presenter.set_audio_delay(25.0);
+        assert_eq!(presenter.audio_delay(), 10.0);
+        presenter.set_audio_delay(-25.0);
+        assert_eq!(presenter.audio_delay(), -10.0);
+        presenter.set_audio_delay(f64::NAN);
+        assert_eq!(presenter.audio_delay(), 0.0);
     }
 
     #[test]

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -438,6 +438,9 @@ ErikaStatus erika_presenter_set_playback_rate(ErikaPresenterHandle *handle, doub
 ErikaStatus erika_presenter_set_volume(ErikaPresenterHandle *handle, double volume);
 ErikaStatus erika_presenter_set_upscaler(ErikaPresenterHandle *handle, int32_t mode);
 ErikaStatus erika_presenter_set_subtitle_scale(ErikaPresenterHandle *handle, double scale);
+/* Positive audio-delay plays audio later than video. seconds is clamped to
+ * ±10 and applies from the next decoded frame. */
+ErikaStatus erika_presenter_set_audio_delay(ErikaPresenterHandle *handle, double seconds);
 ErikaStatus erika_presenter_set_output_headroom(
     ErikaPresenterHandle *handle,
     float headroom,

--- a/crates/erika_capi/src/android_jni.rs
+++ b/crates/erika_capi/src/android_jni.rs
@@ -763,6 +763,10 @@ unsafe fn invoke_presenter(
             let scale = required_f64(args, "scale")?;
             status_value(unsafe { erika_presenter_set_subtitle_scale(handle, scale) })
         }
+        "setAudioDelay" => {
+            let seconds = required_f64(args, "seconds")?;
+            status_value(unsafe { erika_presenter_set_audio_delay(handle, seconds) })
+        }
         "setOutputHeadroom" => {
             let headroom = required_f64(args, "headroom")? as f32;
             let known =

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -1637,6 +1637,25 @@ pub unsafe extern "C" fn erika_presenter_set_volume(
     target_os = "android",
     target_env = "ohos"
 ))]
+/// # Safety
+/// `handle` must be a live pointer returned by `erika_presenter_create*`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_audio_delay(
+    handle: *mut ErikaPresenterHandle,
+    seconds: f64,
+) -> ErikaStatus {
+    with_presenter_mut(handle, |handle| {
+        handle.presenter.set_audio_delay(seconds);
+        ErikaStatus::Ok
+    })
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "windows",
+    target_os = "android"
+))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_set_upscaler(
     handle: *mut ErikaPresenterHandle,
@@ -2432,6 +2451,20 @@ pub unsafe extern "C" fn erika_presenter_set_volume(
     target_os = "windows",
     target_os = "android",
     target_env = "ohos"
+)))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_audio_delay(
+    _handle: *mut std::ffi::c_void,
+    _seconds: f64,
+) -> ErikaStatus {
+    ErikaStatus::PlayerError
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "windows",
+    target_os = "android"
 )))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_set_upscaler(
@@ -4090,6 +4123,32 @@ mod tests {
         target_os = "windows",
         target_os = "android",
         target_env = "ohos"
+    ))]
+    #[test]
+    fn c_presenter_audio_delay_setter_accepts_valid_handle() {
+        assert_eq!(
+            unsafe { erika_presenter_set_audio_delay(std::ptr::null_mut(), 1.0) },
+            ErikaStatus::NullPointer
+        );
+
+        let handle = erika_presenter_create();
+        assert!(!handle.is_null());
+        assert_eq!(
+            unsafe { erika_presenter_set_audio_delay(handle, -0.5) },
+            ErikaStatus::Ok
+        );
+        assert_eq!(
+            unsafe { erika_presenter_set_audio_delay(handle, 1_000.0) },
+            ErikaStatus::Ok
+        );
+        unsafe { erika_presenter_destroy(handle) };
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "windows",
+        target_os = "android"
     ))]
     #[test]
     fn c_presenter_set_upscaler_accepts_valid_handle() {

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
@@ -1720,6 +1720,7 @@ class ErikaFlutterPlugin :
             "setVolume",
             "setUpscaler",
             "setSubtitleScale",
+            "setAudioDelay",
             "getUpscalerStatus",
             "getOutputStatus",
             "getPresenterStats",

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -356,6 +356,7 @@ private final class ErikaNativeLibrary {
   typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetUpscalerFn = @convention(c) (UnsafeMutableRawPointer?, Int32) -> Int32
   typealias SetSubtitleScaleFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SetAudioDelayFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias GetOutputStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
@@ -418,6 +419,7 @@ private final class ErikaNativeLibrary {
   let setVolume: SetVolumeFn?
   let setUpscaler: SetUpscalerFn?
   let setSubtitleScale: SetSubtitleScaleFn?
+  let setAudioDelay: SetAudioDelayFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let getOutputStatus: GetOutputStatusFn?
   let selectAudioTrack: SelectTrackFn
@@ -476,6 +478,7 @@ private final class ErikaNativeLibrary {
     setVolume = Self.loadOptional("erika_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     setUpscaler = Self.loadOptional("erika_presenter_set_upscaler", from: libraryHandle, as: SetUpscalerFn.self)
     setSubtitleScale = Self.loadOptional("erika_presenter_set_subtitle_scale", from: libraryHandle, as: SetSubtitleScaleFn.self)
+    setAudioDelay = Self.loadOptional("erika_presenter_set_audio_delay", from: libraryHandle, as: SetAudioDelayFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     getOutputStatus = Self.loadOptional("erika_presenter_get_output_status", from: libraryHandle, as: GetOutputStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
@@ -672,6 +675,14 @@ private final class ErikaPlayerHost {
     }
     let clampedScale = scale.isFinite ? min(max(scale, 0.25), 4.0) : 1.0
     try check(setSubtitleScale(handle, clampedScale), operation: "set_subtitle_scale")
+  }
+
+  func setAudioDelay(_ seconds: Double) throws {
+    guard let setAudioDelay = library.setAudioDelay else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_audio_delay")
+    }
+    let clampedSeconds = seconds.isFinite ? min(max(seconds, -10.0), 10.0) : 0.0
+    try check(setAudioDelay(handle, clampedSeconds), operation: "set_audio_delay")
   }
 
   func upscalerStatus() throws -> [String: Any] {
@@ -1481,6 +1492,13 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           throw ErikaPluginError.invalidArguments("scale is required.")
         }
         try playerHost(from: args).setSubtitleScale(scale)
+        result(nil)
+      case "setAudioDelay":
+        let args = try dictionaryArgs(call.arguments)
+        guard let seconds = doubleValue(args["seconds"]) else {
+          throw ErikaPluginError.invalidArguments("seconds is required.")
+        }
+        try playerHost(from: args).setAudioDelay(seconds)
         result(nil)
       case "getUpscalerStatus":
         let args = try dictionaryArgs(call.arguments)

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -777,6 +777,22 @@ class ErikaPlayer {
     });
   }
 
+  /// Sets the audio delay with mpv `audio-delay` semantics: a positive
+  /// [delay] plays audio later than the video. Clamped to plus or minus
+  /// 10 seconds.
+  Future<void> setAudioDelay(Duration delay) async {
+    final playerId = await ensureCreated();
+    final seconds =
+        (delay.inMicroseconds / Duration.microsecondsPerSecond).clamp(
+      -10.0,
+      10.0,
+    );
+    await _invoke('setAudioDelay', <String, Object?>{
+      'playerId': playerId,
+      'seconds': seconds,
+    });
+  }
+
   Future<ErikaUpscalerStatus> getUpscalerStatus() async {
     final playerId = await ensureCreated();
     final status = await _channel.invokeMethod<Map<dynamic, dynamic>>(

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -227,6 +227,7 @@ private final class ErikaNativeLibrary {
   typealias SetVolumeFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias SetUpscalerFn = @convention(c) (UnsafeMutableRawPointer?, Int32) -> Int32
   typealias SetSubtitleScaleFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
+  typealias SetAudioDelayFn = @convention(c) (UnsafeMutableRawPointer?, Double) -> Int32
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias GetOutputStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
@@ -289,6 +290,7 @@ private final class ErikaNativeLibrary {
   let setVolume: SetVolumeFn?
   let setUpscaler: SetUpscalerFn?
   let setSubtitleScale: SetSubtitleScaleFn?
+  let setAudioDelay: SetAudioDelayFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let getOutputStatus: GetOutputStatusFn?
   let selectAudioTrack: SelectTrackFn
@@ -341,6 +343,7 @@ private final class ErikaNativeLibrary {
     setVolume = Self.loadOptional("erika_presenter_set_volume", from: libraryHandle, as: SetVolumeFn.self)
     setUpscaler = Self.loadOptional("erika_presenter_set_upscaler", from: libraryHandle, as: SetUpscalerFn.self)
     setSubtitleScale = Self.loadOptional("erika_presenter_set_subtitle_scale", from: libraryHandle, as: SetSubtitleScaleFn.self)
+    setAudioDelay = Self.loadOptional("erika_presenter_set_audio_delay", from: libraryHandle, as: SetAudioDelayFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     getOutputStatus = Self.loadOptional("erika_presenter_get_output_status", from: libraryHandle, as: GetOutputStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
@@ -550,6 +553,14 @@ private final class ErikaPlayerHost {
     }
     let clampedScale = scale.isFinite ? min(max(scale, 0.25), 4.0) : 1.0
     try check(setSubtitleScale(handle, clampedScale), operation: "set_subtitle_scale")
+  }
+
+  func setAudioDelay(_ seconds: Double) throws {
+    guard let setAudioDelay = library.setAudioDelay else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_set_audio_delay")
+    }
+    let clampedSeconds = seconds.isFinite ? min(max(seconds, -10.0), 10.0) : 0.0
+    try check(setAudioDelay(handle, clampedSeconds), operation: "set_audio_delay")
   }
 
   func upscalerStatus() throws -> [String: Any] {
@@ -1511,6 +1522,14 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           throw ErikaPluginError.invalidArguments("scale is required.")
         }
         try host.setSubtitleScale(scale)
+        result(nil)
+      case "setAudioDelay":
+        let args = try dictionaryArgs(call.arguments)
+        let host = try playerHost(from: args)
+        guard let seconds = doubleValue(args["seconds"]) else {
+          throw ErikaPluginError.invalidArguments("seconds is required.")
+        }
+        try host.setAudioDelay(seconds)
         result(nil)
       case "getUpscalerStatus":
         let args = try dictionaryArgs(call.arguments)

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -402,6 +402,28 @@ void main() {
     await player.dispose();
   });
 
+  test('audio delay is forwarded in clamped seconds', () async {
+    final player = ErikaPlayer();
+
+    await player.setAudioDelay(const Duration(milliseconds: -250));
+    await player.setAudioDelay(const Duration(seconds: 25));
+
+    final calls = playerCalls
+        .where((MethodCall call) => call.method == 'setAudioDelay')
+        .toList();
+    expect(calls, hasLength(2));
+    expect(calls[0].arguments, <String, Object?>{
+      'playerId': 7,
+      'seconds': -0.25,
+    });
+    expect(calls[1].arguments, <String, Object?>{
+      'playerId': 7,
+      'seconds': 10.0,
+    });
+
+    await player.dispose();
+  });
+
   test('window overlay methods forward surface geometry', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(playerChannel, (MethodCall call) async {

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -640,6 +640,7 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   using SetVolumeFn = ErikaStatus (*)(ErikaPresenterHandle*, double);
   using SetUpscalerFn = ErikaStatus (*)(ErikaPresenterHandle*, int32_t);
   using SetSubtitleScaleFn = ErikaStatus (*)(ErikaPresenterHandle*, double);
+  using SetAudioDelayFn = ErikaStatus (*)(ErikaPresenterHandle*, double);
   using GetUpscalerStatusFn =
       ErikaStatus (*)(ErikaPresenterHandle*, ErikaUpscalerStatus*);
   using GetOutputStatusFn =
@@ -748,6 +749,7 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   SetVolumeFn set_volume = nullptr;
   SetUpscalerFn set_upscaler = nullptr;
   SetSubtitleScaleFn set_subtitle_scale = nullptr;
+  SetAudioDelayFn set_audio_delay = nullptr;
   GetUpscalerStatusFn get_upscaler_status = nullptr;
   GetOutputStatusFn get_output_status = nullptr;
   SelectTrackFn select_audio_track = nullptr;
@@ -807,6 +809,8 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         LoadOptional<SetUpscalerFn>("erika_presenter_set_upscaler");
     set_subtitle_scale = LoadOptional<SetSubtitleScaleFn>(
         "erika_presenter_set_subtitle_scale");
+    set_audio_delay = LoadOptional<SetAudioDelayFn>(
+        "erika_presenter_set_audio_delay");
     get_upscaler_status = LoadOptional<GetUpscalerStatusFn>(
         "erika_presenter_get_upscaler_status");
     get_output_status = LoadOptional<GetOutputStatusFn>(
@@ -1161,6 +1165,16 @@ struct ErikaFlutterPlugin::PlayerHost {
     }
     const double clamped = std::isfinite(scale) ? std::clamp(scale, 0.25, 4.0) : 1.0;
     Check(library->set_subtitle_scale(handle, clamped), "set_subtitle_scale");
+  }
+
+  void SetAudioDelay(double seconds) {
+    if (library->set_audio_delay == nullptr) {
+      throw PluginError(
+          "Missing Erika C ABI symbol: erika_presenter_set_audio_delay");
+    }
+    const double clamped =
+        std::isfinite(seconds) ? std::clamp(seconds, -10.0, 10.0) : 0.0;
+    Check(library->set_audio_delay(handle, clamped), "set_audio_delay");
   }
 
   EncodableValue GetUpscalerStatus() {
@@ -2142,6 +2156,10 @@ void ErikaFlutterPlugin::HandleMethodCall(
     } else if (method == "setSubtitleScale") {
       PlayerFromArgs(args).SetSubtitleScale(
           DoubleValue(FindArg(args, "scale")).value_or(1.0));
+      result->Success();
+    } else if (method == "setAudioDelay") {
+      PlayerFromArgs(args).SetAudioDelay(
+          DoubleValue(FindArg(args, "seconds")).value_or(0.0));
       result->Success();
     } else if (method == "getUpscalerStatus") {
       result->Success(PlayerFromArgs(args).GetUpscalerStatus());


### PR DESCRIPTION
## Summary

Extracts the audio-delay portion of #53 into its own draft so the API wiring and clock design can be reviewed without blocking mute or subtitle work.

The current implementation carries the original approach: it shifts decoded audio-frame PTS before the output ring buffer and wires `setAudioDelay` through the full platform stack.

## Draft blockers

This implementation is intentionally not ready to merge:

- samples remain in FIFO order; retagging PTS shifts the audio-master clock instead of delaying or advancing sample output
- negative offsets beyond the 250 ms stale-clock tolerance are rejected
- startup, seek, EOF, reported-position, and queued-audio transition semantics are not strict mpv-style audio delay

The intended redesign is an audio delay processor with separate source and presentation timelines: positive changes insert output silence, negative changes trim queued samples, and the master position remains monotonic and truthful.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p erika -p erika_capi --lib` — 391 + 26 tests passed
- `flutter test` — 37 tests passed

Split from #53; draft status documents the known semantic blocker.