### PR TITLE
docs(ohos): 修正鸿蒙解码描述并对齐三语文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 ## 特性
 
-- **硬件加速解码** — VideoToolbox (macOS/iOS)、D3D11VA (Windows)、MediaCodec (Android)，互操作不可用时明确回退软解
-- **零拷贝渲染** — Apple CVPixelBuffer → MTLTexture、Windows D3D11VA 纹理互操作、Android MediaCodec Surface → AHardwareBuffer/Vulkan；无法导入时明确回退 CPU upload
+- **硬件加速解码** — VideoToolbox (macOS/iOS)、D3D11VA (Windows)、MediaCodec (Android)、AVCodec (HarmonyOS)，互操作不可用时明确回退软解
+- **零拷贝渲染** — Apple CVPixelBuffer → MTLTexture、Windows D3D11VA 纹理互操作、Android MediaCodec Surface → AHardwareBuffer/Vulkan、HarmonyOS AVCodec Surface → OHNativeBuffer/Vulkan；无法导入时明确回退 CPU upload
 - **HDR/EDR 输出** — Apple EDR、Windows HDR10，以及 Android FP16 extended-linear scRGB 协商与明确 SDR 回退
 - **原生 Metal 渲染器** — YCbCr 采样、色彩空间转换、tone mapping、字幕/弹幕合成，一次 render pass 完成 (macOS/iOS)
 - **原生 Direct3D 11 渲染器** — Windows: D3D11VA 零拷贝纹理互操作、YCbCr 采样、HDR10 输出、字幕/弹幕 overlay 合成
@@ -25,9 +25,9 @@
 - **字幕** — SRT / WebVTT / ASS 解析，libass 渲染 (静态链接)，嵌入与外挂字幕轨
 - **弹幕** — Bilibili XML / JSON 解析，DFM+ 碰撞避让布局引擎，glyph atlas 原生 GPU 渲染
 - **播放引擎** — play / pause / stop / seek / 倍速，音频主时钟同步，vsync 量化调度
-- **C ABI** — 75 个导出函数，opaque handle 设计，可从 C / C++ / Swift / Dart FFI / 任何 FFI 语言调用
+- **C ABI** — 79 个导出函数，opaque handle 设计，可从 C / C++ / Swift / Dart FFI / 任何 FFI 语言调用
 - **Flutter 插件** — macOS + iOS + Windows + Android + HarmonyOS 原生视图/Texture 嵌入
-- **wgpu 后端** — Android 播放、overlay、截图与 Vulkan/GLES 恢复路径可用；HarmonyOS 使用 OHNativeWindow/OpenGL ES，Linux 仍在规划中
+- **wgpu 后端** — Android 播放、overlay、截图与 Vulkan/GLES 恢复路径可用；HarmonyOS 走 Vulkan，用 OHNativeWindow 呈现、OHNativeBuffer 零拷贝导入；Linux 仍在规划中
 
 ## 快速开始
 
@@ -90,7 +90,7 @@ Erika 提供两组 C ABI 入口，适配不同嵌入场景：
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | **可用** |
 | Linux | — | wgpu (planned) | — | 规划中 |
 | Android 8+ | MediaCodec / software | wgpu (Vulkan + GLES fallback) | AAudio | **可用**；SDR 已验证，extended-linear scRGB 已实现，API 35 HDR 真机 active path 待验收 |
-| HarmonyOS API 18+ | FFmpeg software | wgpu (OpenGL ES) + OHNativeWindow/Flutter Texture | OHAudio | **可用**；SDR 音视频真机验证通过 |
+| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ 软解 | wgpu (Vulkan) + `OHNativeBuffer` 零拷贝导入 | OHAudio | **可用**；已在真机验证，尚未纳入 CI |
 
 ## 仓库结构
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -11,16 +11,16 @@ Rust Player Core
   source abstraction ─── file + HTTP range
   FFmpeg wrappers ────── custom AVIO, probe, demux, decode, seek, audio resample
   playback engine ────── video/audio tick, clock, frame scheduler
-  video decode ───────── VideoToolbox (macOS/iOS), D3D11VA (Windows), software fallback
-  audio output ───────── CoreAudio (macOS), AudioQueue (iOS), WASAPI (Windows), ring buffer
+  video decode ───────── VideoToolbox, D3D11VA, MediaCodec, AVCodec, software fallback
+  audio output ───────── CoreAudio, AudioQueue, WASAPI, AAudio, OHAudio, ring buffer
   overlay timeline ───── subtitle + danmaku composition
   renderer core ──────── color state, render graph, tone map, scaler policy
   Metal renderer ─────── zero-copy NV12/P010, HDR/EDR, subtitle/danmaku pass
   D3D11 renderer ─────── zero-copy D3D11VA, HDR10, subtitle/danmaku pass (Windows)
-  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB
+  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB, OHOS Vulkan
   presenter runtime ──── ties player + renderer + audio + overlays
-  C ABI ──────────────── 75 exported functions, two handle families
-  Flutter plugin ─────── macOS + iOS + Windows + Android native view embedding
+  C ABI ──────────────── 79 exported functions, two handle families
+  Flutter plugin ─────── macOS + iOS + Windows + Android + OpenHarmony embedding
 ```
 
 ## ネイティブ依存関係
@@ -48,7 +48,7 @@ cargo run -p xtask -- deps status
 `erika_ffmpeg_sys` は build 時に bindgen で低レベルバインディングを生成します。`erika::ffmpeg` は安全な Rust ラッパーを提供します。
 
 - **Demuxer**: `AVFormatContext` を保持し、`MediaSource` 由来の Rust-backed custom `AVIOContext` を使うこともできます。stream selection、reference-counted packets、timestamp-based seek をサポートします。
-- **Decoder**: software と VideoToolbox hardware backend を持ちます。hardware frames は BT.2020/PQ metadata を保持し、`CVPixelBufferRef` を通じて Metal に zero-copy で渡せます。
+- **Decoder**: software に加えて VideoToolbox、D3D11VA、MediaCodec、OpenHarmony AVCodec の hardware backend を持ちます。hardware frames は BT.2020/PQ metadata を保持し、platform native handle（Apple では `CVPixelBufferRef`）を通じて renderer に zero-copy で渡せます。
 - **AudioResampler**: `libswresample` を包み、interleaved f32 PCM（既定 48 kHz stereo）へ変換します。
 - **SubtitleDecoder**: 埋め込みテキスト字幕と bitmap 字幕ストリームをデコードします。
 
@@ -123,7 +123,8 @@ Windows のネイティブ renderer（`renderer/d3d11.rs`）：
 - 色空間変換と tone mapping（Metal と同じ pipeline model）。
 - bounded feature texture と source-sized packed DepthToSpace output を使う tiled ArtCNN C4F16/C4F32 compute（`renderer/wgpu_artcnn.rs`）。native luma と Android の converted nonlinear RGB の両方を扱い、`rgb + (Y_sr - Y)` で chroma を保持します。GLES 3.0 は compute を試さず、`Inactive` と `native_luma_sampling` fallback を明示します。
 - subtitle/danmaku composite、frame capture、headless testing 用 offscreen target。display surface が extended-linear の場合も screenshot は常に SDR RGBA8 target へ offscreen render し、未マップの scRGB 値を SDR pixel として返しません。
-- surface handle model は macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window をカバーします。
+- surface handle model は macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window、OpenHarmony `OHNativeWindow` をカバーします。
+- OpenHarmony では AVCodec の Surface 出力を `OHNativeBuffer` 由来の Vulkan external image として import し、Vulkan YCbCr sampler で YUV 変換を GPU 上で行うため、decode したフレームは CPU コピーなしで wgpu compositor に到達します。必要な Vulkan extension がない端末では software decode と CPU upload に fallback し、その経緯は diagnostics event から確認できます。
 - Android は bounded Vulkan/GLES backend recovery と import/capability/quality/device-failure diagnostics を備えます。high-headroom output は FP16 **extended-linear scRGB** であり HDR10/PQ ではありません。renderer は `Rgba16Float`、Vulkan extended-sRGB-linear color space を使い、configure/reconfigure ごとに `ANativeWindow` の `ADATASPACE_SCRGB_LINEAR`（`0x18410000`）を検証します。Android scRGB は BT.709 primaries、`1.0 = 80 nit` で、PQ や HDR10 static metadata は出力しません。
 - Extended-linear が active になる条件は、`ExtendedLinear` の明示要求、HDR 対応 display/surface、Flutter Hybrid Composition の `SurfaceView`、Vulkan wgpu backend、surface の `Rgba16Float` 対応、`SCRGB_LINEAR` dataspace readback 成功です。どれかが欠けると通常の SDR surface を直ちに選び、安定 ABI の fallback reason `0..8` を記録します。そのため GLES と `TextureView` は SDR path です。
 - API 34+ では Android host が `Display.registerHdrSdrRatioChangedListener` で display を監視し、実際の変化を `erika_presenter_set_output_headroom` で Erika に publish します。wgpu は surface を reattach せず、後続 frame の effective content headroom と queryable output status を更新します。ratio が available なら `activeHeadroomKnown` は true で、known flag または ratio が実際に変わった場合だけ `headroomUpdates` が増えます。
@@ -150,7 +151,7 @@ Windows のネイティブ renderer（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` は 2 つの handle family で 75 関数を export します。
+`erika_capi` は 2 つの handle family で 79 関数を export します。
 
 - **`ErikaHandle`**: player control と event polling。rendering は host 管理です。
 - **`ErikaPresenterHandle`**: Erika が full stack を所有します。host は surface を渡して `render_tick` を呼びます。
@@ -161,13 +162,14 @@ Header: `crates/erika_capi/include/erika.h`
 
 ## Flutter Plugin
 
-`packages/erika_flutter` は macOS / iOS / Windows / Android の Flutter embedding を提供します。
+`packages/erika_flutter` は macOS / iOS / Windows / Android / HarmonyOS の Flutter embedding を提供します。
 
 - **Dart**: `ErikaPlayer`（commands + events）、`ErikaWindowOverlayVideoView`（推奨の window-hosted native surface——Apple では Metal、Windows では D3D11 swapchain）、`ErikaVideoView`（compatibility platform view）。
 - **macOS Swift plugin**: `liberika_capi.dylib` を読み込み、`NSWindow` overlay または `NSView`/`CAMetalLayer` platform view surface を作成し、display link から `render_tick` を駆動します。
 - **iOS Swift plugin**: `liberika_capi.a` を static link し、`UIWindow` overlay または `UIView`/`CAMetalLayer` platform view surface を作成し、同じ presenter model を使います。
 - **Windows C++ plugin**（`ErikaFlutterPluginCApi`）: CMake（`build_erika_runtime.cmake`、cargo target `x86_64-pc-windows-msvc`）で `erika_capi.dll` をビルド・リンクし、window-level D3D11 swapchain を host し、frame scheduler から `render_tick` を駆動します。
 - **Android Kotlin/JNI plugin**: Android ABI 向け Rust runtime をビルドし、player ごとに独立した native surface を持ちます。SDR は `TextureView`、extended-linear の要求時は Flutter Hybrid Composition の `SurfaceView` を使います。Activity surface lifecycle、audio focus、noisy-route policy、HDR eligibility/headroom を調整し、active player がある間だけ shared frame scheduler を駆動します。
+- **HarmonyOS ArkTS/N-API plugin**: Hvigor/CMake で `aarch64-unknown-linux-ohos` 向けに `liberika_capi.so` をビルドし、Flutter external texture を登録して、その texture の `OHNativeWindow` を presenter に attach します。音声は OHAudio を通じて interleaved f32 PCM で出力します。
 
 embedding model と HDR strategy は `docs/flutter_embedding.md` を参照してください。
 
@@ -180,3 +182,4 @@ embedding model と HDR strategy は `docs/flutter_embedding.md` を参照して
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan + GLES fallback | AAudio | Available。SDR は検証済み、extended-linear scRGB は API 35 HDR 実機 acceptance 待ち |
+| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan、`OHNativeBuffer` zero-copy import | OHAudio | Available。実機で検証済み、CI は未カバー |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,16 +14,16 @@ Rust Player Core
   source abstraction ─── file + HTTP range
   FFmpeg wrappers ────── custom AVIO, probe, demux, decode, seek, audio resample
   playback engine ────── video/audio tick, clock, frame scheduler
-  video decode ───────── VideoToolbox (macOS/iOS), D3D11VA (Windows), software fallback
-  audio output ───────── CoreAudio (macOS), AudioQueue (iOS), WASAPI (Windows), ring buffer
+  video decode ───────── VideoToolbox, D3D11VA, MediaCodec, AVCodec, software fallback
+  audio output ───────── CoreAudio, AudioQueue, WASAPI, AAudio, OHAudio, ring buffer
   overlay timeline ───── subtitle + danmaku composition
   renderer core ──────── color state, render graph, tone map, scaler policy
   Metal renderer ─────── zero-copy NV12/P010, HDR/EDR, subtitle/danmaku pass
   D3D11 renderer ─────── zero-copy D3D11VA, HDR10, subtitle/danmaku pass (Windows)
-  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB
+  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB, OHOS Vulkan
   presenter runtime ──── ties player + renderer + audio + overlays
-  C ABI ──────────────── 75 exported functions, two handle families
-  Flutter plugin ─────── macOS + iOS + Windows + Android native view embedding
+  C ABI ──────────────── 79 exported functions, two handle families
+  Flutter plugin ─────── macOS + iOS + Windows + Android + OpenHarmony embedding
 ```
 
 ## Native Dependencies
@@ -56,8 +56,8 @@ cargo run -p xtask -- deps status
 - **Demuxer** — owns `AVFormatContext`, optionally with a Rust-backed custom
   `AVIOContext` from `MediaSource`. Supports stream selection, reference-counted
   packets, and timestamp-based seek.
-- **Decoder** — software plus VideoToolbox, D3D11VA, and MediaCodec hardware
-  backends. Android software AV1 explicitly selects the source-built
+- **Decoder** — software plus VideoToolbox, D3D11VA, MediaCodec, and OpenHarmony
+  AVCodec hardware backends. Android software AV1 explicitly selects the source-built
   `libdav1d` decoder. Hardware frames preserve color metadata for the renderer's
   platform-specific import or upload path.
 - **AudioResampler** — wraps `libswresample`, converts to interleaved f32 PCM
@@ -191,7 +191,12 @@ Second renderer backend for portability:
   surface is extended-linear, so screenshots never expose unclamped scRGB
   values as if they were SDR pixels.
 - Surface handle model covers macOS NSView, iOS UIView, Windows HWND,
-  X11/Wayland, Android native windows.
+  X11/Wayland, Android native windows, OpenHarmony `OHNativeWindow`.
+- OpenHarmony imports AVCodec Surface output as an `OHNativeBuffer`-backed
+  Vulkan external image and resolves YUV on the GPU with a Vulkan YCbCr
+  sampler, so decoded frames reach the wgpu compositor without a CPU copy.
+  Devices without the required Vulkan extensions fall back to software decode
+  and CPU upload, and the fallback is reported through the diagnostics events.
 - Android has bounded Vulkan/GLES backend recovery and explicit import,
   capability, quality-reduction, and device-failure diagnostics. Its
   high-headroom output is FP16 **extended-linear scRGB**, not HDR10/PQ: the
@@ -250,7 +255,7 @@ DanmakuEngine, and audio output. The host supplies a native surface and drives
 
 ## C ABI
 
-`erika_capi` exports 75 functions through two handle families:
+`erika_capi` exports 79 functions through two handle families:
 
 - **`ErikaHandle`** — player control and event polling. The host owns rendering.
 - **`ErikaPresenterHandle`** — Erika owns the full stack. The host provides a
@@ -266,7 +271,8 @@ Header: `crates/erika_capi/include/erika.h`
 
 ## Flutter Plugin
 
-`packages/erika_flutter` provides macOS, iOS, Windows, and Android Flutter embedding:
+`packages/erika_flutter` provides macOS, iOS, Windows, Android, and HarmonyOS
+Flutter embedding:
 
 - **Dart**: `ErikaPlayer` (commands + events), `ErikaWindowOverlayVideoView`
   (recommended window-hosted native surface — Metal on Apple, D3D11 swapchain on
@@ -287,6 +293,10 @@ Header: `crates/erika_capi/include/erika.h`
   Composition. The plugin coordinates Activity surface lifecycle, audio focus,
   noisy-route policy, HDR eligibility/headroom, and drives presentation from a
   shared frame scheduler only while players are active.
+- **HarmonyOS ArkTS/N-API plugin**: builds `liberika_capi.so` for
+  `aarch64-unknown-linux-ohos` through Hvigor/CMake, registers a Flutter
+  external texture, and attaches that texture's `OHNativeWindow` to the
+  presenter. Audio goes through OHAudio as interleaved f32 PCM.
 
 See `docs/flutter_embedding.md` for the embedding model and HDR strategy.
 
@@ -299,3 +309,4 @@ See `docs/flutter_embedding.md` for the embedding model and HDR strategy.
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan with GLES fallback | AAudio | Available; SDR validated, extended-linear scRGB implementation awaits API 35 HDR-device acceptance |
+| HarmonyOS API 18+ | AVCodec (H.264/HEVC) / software | wgpu Vulkan, `OHNativeBuffer` zero-copy import | OHAudio | Available; validated on device, not yet covered by CI |

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -11,16 +11,16 @@ Rust Player Core
   source abstraction ─── file + HTTP range
   FFmpeg wrappers ────── custom AVIO, probe, demux, decode, seek, audio resample
   playback engine ────── video/audio tick, clock, frame scheduler
-  video decode ───────── VideoToolbox (macOS/iOS), D3D11VA (Windows), software fallback
-  audio output ───────── CoreAudio (macOS), AudioQueue (iOS), WASAPI (Windows), ring buffer
+  video decode ───────── VideoToolbox, D3D11VA, MediaCodec, AVCodec, software fallback
+  audio output ───────── CoreAudio, AudioQueue, WASAPI, AAudio, OHAudio, ring buffer
   overlay timeline ───── subtitle + danmaku composition
   renderer core ──────── color state, render graph, tone map, scaler policy
   Metal renderer ─────── zero-copy NV12/P010, HDR/EDR, subtitle/danmaku pass
   D3D11 renderer ─────── zero-copy D3D11VA, HDR10, subtitle/danmaku pass (Windows)
-  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB
+  wgpu renderer ──────── cross-platform video, overlays, capture, Android scRGB, OHOS Vulkan
   presenter runtime ──── ties player + renderer + audio + overlays
-  C ABI ──────────────── 75 exported functions, two handle families
-  Flutter plugin ─────── macOS + iOS + Windows + Android native view embedding
+  C ABI ──────────────── 79 exported functions, two handle families
+  Flutter plugin ─────── macOS + iOS + Windows + Android + OpenHarmony embedding
 ```
 
 ## 原生依赖
@@ -48,7 +48,7 @@ cargo run -p xtask -- deps status
 `erika_ffmpeg_sys` 在构建时通过 bindgen 生成底层绑定。`erika::ffmpeg` 提供安全的 Rust 封装：
 
 - **Demuxer**：持有 `AVFormatContext`，可选使用来自 `MediaSource` 的 Rust 后端自定义 `AVIOContext`。支持流选择、引用计数 packet 和基于时间戳的 seek。
-- **Decoder**：软件和 VideoToolbox 硬件后端。硬件帧保留 BT.2020/PQ 元数据，并携带 `CVPixelBufferRef` 供 Metal 零拷贝导入。
+- **Decoder**：软件，以及 VideoToolbox、D3D11VA、MediaCodec、OpenHarmony AVCodec 硬件后端。硬件帧保留 BT.2020/PQ 元数据，并携带平台原生句柄（Apple 上是 `CVPixelBufferRef`）供渲染器零拷贝导入。
 - **AudioResampler**：封装 `libswresample`，输出 interleaved f32 PCM（默认 48 kHz stereo）。
 - **SubtitleDecoder**：解码内嵌文本和位图字幕流。
 
@@ -123,7 +123,8 @@ Windows 平台的原生渲染器（`renderer/d3d11.rs`）：
 - 色彩空间转换、tone mapping（与 Metal 保持同一流水线模型）。
 - 分块执行 ArtCNN C4F16/C4F32（`renderer/wgpu_artcnn.rs`），用有界 feature texture 和源分辨率 packed DepthToSpace 输出控制显存。既支持原生 luma plane，也支持 Android 已转换的 nonlinear RGB texture，并通过 `rgb + (Y_sr - Y)` 保持色度。GLES 3.0 不尝试 compute，而是明确报告 `Inactive` 和 `native_luma_sampling` 回退。
 - 字幕/弹幕合成、截图，以及可用于无头验证的离屏 render target。即使显示 surface 是 extended-linear，截图也始终离屏渲染到 SDR RGBA8 target，避免把未映射的 scRGB 值当成 SDR 像素输出。
-- 表面句柄模型覆盖 macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window。
+- 表面句柄模型覆盖 macOS NSView、iOS UIView、Windows HWND、X11/Wayland、Android native window、OpenHarmony `OHNativeWindow`。
+- OpenHarmony 把 AVCodec 的 Surface 输出作为 `OHNativeBuffer` 支撑的 Vulkan 外部图像导入，并用 Vulkan YCbCr sampler 在 GPU 上完成 YUV 转换，解码帧无需 CPU 拷贝即可进入 wgpu 合成器。缺少所需 Vulkan 扩展的设备回退到软解 + CPU 上传，回退过程通过诊断事件上报。
 - Android 提供有界 Vulkan/GLES backend recovery，以及 import、能力、质量降级和 device failure 的结构化日志。其高 headroom 输出是 FP16 **extended-linear scRGB**，不是 HDR10/PQ：renderer 使用 `Rgba16Float`、Vulkan extended-sRGB-linear color space，并在每次 configure/reconfigure 后验证 `ANativeWindow` 的 `ADATASPACE_SCRGB_LINEAR`（`0x18410000`）。Android scRGB 使用 BT.709 primaries，`1.0 = 80 nit`，不会输出 PQ 或 HDR10 static metadata。
 - Extended-linear 只有在显式请求 `ExtendedLinear`、显示器/surface 支持 HDR、使用 Flutter Hybrid Composition 承载 `SurfaceView`、wgpu 后端为 Vulkan、surface 支持 `Rgba16Float`，且 `SCRGB_LINEAR` dataspace 回读成功时才会激活。任一条件缺失都会立即选择正常 SDR surface，并记录稳定的 `0..8` fallback reason；因此 GLES 与 `TextureView` 都是 SDR 路径。
 - API 34+ 上，Android 宿主通过 `Display.registerHdrSdrRatioChangedListener` 观察显示器，并把真实变化经 `erika_presenter_set_output_headroom` 发布给 Erika。wgpu 无需重新 attach surface，就会让后续帧使用更新后的有效内容 headroom，并同步可查询状态。ratio 可用时 `activeHeadroomKnown` 为 true；只有 known 标志或 ratio 确实变化时，`headroomUpdates` 才增长。
@@ -150,7 +151,7 @@ Windows 平台的原生渲染器（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` 通过两组 handle family 导出 75 个函数：
+`erika_capi` 通过两组 handle family 导出 79 个函数：
 
 - **`ErikaHandle`**：播放器控制与事件轮询，渲染由宿主管理。
 - **`ErikaPresenterHandle`**：Erika 持有完整栈，宿主只需提供 surface 并调用 `render_tick`。
@@ -161,13 +162,14 @@ Header：`crates/erika_capi/include/erika.h`
 
 ## Flutter Plugin
 
-`packages/erika_flutter` 提供 macOS、iOS、Windows 和 Android 的 Flutter embedding：
+`packages/erika_flutter` 提供 macOS、iOS、Windows、Android 和 HarmonyOS 的 Flutter embedding：
 
 - **Dart**：`ErikaPlayer`（命令 + 事件）、`ErikaWindowOverlayVideoView`（推荐的 window-hosted native surface——Apple 上是 Metal，Windows 上是 D3D11 swapchain）、`ErikaVideoView`（兼容 platform view）。
 - **macOS Swift plugin**：加载 `liberika_capi.dylib`，创建 `NSWindow` overlay 或 `NSView`/`CAMetalLayer` platform view，并通过 display link 驱动 `render_tick`。
 - **iOS Swift plugin**：静态链接 `liberika_capi.a`，创建 `UIWindow` overlay 或 `UIView`/`CAMetalLayer` platform view，并沿用同一 presenter 模型。
 - **Windows C++ plugin**（`ErikaFlutterPluginCApi`）：通过 CMake（`build_erika_runtime.cmake`，cargo target `x86_64-pc-windows-msvc`）构建并链接 `erika_capi.dll`，host 一个 window-level D3D11 swapchain，并由帧调度器驱动 `render_tick`。
 - **Android Kotlin/JNI plugin**：为 Android ABI 构建 Rust runtime，每个 player 持有独立原生 surface。SDR 使用 `TextureView`；请求 extended-linear 时，通过 Flutter Hybrid Composition 使用 `SurfaceView`。插件协调 Activity surface lifecycle、音频焦点、noisy-route、HDR eligibility/headroom，并只在存在活跃 player 时驱动共享帧调度器。
+- **HarmonyOS ArkTS/N-API plugin**：通过 Hvigor/CMake 为 `aarch64-unknown-linux-ohos` 构建 `liberika_capi.so`，注册 Flutter 外部纹理，并把该纹理的 `OHNativeWindow` attach 给 presenter。音频经 OHAudio 以交错 f32 PCM 输出。
 
 Embedding 模型和 HDR 策略见 `docs/flutter_embedding.md`。
 
@@ -180,3 +182,4 @@ Embedding 模型和 HDR 策略见 `docs/flutter_embedding.md`。
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan + GLES fallback | AAudio | Available；SDR 已验证，extended-linear scRGB 等待 API 35 HDR 真机验收 |
+| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan，`OHNativeBuffer` 零拷贝导入 | OHAudio | Available；已在真机验证，尚未纳入 CI |

--- a/docs/building.ja.md
+++ b/docs/building.ja.md
@@ -100,9 +100,16 @@ cargo run -p xtask -- deps build --all --profile lgpl
 | `armv7-linux-androideabi`（`armeabi-v7a`） | Android ARMv7 | |
 | `x86_64-linux-android`（`android-x64`） | Android x86_64 | |
 | `i686-linux-android`（`x86`） | Android x86 | Android 共有ライブラリで非 PIC 再配置を避けるため、x86 アセンブリ高速化を無効化。 |
+| `aarch64-unknown-linux-ohos`（`ohos-arm64`） | HarmonyOS arm64 | DevEco Studio の OpenHarmony Native SDK を使用。`OHOS_NDK_HOME` または `OHOS_SDK_NATIVE` と `aarch64-unknown-linux-ohos` Rust target が必要。 |
 
 デプロイ最小バージョンは既定で macOS `11.0` / iOS `13.0`。
 `MACOSX_DEPLOYMENT_TARGET` / `IPHONEOS_DEPLOYMENT_TARGET` で上書き可能。
+
+HarmonyOS build は `OHOS_NDK_HOME` または `OHOS_SDK_NATIVE` が指す DevEco Studio の
+`openharmony/native` ディレクトリを使い、その中の `aarch64-unknown-linux-ohos-clang`
+で FFmpeg、zlib、Erika を build します。Flutter plugin の Hvigor/CMake build が
+この chain を自動実行し、`liberika_capi.so` と `liberika_flutter.so` を HAP に
+package します。
 
 ### Source build architecture の選択
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -63,6 +63,9 @@ Run the commands from a shell where the MSVC environment is active (e.g. a
 - Rust standard-library targets for the ABIs you build:
   `aarch64-linux-android`, `armv7-linux-androideabi`,
   `x86_64-linux-android`, and `i686-linux-android`.
+- For HarmonyOS: the DevEco Studio OpenHarmony Native SDK, pointed at by
+  `OHOS_NDK_HOME` or `OHOS_SDK_NATIVE`, plus the
+  `aarch64-unknown-linux-ohos` Rust standard-library target.
 
 Erika's Android minimum is API **26**. Override it with
 `ANDROID_API_LEVEL` only when targeting a newer API.
@@ -112,12 +115,19 @@ Subcommands: `plan` (print the plan), `fetch` (download sources only),
 | `armv7-linux-androideabi` (or `armeabi-v7a`) | Android ARMv7 | 32-bit ARM compatibility ABI. |
 | `x86_64-linux-android` (or `android-x64`) | Android x86_64 | Emulator and x86_64 device ABI. |
 | `i686-linux-android` (or `x86`) | Android x86 | 32-bit emulator compatibility ABI; x86 assembly acceleration is disabled because Android shared libraries cannot contain its non-PIC relocations. |
+| `aarch64-unknown-linux-ohos` (or `ohos-arm64`) | HarmonyOS arm64 | Uses the DevEco Studio OpenHarmony Native SDK. |
 
 Deployment minimums default to macOS `11.0` / iOS `13.0` and can be overridden
 with `MACOSX_DEPLOYMENT_TARGET` / `IPHONEOS_DEPLOYMENT_TARGET`.
 
 Android builds use `android-26`, `c++_shared`, PIC static dependencies, and the
 NDK LLVM toolchain selected for the requested ABI.
+
+HarmonyOS builds take the DevEco Studio `openharmony/native` directory from
+`OHOS_NDK_HOME` or `OHOS_SDK_NATIVE` and build FFmpeg, zlib, and Erika with the
+`aarch64-unknown-linux-ohos-clang` toolchain inside it. The Flutter plugin's
+Hvigor/CMake build runs this chain automatically and packages `liberika_capi.so`
+and `liberika_flutter.so` into the HAP.
 
 ### Selecting source-build architectures
 

--- a/docs/building.zh.md
+++ b/docs/building.zh.md
@@ -54,6 +54,8 @@ xtask deps build  ──▶  third_party/dist/<target>/<profile>/{ffmpeg,dav1d,z
   `CC_FOR_BUILD` / `CXX_FOR_BUILD`。
 - 按需安装四个 Rust target:`aarch64-linux-android`、
   `armv7-linux-androideabi`、`x86_64-linux-android`、`i686-linux-android`。
+- HarmonyOS:DevEco Studio 的 OpenHarmony Native SDK(由 `OHOS_NDK_HOME` 或
+  `OHOS_SDK_NATIVE` 指向),以及 `aarch64-unknown-linux-ohos` Rust target。
 
 Android 最低 API 为 **26**;只在需要更高版本时用 `ANDROID_API_LEVEL` 覆盖。
 

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -363,6 +363,7 @@ Erika は Vulkan、`Rgba16Float`、`ADATASPACE_SCRGB_LINEAR` も検証します�
 
 ```c
 ErikaStatus erika_presenter_render_tick(ErikaPresenterHandle *, double time_seconds, ErikaPresenterStats *out_stats);
+ErikaStatus erika_presenter_get_stats(ErikaPresenterHandle *, ErikaPresenterStats *out_stats);
 ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_event);
 ```
 
@@ -372,6 +373,50 @@ Windows のフレームスケジューラなど）。`time_seconds` はそのフ
 **プレゼンテーションタイムスタンプ**を渡します。`out_stats` が非 `NULL` なら、パイプ
 ラインカウンタのスナップショットが書き込まれます。`poll_event` は非ブロッキングで、
 アイドル時は `NoEvent` を返します。
+
+`get_stats` は同じ `ErikaPresenterStats` スナップショットを、フレームを描画せずに
+書き込みます。ホストが表示ループとは別の周期でカウンタをサンプリングする場合に
+使ってください。プレゼンテーションは進みません。
+
+### JSON ブリッジ
+
+プラットフォームチャネルが既に構造化引数をシリアライズしている埋め込み側
+（例えば HarmonyOS ArkTS プラグイン）向けに、同じ presenter 面が JSON でも
+利用できます。
+
+```c
+char *erika_presenter_invoke_json(ErikaPresenterHandle *, const char *method,
+                                  const char *arguments_json);
+char *erika_presenter_render_tick_json(ErikaPresenterHandle *, double time_seconds);
+char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
+```
+
+返される文字列は Erika が所有するため、`erika_string_free` で解放してください。
+`poll_event_json` はイベントが無いとき envelope ではなく `NULL` を返すので、
+`NULL` はエラーではなくアイドルを意味します。
+
+3 つとも結果を同じ envelope に包みます。
+
+```json
+{ "ok": true,  "status": 0, "value": <result> }
+{ "ok": false, "status": 1, "error": "<message>" }
+```
+
+`arguments_json` は JSON オブジェクトである必要があります。`method` は操作を選び、
+C エントリポイントに対応します: `open`、`play`、`pause`、`stop`、`close`、`seek`、
+`setPlaybackRate`、`setVolume`、`setUpscaler`、`setSubtitleScale`、
+`getUpscalerStatus`、`getOutputStatus`、`getPresenterStats`、`tracks`、
+`addExternalSubtitle`、`removeSubtitleTrack`、`selectAudioTrack`、
+`selectSubtitleTrack`、および danmaku 系（`loadDanmakuFile`、`loadDanmakuJson`、
+`addDanmakuTrackFile`、`addDanmakuTrackJson`、`removeDanmakuTrack`、
+`setDanmakuTrackEnabled`、`setDanmakuTrackOffset`、`setDanmakuGlobalOffset`、
+`danmakuTracks`、`clearDanmaku`、`setDanmakuEnabled`、`setDanmakuConfig`）。
+未知の method は abort せず `ok: false` を返します。正となる dispatch table は
+`crates/erika_capi/src/presenter_json.rs` です。
+
+このブリッジは利便性のためのレイヤーであり、2 つ目の API ではありません。上で
+説明した関数をそのまま呼ぶだけで、追加の機能はありません。プラットフォーム
+チャネルで構造体を渡せるホストは型付きエントリポイントを優先してください。
 
 ### 診断とスクリーンショット
 

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -380,6 +380,7 @@ falls back to SDR and remains queryable.
 
 ```c
 ErikaStatus erika_presenter_render_tick(ErikaPresenterHandle *, double time_seconds, ErikaPresenterStats *out_stats);
+ErikaStatus erika_presenter_get_stats(ErikaPresenterHandle *, ErikaPresenterStats *out_stats);
 ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_event);
 ```
 
@@ -389,6 +390,51 @@ display clock for the frame in seconds — Erika uses it for vsync-quantized
 scheduling, so pass the presentation timestamp, not wall-clock deltas. If
 `out_stats` is non-`NULL` it is filled with a snapshot of pipeline counters.
 `poll_event` is non-blocking and returns `NoEvent` when idle.
+
+`get_stats` fills the same `ErikaPresenterStats` snapshot without rendering a
+frame. Use it when the host samples counters on a different cadence from the
+display loop; it does not advance presentation.
+
+### JSON bridge
+
+For embedders whose platform channel already serializes structured arguments
+(the HarmonyOS ArkTS plugin, for example), the same presenter surface is
+available as JSON:
+
+```c
+char *erika_presenter_invoke_json(ErikaPresenterHandle *, const char *method,
+                                  const char *arguments_json);
+char *erika_presenter_render_tick_json(ErikaPresenterHandle *, double time_seconds);
+char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
+```
+
+Every returned string is owned by Erika and must be released with
+`erika_string_free`. `poll_event_json` returns `NULL` — not an envelope — when
+no event is pending, so a `NULL` return is the idle case, not an error.
+
+All three wrap their result in an envelope:
+
+```json
+{ "ok": true,  "status": 0, "value": <result> }
+{ "ok": false, "status": 1, "error": "<message>" }
+```
+
+`arguments_json` must be a JSON object. `method` selects the operation and
+mirrors the C entry points: `open`, `play`, `pause`, `stop`, `close`, `seek`,
+`setPlaybackRate`, `setVolume`, `setUpscaler`, `setSubtitleScale`,
+`getUpscalerStatus`, `getOutputStatus`, `getPresenterStats`, `tracks`,
+`addExternalSubtitle`, `removeSubtitleTrack`, `selectAudioTrack`,
+`selectSubtitleTrack`, and the danmaku family (`loadDanmakuFile`,
+`loadDanmakuJson`, `addDanmakuTrackFile`, `addDanmakuTrackJson`,
+`removeDanmakuTrack`, `setDanmakuTrackEnabled`, `setDanmakuTrackOffset`,
+`setDanmakuGlobalOffset`, `danmakuTracks`, `clearDanmaku`, `setDanmakuEnabled`,
+`setDanmakuConfig`). An unknown method fails with `ok: false` rather than
+aborting. The authoritative dispatch table is
+`crates/erika_capi/src/presenter_json.rs`.
+
+The bridge is a convenience layer, not a second API: it calls the same
+functions documented above and carries no extra capability. Hosts that can pass
+structs across their platform channel should prefer the typed entry points.
 
 ### Diagnostics and capture
 

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -349,6 +349,7 @@ Android extended-linear 应把 Flutter Hybrid Composition `SurfaceView` 对应�
 
 ```c
 ErikaStatus erika_presenter_render_tick(ErikaPresenterHandle *, double time_seconds, ErikaPresenterStats *out_stats);
+ErikaStatus erika_presenter_get_stats(ErikaPresenterHandle *, ErikaPresenterStats *out_stats);
 ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_event);
 ```
 
@@ -356,6 +357,45 @@ ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_e
 帧调度器）。`time_seconds` 是该帧的宿主显示时钟（秒）——Erika 用它做 vsync 量化调度，
 所以传**呈现时间戳**，不是 wall-clock 增量。若 `out_stats` 非 `NULL`，会填入流水线
 计数器快照。`poll_event` 非阻塞，空闲时返回 `NoEvent`。
+
+`get_stats` 填入同样的 `ErikaPresenterStats` 快照，但不渲染帧。当宿主采样计数器的
+节奏与显示循环不同时用它；它不推进呈现。
+
+### JSON 桥
+
+对于平台通道本身就在序列化结构化参数的嵌入方（例如 HarmonyOS ArkTS 插件），
+同一套 presenter 接口也以 JSON 形式提供：
+
+```c
+char *erika_presenter_invoke_json(ErikaPresenterHandle *, const char *method,
+                                  const char *arguments_json);
+char *erika_presenter_render_tick_json(ErikaPresenterHandle *, double time_seconds);
+char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
+```
+
+返回的字符串归 Erika 所有，必须用 `erika_string_free` 释放。`poll_event_json`
+在无事件时返回 `NULL`——不是信封——所以 `NULL` 表示空闲而非错误。
+
+三者的返回值都包在同一层信封里：
+
+```json
+{ "ok": true,  "status": 0, "value": <result> }
+{ "ok": false, "status": 1, "error": "<message>" }
+```
+
+`arguments_json` 必须是 JSON 对象。`method` 选择操作，与 C 入口一一对应：
+`open`、`play`、`pause`、`stop`、`close`、`seek`、`setPlaybackRate`、`setVolume`、
+`setUpscaler`、`setSubtitleScale`、`getUpscalerStatus`、`getOutputStatus`、
+`getPresenterStats`、`tracks`、`addExternalSubtitle`、`removeSubtitleTrack`、
+`selectAudioTrack`、`selectSubtitleTrack`，以及弹幕系列（`loadDanmakuFile`、
+`loadDanmakuJson`、`addDanmakuTrackFile`、`addDanmakuTrackJson`、
+`removeDanmakuTrack`、`setDanmakuTrackEnabled`、`setDanmakuTrackOffset`、
+`setDanmakuGlobalOffset`、`danmakuTracks`、`clearDanmaku`、`setDanmakuEnabled`、
+`setDanmakuConfig`）。未知 method 返回 `ok: false`，不会中止。权威分发表见
+`crates/erika_capi/src/presenter_json.rs`。
+
+这层桥只是便利封装，不是第二套 API：它调用的就是上面这些函数，没有额外能力。
+能在平台通道上传结构体的宿主应优先用类型化入口。
 
 ### 诊断与截图
 

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -53,6 +53,24 @@ FP16 extended-linear scRGB は `Rgba16Float` negotiation と
 GLES、`TextureView`、FP16 不在、dataspace verification failure では SDR playback を継続し、
 query 可能な fallback reason と明示的な log を提供します。
 
+## HarmonyOS Surface Strategies
+
+HarmonyOS では `ErikaVideoView` を使います。ArkTS plugin が Flutter external
+texture を登録し、その texture の surface を `OHNativeWindow` として取得して
+presenter に attach します。wgpu はその上で Vulkan 描画を行い、window system
+integration には `VK_OHOS_surface` を使います。
+
+video decode の既定は HarmonyOS AVCodec（H.264 / HEVC）です。AVCodec は Surface に
+直接 decode し、その `OHNativeBuffer` を Vulkan external image として import して
+Vulkan YCbCr sampler で解決するため、decode したフレームは CPU コピーなしで
+compositor に届きます。字幕・danmaku・overlay は他 platform と同じ wgpu pass で
+合成されます。
+
+必要な Vulkan extension が無い端末は FFmpeg software decode と CPU upload に
+fallback します。fallback は再生を失敗させず、`VideoDecoderChanged` event と
+presenter diagnostics から報告されます。HarmonyOS path は実機で検証済みですが、
+CI では未カバーです。
+
 ## iOS Build Path
 
 iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を app にリンクし、対象 iOS architecture 向けに Rust の `erika_capi` crate をビルドします。

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -75,6 +75,24 @@ API 35 HDR device. Unsupported displays, GLES, `TextureView`, missing FP16, or
 dataspace verification failures continue in SDR with a queryable fallback
 reason and explicit logs.
 
+## HarmonyOS Surface Strategies
+
+On HarmonyOS, use `ErikaVideoView`. The ArkTS plugin registers a Flutter
+external texture, takes that texture's surface as an `OHNativeWindow`, and
+attaches it to the presenter; wgpu then renders through Vulkan, using
+`VK_OHOS_surface` for window-system integration.
+
+Video decoding defaults to HarmonyOS AVCodec (H.264 and HEVC). AVCodec decodes
+straight into a Surface, whose `OHNativeBuffer` is imported as a Vulkan
+external image and resolved by a Vulkan YCbCr sampler, so decoded frames reach
+the compositor with no CPU copy. Subtitles, danmaku, and overlays composite in
+the same wgpu pass as every other platform.
+
+Devices missing the required Vulkan extensions fall back to FFmpeg software
+decode with CPU upload. The fallback is reported through `VideoDecoderChanged`
+events and presenter diagnostics instead of failing playback. The HarmonyOS
+path is validated on device but is not yet covered by CI.
+
 ## iOS Build Path
 
 The iOS plugin links the Erika C ABI static library into the app through a

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -50,6 +50,21 @@ FP16 extended-linear scRGB 已实现完整的 `Rgba16Float` 协商和
 HDR 真机。显示器不支持 HDR、GLES、`TextureView`、缺少 FP16 或 dataspace 验证失败时都会
 继续 SDR 播放，并提供可查询的 fallback reason 和明确日志。
 
+## HarmonyOS Surface Strategies
+
+HarmonyOS 上请使用 `ErikaVideoView`。ArkTS 插件注册 Flutter 外部纹理，把该纹理的
+surface 取为 `OHNativeWindow` 并 attach 给 presenter；wgpu 随后通过 Vulkan 渲染，
+窗口系统集成走 `VK_OHOS_surface`。
+
+视频解码默认使用 HarmonyOS AVCodec（H.264 与 HEVC）。AVCodec 直接解码到 Surface，
+其 `OHNativeBuffer` 作为 Vulkan 外部图像导入，并由 Vulkan YCbCr sampler 解析，
+因此解码帧无需 CPU 拷贝即可到达合成器。字幕、弹幕和 overlay 与其他平台一样，
+在同一个 wgpu pass 里合成。
+
+缺少所需 Vulkan 扩展的设备回退到 FFmpeg 软解 + CPU 上传。回退通过
+`VideoDecoderChanged` 事件和 presenter 诊断上报，而不是让播放失败。HarmonyOS
+路径已在真机验证，但尚未纳入 CI。
+
 ## iOS Build Path
 
 iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进 app，并为目标 iOS architecture 构建 Rust `erika_capi` crate。

--- a/packages/erika_flutter/README.ja.md
+++ b/packages/erika_flutter/README.ja.md
@@ -12,6 +12,7 @@ Erika メディア再生エンジン向けの Flutter plugin です。
 - iOS plugin は Erika の static library を link します。
 - Windows plugin は Erika C ABI DLL を build して link します。
 - Android plugin は ABI ごとに `liberika_capi.so` を build し、`Choreographer` から native surface を駆動します。
+- HarmonyOS plugin は Flutter external texture を登録し、その `OHNativeWindow` を Erika に attach して、OHAudio で低レイテンシの PCM 出力を行います。
 - Erika は `ErikaPresenterHandle` を通じて playback、rendering、audio、timing、overlay を担当します。
 
 ## Video Surfaces
@@ -67,6 +68,24 @@ API 34+ では plugin が `Display.registerHdrSdrRatioChangedListener` を監視
 change を Erika に publish します。wgpu は surface を reattach せず後続 frame target と
 output status を更新します。API 35 では host の global Window を変更せず、`SurfaceView`
 ごとに desired HDR headroom も設定します。
+
+## HarmonyOS Setup
+
+HarmonyOS module には DevEco Studio の OpenHarmony Native SDK と Rust の
+`aarch64-unknown-linux-ohos` target が必要です。Hvigor/CMake build が LGPL の
+FFmpeg/zlib 依存と `liberika_capi.so` を compile し、その runtime を
+`liberika_flutter.so` と一緒に package します。
+
+HarmonyOS では `ErikaVideoView` を使ってください。Flutter external texture を登録し、
+その texture surface を `OHNativeWindow` として取得して、wgpu Vulkan で描画します。
+音声は OHAudio の interleaved f32 PCM です。
+
+video decode は既定で HarmonyOS AVCodec の hardware decode（H.264 / HEVC）です。
+AVCodec は Surface に描画し、その `OHNativeBuffer` を Vulkan external image として
+import して Vulkan YCbCr sampler で解決するため、フレームは CPU コピーなしで
+compositor に届きます。必要な Vulkan extension を持たない端末は FFmpeg software
+decode と CPU upload に fallback します。fallback は再生を失敗させず、
+`VideoDecoderChanged` event と presenter diagnostics から報告されます。
 
 ## HTTP ヘッダー
 

--- a/packages/erika_flutter/README.md
+++ b/packages/erika_flutter/README.md
@@ -125,10 +125,16 @@ LGPL FFmpeg/zlib dependencies and `liberika_capi.so`, then packages that runtime
 alongside `liberika_flutter.so`.
 
 Use `ErikaVideoView` on HarmonyOS. It registers a Flutter external texture,
-obtains the texture surface as an `OHNativeWindow`, and renders through
-wgpu/OpenGL ES. Audio uses OHAudio with interleaved f32 PCM. The current
-HarmonyOS path uses FFmpeg software decoding; AVCodec hardware decoding is not
-yet enabled.
+obtains the texture surface as an `OHNativeWindow`, and renders through wgpu
+Vulkan. Audio uses OHAudio with interleaved f32 PCM.
+
+Video decoding defaults to HarmonyOS AVCodec hardware decoding for H.264 and
+HEVC. AVCodec renders into a Surface whose `OHNativeBuffer` is imported as a
+Vulkan external image and resolved with a Vulkan YCbCr sampler, so frames reach
+the compositor without a CPU copy. Devices that do not expose the required
+Vulkan extensions fall back to FFmpeg software decoding and CPU upload; the
+fallback is reported through `VideoDecoderChanged` events and the presenter
+diagnostics rather than failing playback.
 
 ## HTTP Headers
 

--- a/packages/erika_flutter/README.zh.md
+++ b/packages/erika_flutter/README.zh.md
@@ -12,6 +12,7 @@ Erika 媒体播放引擎的 Flutter plugin。
 - iOS 插件链接 Erika 静态库。
 - Windows 插件构建并链接 Erika C ABI DLL。
 - Android 插件按 ABI 构建 `liberika_capi.so`，并由 `Choreographer` 驱动原生 surface。
+- HarmonyOS 插件注册 Flutter 外部纹理，把它的 `OHNativeWindow` attach 给 Erika，并用 OHAudio 做低延迟 PCM 输出。
 - Erika 通过 `ErikaPresenterHandle` 负责播放、渲染、音频、时序和 overlay。
 
 ## Video Surfaces
@@ -66,6 +67,22 @@ Android 最低版本仍为 API 26。Extended-linear 还要求 native-window data
 `Display.registerHdrSdrRatioChangedListener`，把真实 ratio 变化发布给 Erika，让 wgpu 无需
 重新 attach surface 就能更新后续帧 target 和输出状态。API 35 上插件还会按
 `SurfaceView` 设置 desired HDR headroom，不修改宿主的全局 Window。
+
+## HarmonyOS Setup
+
+HarmonyOS 模块需要 DevEco Studio 的 OpenHarmony Native SDK 和 Rust 的
+`aarch64-unknown-linux-ohos` target。它的 Hvigor/CMake 构建会编译 LGPL 的
+FFmpeg/zlib 依赖和 `liberika_capi.so`，然后把这套运行时和 `liberika_flutter.so`
+一起打包。
+
+HarmonyOS 上请使用 `ErikaVideoView`。它注册 Flutter 外部纹理，把纹理 surface 取为
+`OHNativeWindow`，并通过 wgpu Vulkan 渲染。音频走 OHAudio，交错 f32 PCM。
+
+视频解码默认使用 HarmonyOS AVCodec 硬解，支持 H.264 和 HEVC。AVCodec 渲染到
+Surface，其 `OHNativeBuffer` 作为 Vulkan 外部图像导入，再由 Vulkan YCbCr sampler
+解析，因此帧无需 CPU 拷贝即可到达合成器。不具备所需 Vulkan 扩展的设备回退到
+FFmpeg 软解 + CPU 上传；回退会通过 `VideoDecoderChanged` 事件和 presenter 诊断
+上报，而不是让播放失败。
 
 ## HTTP 请求头
 

--- a/readme/README.en.md
+++ b/readme/README.en.md
@@ -15,19 +15,19 @@ The host application provides a rendering surface and sends playback commands â€
 
 ## Features
 
-- **Hardware-accelerated decoding** -- VideoToolbox (macOS/iOS), D3D11VA (Windows), and MediaCodec (Android), with explicit software-decode fallback when interop is unavailable
-- **Zero-copy rendering** -- CVPixelBuffer to MTLTexture (Apple), D3D11VA texture interop (Windows), and MediaCodec Surface to AHardwareBuffer/Vulkan (Android), with explicit CPU-upload fallback when import fails
+- **Hardware-accelerated decoding** -- VideoToolbox (macOS/iOS), D3D11VA (Windows), MediaCodec (Android), and AVCodec (HarmonyOS), with explicit software-decode fallback when interop is unavailable
+- **Zero-copy rendering** -- CVPixelBuffer to MTLTexture (Apple), D3D11VA texture interop (Windows), MediaCodec Surface to AHardwareBuffer/Vulkan (Android), and AVCodec Surface to OHNativeBuffer/Vulkan (HarmonyOS), with explicit CPU-upload fallback when import fails
 - **HDR/EDR output** -- Apple EDR, Windows HDR10, and Android FP16 extended-linear scRGB negotiation with explicit SDR fallback
 - **Native Metal renderer** -- YCbCr sampling, color space conversion, tone mapping, subtitle/danmaku compositing in a single render pass (macOS/iOS)
 - **Native Direct3D 11 renderer** -- Windows: D3D11VA zero-copy texture interop, YCbCr sampling, HDR10 output, subtitle/danmaku overlay compositing
 - **Neural upscaling** -- ArtCNN anime luma 2x super-resolution using Metal and wgpu/Vulkan compute, integrated into the rendering pipeline
-- **Audio output** -- CoreAudio (macOS) / AudioQueue (iOS) / WASAPI (Windows) / AAudio (Android), f32 PCM ring buffer, audio clock synchronization
+- **Audio output** -- CoreAudio (macOS) / AudioQueue (iOS) / WASAPI (Windows) / AAudio (Android) / OHAudio (HarmonyOS), f32 PCM ring buffer, audio clock synchronization
 - **Subtitles** -- SRT / WebVTT / ASS parsing, libass rendering (statically linked), embedded and external subtitle tracks
 - **Danmaku** -- Bilibili XML / JSON parsing, DFM+ collision-aware lane layout engine, glyph atlas native GPU rendering
 - **Playback engine** -- play / pause / stop / seek / rate control, audio-master clock discipline, vsync-quantized frame scheduling
-- **C ABI** -- 75 exported functions, opaque handle design, callable from C / C++ / Swift / Dart FFI / any FFI-capable language
-- **Flutter plugin** -- macOS + iOS + Windows + Android native view embedding with platform-native high-dynamic-range surface paths
-- **wgpu backend** -- Android playback, overlays, capture, and bounded Vulkan/GLES recovery are available; Linux remains planned
+- **C ABI** -- 79 exported functions, opaque handle design, callable from C / C++ / Swift / Dart FFI / any FFI-capable language
+- **Flutter plugin** -- macOS + iOS + Windows + Android + HarmonyOS native view/Texture embedding with platform-native high-dynamic-range surface paths
+- **wgpu backend** -- Android playback, overlays, capture, and bounded Vulkan/GLES recovery are available; HarmonyOS runs on Vulkan, presenting through OHNativeWindow with OHNativeBuffer zero-copy import; Linux remains planned
 
 ## Quick Start
 
@@ -90,6 +90,7 @@ Header: [`crates/erika_capi/include/erika.h`](crates/erika_capi/include/erika.h)
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | **Available** |
 | Linux | -- | wgpu (planned) | -- | Planned |
 | Android 8+ | MediaCodec / software | wgpu (Vulkan + GLES fallback) | AAudio | **Available**; SDR verified, extended-linear scRGB implemented, API 35 HDR-device active-path acceptance pending |
+| HarmonyOS API 18+ | AVCodec (H.264/HEVC) / software | wgpu (Vulkan) + `OHNativeBuffer` zero-copy import | OHAudio | **Available**; validated on device, not yet covered by CI |
 
 ## Repository Structure
 
@@ -97,7 +98,7 @@ Header: [`crates/erika_capi/include/erika.h`](crates/erika_capi/include/erika.h)
 crates/erika              Core playback library
 crates/erika_capi         C ABI export layer
 crates/erika_ffmpeg_sys   Low-level FFmpeg bindings
-packages/erika_flutter    Flutter plugin (macOS + iOS + Windows + Android)
+packages/erika_flutter    Flutter plugin (macOS + iOS + Windows + Android + HarmonyOS)
 examples/                 Validation and demo programs
 xtask/                    Native dependency build orchestration
 docs/                     Architecture and embedding documentation
@@ -121,6 +122,7 @@ docs/                     Architecture and embedding documentation
 - Xcode Command Line Tools (macOS/iOS)
 - MSVC toolchain + Windows SDK (Windows, target `x86_64-pc-windows-msvc`)
 - Android SDK + NDK r29 and the corresponding Android Rust targets
+- DevEco Studio OpenHarmony Native SDK and the Rust `aarch64-unknown-linux-ohos` target
 - CMake, pkg-config
 
 ### Build Native Dependencies

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -15,19 +15,19 @@
 
 ## 機能
 
-- **ハードウェアアクセラレーション** -- VideoToolbox (macOS/iOS)、D3D11VA (Windows)、MediaCodec (Android)。相互運用不可時は明示的に software decode へ fallback
-- **ゼロコピーレンダリング** -- CVPixelBuffer → MTLTexture (Apple)、D3D11VA texture interop (Windows)、MediaCodec Surface → AHardwareBuffer/Vulkan (Android)。import 失敗時は明示的に CPU upload へ fallback
+- **ハードウェアアクセラレーション** -- VideoToolbox (macOS/iOS)、D3D11VA (Windows)、MediaCodec (Android)、AVCodec (HarmonyOS)。相互運用不可時は明示的に software decode へ fallback
+- **ゼロコピーレンダリング** -- CVPixelBuffer → MTLTexture (Apple)、D3D11VA texture interop (Windows)、MediaCodec Surface → AHardwareBuffer/Vulkan (Android)、AVCodec Surface → OHNativeBuffer/Vulkan (HarmonyOS)。import 失敗時は明示的に CPU upload へ fallback
 - **HDR/EDR 出力** -- Apple EDR、Windows HDR10、Android FP16 extended-linear scRGB negotiation と明示的な SDR fallback
 - **Metal ネイティブレンダラー** -- YCbCr サンプリング、色空間変換、トーンマッピング、字幕/弾幕合成を単一レンダーパスで実行 (macOS/iOS)
 - **Direct3D 11 ネイティブレンダラー** -- Windows: D3D11VA ゼロコピーテクスチャ相互運用、YCbCr サンプリング、HDR10 出力、字幕/弾幕 overlay 合成
 - **ニューラル超解像** -- ArtCNN によるアニメ輝度 2x 超解像。Metal と wgpu/Vulkan compute で render pipeline に統合
-- **音声出力** -- CoreAudio (macOS) / AudioQueue (iOS) / WASAPI (Windows) / AAudio (Android)、f32 PCM リングバッファ、音声クロック同期
+- **音声出力** -- CoreAudio (macOS) / AudioQueue (iOS) / WASAPI (Windows) / AAudio (Android) / OHAudio (HarmonyOS)、f32 PCM リングバッファ、音声クロック同期
 - **字幕** -- SRT / WebVTT / ASS パーサー、libass レンダリング（静的リンク）、埋め込みおよび外部字幕トラック
 - **弾幕** -- Bilibili XML / JSON パーサー、DFM+ 衝突回避レーン配置エンジン、グリフアトラスによるネイティブ GPU レンダリング
 - **再生エンジン** -- play / pause / stop / seek / 再生速度制御、音声マスタークロック同期、vsync 量子化フレームスケジューリング
-- **C ABI** -- 75 のエクスポート関数、不透明ハンドル設計、C / C++ / Swift / Dart FFI / 任意の FFI 対応言語から呼び出し可能
-- **Flutter プラグイン** -- macOS + iOS + Windows + Android の native view embedding と platform-native high-dynamic-range surface path
-- **wgpu バックエンド** -- Android の playback、overlay、capture、bounded Vulkan/GLES recovery は利用可能。Linux は引き続き計画中
+- **C ABI** -- 79 のエクスポート関数、不透明ハンドル設計、C / C++ / Swift / Dart FFI / 任意の FFI 対応言語から呼び出し可能
+- **Flutter プラグイン** -- macOS + iOS + Windows + Android + HarmonyOS の native view / Texture embedding と platform-native high-dynamic-range surface path
+- **wgpu バックエンド** -- Android の playback、overlay、capture、bounded Vulkan/GLES recovery は利用可能。HarmonyOS は Vulkan で動作し、OHNativeWindow で present して OHNativeBuffer を zero-copy import します。Linux は引き続き計画中
 
 ## クイックスタート
 
@@ -90,6 +90,7 @@ ErikaVideoView(player: player)
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | **利用可能** |
 | Linux | -- | wgpu (計画中) | -- | 計画中 |
 | Android 8+ | MediaCodec / software | wgpu (Vulkan + GLES fallback) | AAudio | **利用可能**。SDR は検証済み、extended-linear scRGB は実装済み、API 35 HDR 実機の active path acceptance 待ち |
+| HarmonyOS API 18+ | AVCodec (H.264/HEVC) / software | wgpu (Vulkan) + `OHNativeBuffer` zero-copy import | OHAudio | **利用可能**。実機で検証済み、CI は未カバー |
 
 ## リポジトリ構成
 
@@ -97,7 +98,7 @@ ErikaVideoView(player: player)
 crates/erika              コア再生ライブラリ
 crates/erika_capi         C ABI エクスポート層
 crates/erika_ffmpeg_sys   FFmpeg 低レベルバインディング
-packages/erika_flutter    Flutter プラグイン (macOS + iOS + Windows + Android)
+packages/erika_flutter    Flutter プラグイン (macOS + iOS + Windows + Android + HarmonyOS)
 examples/                 検証・デモプログラム
 xtask/                    ネイティブ依存関係ビルドオーケストレーション
 docs/                     アーキテクチャと組み込みドキュメント
@@ -121,6 +122,7 @@ docs/                     アーキテクチャと組み込みドキュメント
 - Xcode Command Line Tools (macOS/iOS)
 - MSVC ツールチェーン + Windows SDK (Windows、ターゲット `x86_64-pc-windows-msvc`)
 - Android SDK + NDK r29 と対象 Android ABI の Rust target
+- DevEco Studio OpenHarmony Native SDK と Rust の `aarch64-unknown-linux-ohos` target
 - CMake, pkg-config
 
 ### ネイティブ依存関係のビルド


### PR DESCRIPTION
## 背景

#59 落地了 HarmonyOS AVCodec 硬件解码，但随之合入的文档描述的是该分支**早期只有软解时**的状态，而且每处只覆盖了一种语言。这个 PR 只改文档，不动代码。

## 1. 修正与代码矛盾的描述

有两处文档在说「鸿蒙走软解、AVCodec 尚未启用」，但 `crates/erika/src/playback.rs:534` 里 `VideoDecodePreference::default()` 在 `target_env = "ohos"` 下返回的就是 `AvCodec`：

| 位置 | 原文 | 实际 |
|---|---|---|
| `README.md:93` | `HarmonyOS API 18+ \| FFmpeg software \| wgpu (OpenGL ES)` | AVCodec 硬解 + Vulkan |
| `README.md:30` | 「HarmonyOS 使用 OHNativeWindow/OpenGL ES」 | Vulkan + `OHNativeBuffer` 零拷贝导入 |
| `packages/erika_flutter/README.md` | "AVCodec hardware decoding is not yet enabled" | 默认即 AVCodec |

## 2. 导出函数计数 75 → 79

`docs/architecture.{md,zh,ja}` 和三个根 README 都写着 75。实际交叉核对结果：

- `crates/erika_capi/include/erika.h` 声明 **79** 个 `erika_*` 符号
- `erika_capi` 实现 **79** 个 `pub extern "C" fn`
- 两者双向零漂移（头文件本身维护得很干净，只是文档里这个手写数字没跟上）

79 = 原先的 75 + #59 新增的 4 个。

## 3. 补齐新增 C API 文档

#59 新增了 4 个公开函数，`capi_reference` 三语此前**一处提及都没有**：

- `erika_presenter_get_stats` — 不渲染帧地取同一份 `ErikaPresenterStats` 快照
- `erika_presenter_invoke_json` / `render_tick_json` / `poll_event_json` — JSON 桥

文档按 `crates/erika_capi/src/presenter_json.rs` 的实现写，含响应信封格式、`erika_string_free` 所有权、`poll_event_json` 空闲时返回 `NULL`（而非信封）这个易踩点，以及完整 method 列表。

## 4. 三语对齐

此前覆盖是割裂的，方向还相反：

| 内容 | 中 | 英 | 日 |
|---|:-:|:-:|:-:|
| 根 README 鸿蒙 | ✅ | ❌ | ❌ |
| `docs/building` | ✅ | ❌ | ❌ |
| 插件 README | ❌ | ✅ | ❌ |
| `architecture` / `flutter_embedding` / `capi_reference` | ❌ | ❌ | ❌ |

现在 18 个文件全部覆盖：平台支持表、surface handle 模型、解码后端列表、Flutter 插件列表、构建前置条件、`## HarmonyOS Surface Strategies` 小节。

顺带修了两个既有疏漏：`architecture` 的解码/音频摘要行原本连 MediaCodec 和 AAudio 都没列；zh/ja 的 Decoder 段落还停在「只有 VideoToolbox」。

平台版本号统一用仓库既有的 `HarmonyOS API 18+`。

## 未包含

- `docs/architecture.*` 的 Audio Output 小节目前只写了 macOS / iOS，连 Windows 和 Android 都没有。只补一个 OHOS 会更不协调，建议单开一次「补全成五平台」。
- CI 没有 OHOS job、`[patch.crates-io]` 在升 wgpu 时会静默失效（cargo 只 warn 不 error，会 fallback 回 registry 版本从而丢掉 `VK_OHOS_surface`）——这两个要动 CI 和构建约束，不适合混进文档 PR。

## 验证

- 纯文档改动，无代码变更
- 表格列数、代码围栏一致性已校验
- 全仓库扫描确认无 `75 exported` / `wgpu (OpenGL ES)` / `AVCodec ... not yet enabled` 残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)