### PR TITLE
docs: record follow-up performance work

### DIFF
--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -2716,6 +2716,9 @@ impl WgpuRenderer {
             let start = index * stride;
             bytes[start..start + uniform_size].copy_from_slice(bytemuck::bytes_of(uniform));
         }
+        // TODO(perf): retain a growable per-frame uniform buffer and update it via
+        // `Queue::write_buffer` (or a small ring) instead of allocating a new GPU
+        // buffer for every danmaku frame. Keep `stride` device-aligned when reusing it.
         let uniform_buffer = self
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/crates/erika/src/source.rs
+++ b/crates/erika/src/source.rs
@@ -918,6 +918,9 @@ impl MediaSource for HttpRangeSource {
         // servers close a HEAD connection without an explicit Connection
         // header; reusing that stale socket for the first GET otherwise
         // surfaces as `Peer disconnected`.
+        // TODO(perf): cache a dedicated metadata agent on `HttpRangeSource` so
+        // repeated `len()` probes without Content-Length do not rebuild the TLS
+        // client, while still keeping HEAD sockets out of the range-request pool.
         let head_agent = http_agent();
         let mut attempt = 0u32;
         let head_error = loop {


### PR DESCRIPTION
## Summary

- document the planned reuse of the batched danmaku dynamic uniform buffer
- document caching a dedicated HTTP metadata agent for repeated length probes

## Why

PR #59 intentionally keeps these paths simple and correct, but both contain clear follow-up performance opportunities. Keeping the TODOs beside the allocation sites preserves the constraints that future implementations must maintain: device-aligned dynamic offsets and isolation between HEAD and range-request connection pools.

## Impact

Comments only; runtime behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
