### PR TITLE
ci: verify OpenHarmony builds and wgpu patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Check license policy
         run: cargo run --locked -p xtask -- check license
+      - name: Verify vendored Cargo patches
+        run: cargo run --locked -p xtask -- check cargo-patches
       - name: Get Flutter dependencies
         working-directory: packages/erika_flutter
         run: flutter pub get

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -1,0 +1,136 @@
+name: OpenHarmony
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".cargo/**"
+      - ".github/workflows/ohos.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "packages/erika_flutter/ohos/**"
+      - "third_party/patches/**"
+      - "third_party/wgpu-hal/**"
+      - "xtask/**"
+  push:
+    branches: [main]
+    paths:
+      - ".cargo/**"
+      - ".github/workflows/ohos.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "packages/erika_flutter/ohos/**"
+      - "third_party/patches/**"
+      - "third_party/wgpu-hal/**"
+      - "xtask/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ohos-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  ERIKA_NATIVE_PROFILE: lgpl
+  ERIKA_NATIVE_TARGET: aarch64-unknown-linux-ohos
+  OHOS_COMPATIBLE_SDK_VERSION: "18"
+
+jobs:
+  native:
+    name: OpenHarmony native (arm64)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-ohos
+      - name: Setup OpenHarmony SDK
+        id: ohos_sdk
+        uses: openharmony-rs/setup-ohos-sdk@b312caf8a43bb836aa24c08f65f97e1f09a89cad # v1.0.1
+        with:
+          version: "5.1.0"
+          components: native
+          cache: true
+      - name: Install native build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake make ninja-build pkg-config
+      - name: Configure OpenHarmony toolchain
+        env:
+          NATIVE_ROOT: ${{ steps.ohos_sdk.outputs.ohos_sdk_native }}
+        run: |
+          set -euo pipefail
+          test -x "$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
+          test -x "$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang++"
+          test -f "$NATIVE_ROOT/build/cmake/ohos.toolchain.cmake"
+          {
+            echo "OHOS_NDK_HOME=$NATIVE_ROOT"
+            echo "OHOS_SDK_NATIVE=$NATIVE_ROOT"
+            echo "LIBCLANG_PATH=$NATIVE_ROOT/llvm/lib"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
+            echo "CC_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
+            echo "CXX_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang++"
+            echo "AR_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/llvm-ar"
+          } >> "$GITHUB_ENV"
+      - name: Cache native dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            third_party/cache
+            third_party/src
+            third_party/build/${{ env.ERIKA_NATIVE_TARGET }}/${{ env.ERIKA_NATIVE_PROFILE }}
+            third_party/dist/${{ env.ERIKA_NATIVE_TARGET }}/${{ env.ERIKA_NATIVE_PROFILE }}
+          key: native-v1-ohos-${{ env.ERIKA_NATIVE_TARGET }}-api${{ env.OHOS_COMPATIBLE_SDK_VERSION }}-${{ hashFiles('xtask/src/main.rs', 'third_party/patches/**') }}
+      - name: Build OpenHarmony native dependencies
+        run: >-
+          cargo run --locked -p xtask -- deps build
+          --profile "$ERIKA_NATIVE_PROFILE"
+          --target "$ERIKA_NATIVE_TARGET"
+      - name: Build OpenHarmony C API
+        run: >-
+          cargo build --locked -p erika_capi --release
+          --target "$ERIKA_NATIVE_TARGET"
+          --no-default-features --features wgpu
+      - name: Build OpenHarmony Flutter native bridge
+        run: |
+          set -euo pipefail
+          cmake -S packages/erika_flutter/ohos/src/main/cpp \
+            -B target/ohos-plugin-ci \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="$OHOS_SDK_NATIVE/build/cmake/ohos.toolchain.cmake" \
+            -DOHOS_ARCH=arm64-v8a \
+            -DOHOS_SDK_NATIVE="$OHOS_SDK_NATIVE"
+          cmake --build target/ohos-plugin-ci --target erika_flutter_plugin
+      - name: Verify OpenHarmony ELF and ABI
+        run: |
+          set -euo pipefail
+          library="target/$ERIKA_NATIVE_TARGET/release/liberika_capi.so"
+          readelf="$OHOS_SDK_NATIVE/llvm/bin/llvm-readelf"
+          nm="$OHOS_SDK_NATIVE/llvm/bin/llvm-nm"
+          test -f "$library"
+          "$readelf" -h "$library" | grep -Eq 'Machine:.*AArch64'
+          "$readelf" -d "$library" | grep -Eq '\(SONAME\).*liberika_capi\.so'
+          symbols="$($nm --dynamic --defined-only "$library" | awk '{print $NF}')"
+          for symbol in \
+            erika_presenter_invoke_json \
+            erika_presenter_render_tick_json \
+            erika_presenter_poll_event_json
+          do
+            grep -Fxq "$symbol" <<< "$symbols"
+          done
+          find target/ohos-plugin-ci -type f -name 'liberika_flutter.so' -print -quit | grep -q .
+      - name: Upload OpenHarmony native libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: erika-capi-openharmony-arm64
+          path: |
+            target/aarch64-unknown-linux-ohos/release/liberika_capi.so
+            target/ohos-plugin-ci/**/liberika_flutter.so
+          if-no-files-found: error

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -69,10 +69,16 @@ jobs:
           test -x "$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
           test -x "$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang++"
           test -f "$NATIVE_ROOT/build/cmake/ohos.toolchain.cmake"
+          cxx_include="$NATIVE_ROOT/llvm/include/libcxx-ohos/include/c++/v1"
+          if [[ ! -f "$cxx_include/vector" ]]; then
+            cxx_include="$NATIVE_ROOT/llvm/include/c++/v1"
+          fi
+          test -f "$cxx_include/vector"
           {
             echo "OHOS_NDK_HOME=$NATIVE_ROOT"
             echo "OHOS_SDK_NATIVE=$NATIVE_ROOT"
             echo "LIBCLANG_PATH=$NATIVE_ROOT/llvm/lib"
+            echo "BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_ohos=--target=aarch64-unknown-linux-ohos --sysroot=$NATIVE_ROOT/sysroot -isystem $cxx_include"
             echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
             echo "CC_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang"
             echo "CXX_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang++"

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.93.0
         with:
           targets: aarch64-unknown-linux-ohos
       - name: Setup OpenHarmony SDK
@@ -84,8 +84,9 @@ jobs:
             echo "CXX_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/aarch64-unknown-linux-ohos-clang++"
             echo "AR_aarch64_unknown_linux_ohos=$NATIVE_ROOT/llvm/bin/llvm-ar"
           } >> "$GITHUB_ENV"
-      - name: Cache native dependencies
-        uses: actions/cache@v4
+      - name: Restore native dependencies
+        id: native-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             third_party/cache
@@ -98,6 +99,16 @@ jobs:
           cargo run --locked -p xtask -- deps build
           --profile "$ERIKA_NATIVE_PROFILE"
           --target "$ERIKA_NATIVE_TARGET"
+      - name: Save native dependencies
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            third_party/cache
+            third_party/src
+            third_party/build/${{ env.ERIKA_NATIVE_TARGET }}/${{ env.ERIKA_NATIVE_PROFILE }}
+            third_party/dist/${{ env.ERIKA_NATIVE_TARGET }}/${{ env.ERIKA_NATIVE_PROFILE }}
+          key: ${{ steps.native-cache.outputs.cache-primary-key }}
       - name: Build OpenHarmony C API
         run: >-
           cargo build --locked -p erika_capi --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ name = "xtask"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "serde_json",
  "sha2",
  "ureq",
 ]

--- a/crates/erika/Cargo.toml
+++ b/crates/erika/Cargo.toml
@@ -29,7 +29,7 @@ smallvec.workspace = true
 soundtouch.workspace = true
 thiserror.workspace = true
 ureq.workspace = true
-wgpu = { version = "29.0.3", optional = true }
+wgpu = { version = "=29.0.3", optional = true }
 pollster = { version = "0.4.0", optional = true }
 bytemuck = { version = "1.25.0", features = ["derive"], optional = true }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,4 +9,5 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 sha2.workspace = true
+serde_json.workspace = true
 ureq.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -88,12 +88,95 @@ fn main() -> Result<()> {
 
 fn check(mut args: Vec<String>) -> Result<()> {
     if args.is_empty() {
-        bail!("missing check subcommand: license");
+        bail!("missing check subcommand: cargo-patches or license");
     }
     match args.remove(0).as_str() {
+        "cargo-patches" => check_cargo_patches(),
         "license" => check_license_policy(),
         other => bail!("unknown check subcommand: {other}"),
     }
+}
+
+fn check_cargo_patches() -> Result<()> {
+    let root = workspace_root()?;
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let output = Command::new(cargo)
+        .args([
+            "metadata",
+            "--locked",
+            "--format-version",
+            "1",
+            "--all-features",
+        ])
+        .arg("--manifest-path")
+        .arg(root.join("Cargo.toml"))
+        .output()
+        .context("run cargo metadata for patch verification")?;
+    if !output.status.success() {
+        bail!(
+            "cargo metadata failed while verifying patches ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("parse cargo metadata")?;
+    let packages = metadata["packages"]
+        .as_array()
+        .context("cargo metadata did not contain a packages array")?;
+    let resolved = packages
+        .iter()
+        .filter(|package| package["name"].as_str() == Some("wgpu-hal"))
+        .collect::<Vec<_>>();
+    if resolved.len() != 1 {
+        let versions = resolved
+            .iter()
+            .map(|package| {
+                format!(
+                    "{} ({})",
+                    package["version"].as_str().unwrap_or("unknown version"),
+                    package["source"].as_str().unwrap_or("path")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "expected exactly one resolved wgpu-hal package from the vendored patch, found {}: [{}]",
+            resolved.len(),
+            versions
+        );
+    }
+
+    let package = resolved[0];
+    if !package["source"].is_null() {
+        bail!(
+            "vendored wgpu-hal patch is inactive; Cargo resolved {} from {}",
+            package["version"].as_str().unwrap_or("unknown version"),
+            package["source"].as_str().unwrap_or("an unknown source")
+        );
+    }
+    let actual_manifest = package["manifest_path"]
+        .as_str()
+        .context("resolved wgpu-hal package has no manifest_path")?;
+    let actual_manifest = fs::canonicalize(actual_manifest)
+        .with_context(|| format!("canonicalize resolved wgpu-hal manifest {actual_manifest}"))?;
+    let expected_manifest = fs::canonicalize(root.join("third_party/wgpu-hal/Cargo.toml"))
+        .context("canonicalize vendored wgpu-hal manifest")?;
+    if actual_manifest != expected_manifest {
+        bail!(
+            "vendored wgpu-hal patch is inactive; expected {}, resolved {}",
+            expected_manifest.display(),
+            actual_manifest.display()
+        );
+    }
+
+    println!(
+        "cargo patch ok: wgpu-hal {} resolves from {}",
+        package["version"].as_str().unwrap_or("unknown version"),
+        expected_manifest.display()
+    );
+    Ok(())
 }
 
 fn deps(mut args: Vec<String>) -> Result<()> {
@@ -4888,5 +4971,6 @@ fn print_help() {
     println!(
         "  cargo run -p xtask -- deps build --profile lgpl [--target host|aarch64-apple-darwin|x86_64-apple-darwin|aarch64-apple-ios|aarch64-apple-ios-sim|x86_64-apple-ios|x86_64-pc-windows-msvc|aarch64-pc-windows-msvc|aarch64-linux-android|armv7-linux-androideabi|x86_64-linux-android|i686-linux-android] [--force] [--jobs N]"
     );
+    println!("  cargo run -p xtask -- check cargo-patches");
     println!("  cargo run -p xtask -- check license");
 }


### PR DESCRIPTION
## Summary

- add an OpenHarmony API 18 arm64 CI workflow that builds native dependencies, `erika_capi`, and the Flutter N-API bridge
- verify the resulting C API ELF architecture, SONAME, and JSON presenter ABI exports
- add `xtask check cargo-patches` and run it in the always-on Quality job
- pin `wgpu` exactly so upgrades must deliberately refresh the vendored `wgpu-hal`

## Why

HarmonyOS/OpenHarmony-specific Rust and native code previously had no CI compiler coverage. In addition, Cargo only warns when a `[patch.crates-io]` package stops matching the dependency graph, so a future wgpu upgrade could silently select the registry `wgpu-hal` and lose Erika's `VK_OHOS_surface` adaptation.

The new dependency-graph check requires exactly one resolved `wgpu-hal`, with no registry source and a manifest path equal to `third_party/wgpu-hal/Cargo.toml`. The OpenHarmony workflow uses the 5.1.0 native SDK (API 18), matching Erika's current compatibility target, and pins the SDK setup action to a full commit SHA.

## Impact

Relevant pull requests and pushes to `main` now cross-compile the actual OpenHarmony native libraries. Dependency-only upgrades fail early if the vendored wgpu patch is no longer active. Runtime behavior is unchanged.

This job validates compilation, linkage, and exported ABI. Device-only AVCodec, native-window, and Vulkan presentation behavior still requires a physical HarmonyOS/OpenHarmony smoke test.

## Validation

- `cargo test --locked -p xtask` (17 passed)
- `cargo run --locked -p xtask -- check license`
- `cargo run --locked -p xtask -- check cargo-patches`
- `cargo metadata --locked --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`
- parsed `.github/workflows/ohos.yml` with Ruby YAML
