### PR TITLE
fix(playback): stabilize Windows overlay and resume seeks

### DIFF
--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -415,6 +415,17 @@ impl Demuxer {
         let absolute_target =
             absolute_seek_target_micros(relative_target, self.timeline_origin_micros);
         let seek_stream = self.selected_video_seek_stream();
+        let selected_streams = match &self.selection {
+            StreamSelection::All => None,
+            StreamSelection::Only(streams) => Some(streams.iter().copied().collect::<Vec<_>>()),
+        };
+        let available_video_streams = self
+            .probe
+            .tracks
+            .iter()
+            .filter(|track| track.kind == TrackKind::Video)
+            .map(|track| track.id)
+            .collect::<Vec<_>>();
         let (stream_index, target) = seek_stream.map_or((-1, absolute_target), |stream_index| {
             let time_base = self
                 .stream_time_base(stream_index)
@@ -433,6 +444,8 @@ impl Demuxer {
                 "timelineOriginMicros": self.timeline_origin_micros,
                 "absoluteTargetMicros": absolute_target,
                 "targetInSeekTimeBase": target,
+                "selectedStreams": selected_streams,
+                "availableVideoStreams": available_video_streams,
             })
             .to_string(),
         );

--- a/crates/erika/src/playback.rs
+++ b/crates/erika/src/playback.rs
@@ -463,7 +463,23 @@ fn handle_demux_command(
             *generation = next_generation;
             *eof = false;
             *active = false;
-            *pending_seek = None;
+            if let Some((seek_generation, position)) = pending_seek.as_mut() {
+                trace::diagnostic(
+                    serde_json::json!({
+                        "event": "demux_pending_seek",
+                        "stage": "preserved_across_stream_selection",
+                        "seekGeneration": *seek_generation,
+                        "selectionGeneration": next_generation,
+                        "targetSeconds": position.as_secs_f64(),
+                    })
+                    .to_string(),
+                );
+                // A track selection can race with the first resume seek before
+                // the demux worker receives Start. Keep that seek, but retarget
+                // its packet generation to the new selection so the caller does
+                // not discard every packet as stale.
+                *seek_generation = next_generation;
+            }
             if let Err(error) = demuxer.set_stream_selection(selection) {
                 let _ = packets.send(DemuxMessage::Error {
                     generation: *generation,

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -31,9 +31,9 @@ use ::windows::Win32::Graphics::Dxgi::Common::{
     DXGI_FORMAT_R32G32_FLOAT, DXGI_SAMPLE_DESC,
 };
 use ::windows::Win32::Graphics::Dxgi::{
-    DXGI_HDR_METADATA_HDR10, DXGI_HDR_METADATA_TYPE_HDR10, DXGI_HDR_METADATA_TYPE_NONE,
-    DXGI_PRESENT, DXGI_PRESENT_PARAMETERS, DXGI_SCALING_STRETCH,
-    DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT, DXGI_SWAP_CHAIN_DESC1,
+    DXGI_ERROR_WAS_STILL_DRAWING, DXGI_HDR_METADATA_HDR10, DXGI_HDR_METADATA_TYPE_HDR10,
+    DXGI_HDR_METADATA_TYPE_NONE, DXGI_PRESENT_DO_NOT_WAIT, DXGI_PRESENT_PARAMETERS,
+    DXGI_SCALING_STRETCH, DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT, DXGI_SWAP_CHAIN_DESC1,
     DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT, IDXGIAdapter, IDXGIDevice,
     IDXGIFactory2, IDXGIResource, IDXGISwapChain1, IDXGISwapChain3, IDXGISwapChain4,
 };
@@ -1280,10 +1280,22 @@ impl D3d11Renderer {
         }
         state.draw_video(video, scene_rtv, target_rect)?;
         if !overlay_draws.is_empty() {
-            state.draw_overlays(&overlay_draws, scene_rtv, physical.width, physical.height)?;
+            // Subtitle coordinates are produced in the video-frame viewport.
+            // Composite them through the same aspect-fit viewport as the video
+            // so resizing the window cannot stretch the subtitle independently.
+            state.draw_overlays(&overlay_draws, scene_rtv, target_rect)?;
         }
         if !danmaku_draws.is_empty() {
-            state.draw_overlays(&danmaku_draws, scene_rtv, physical.width, physical.height)?;
+            state.draw_overlays(
+                &danmaku_draws,
+                scene_rtv,
+                D3d11DrawRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: physical.width.max(1) as f32,
+                    height: physical.height.max(1) as f32,
+                },
+            )?;
         }
         if let Some((_, linear_srv)) = linear_target {
             state.draw_encode(
@@ -1674,17 +1686,16 @@ impl D3d11DeviceState {
         &self,
         draws: &[D3d11OverlayDraw],
         render_target: &ID3D11RenderTargetView,
-        width: u32,
-        height: u32,
+        target: D3d11DrawRect,
     ) -> Result<()> {
         if draws.is_empty() {
             return Ok(());
         }
         let viewport = D3D11_VIEWPORT {
-            TopLeftX: 0.0,
-            TopLeftY: 0.0,
-            Width: width.max(1) as f32,
-            Height: height.max(1) as f32,
+            TopLeftX: target.x,
+            TopLeftY: target.y,
+            Width: target.width.max(1.0),
+            Height: target.height.max(1.0),
             MinDepth: 0.0,
             MaxDepth: 1.0,
         };
@@ -2072,9 +2083,14 @@ fn present_swapchain(swapchain: &IDXGISwapChain1, operation: &'static str) -> Re
         pScrollRect: ptr::null_mut(),
         pScrollOffset: ptr::null_mut(),
     };
-    unsafe { swapchain.Present1(1, DXGI_PRESENT(0), &params) }
-        .ok()
-        .map_err(|error| d3d_error(operation, error))
+    let status = unsafe { swapchain.Present1(0, DXGI_PRESENT_DO_NOT_WAIT, &params) };
+    // Rendering shares the Windows platform thread with WM_MOVING. Never wait
+    // for a full DXGI queue here: dropping one presentation keeps window
+    // interaction responsive while decode/audio continue normally.
+    if status == DXGI_ERROR_WAS_STILL_DRAWING {
+        return Ok(());
+    }
+    status.ok().map_err(|error| d3d_error(operation, error))
 }
 
 fn create_plane_srv(

--- a/packages/erika_flutter/windows/CMakeLists.txt
+++ b/packages/erika_flutter/windows/CMakeLists.txt
@@ -62,6 +62,9 @@ add_library(${PLUGIN_NAME} SHARED
 )
 
 apply_standard_settings(${PLUGIN_NAME})
+if(MSVC)
+  target_compile_options(${PLUGIN_NAME} PRIVATE /utf-8)
+endif()
 
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -948,6 +948,10 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
                 bool is_visible,
                 std::optional<int64_t> generation,
                 const std::optional<std::string>& debug_label) {
+    if (!is_visible && generation && active_generation != 0 &&
+        *generation != active_generation) {
+      return;
+    }
     if (generation) {
       active_generation = *generation;
     }
@@ -1046,6 +1050,7 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
   double logical_height = 1.0;
   bool visible = false;
   int64_t active_generation = 0;
+  int64_t owner_player_id = 0;
 };
 
 struct ErikaFlutterPlugin::PlayerHost {
@@ -1416,6 +1421,9 @@ struct ErikaFlutterPlugin::PlayerHost {
     attached_hwnd = overlay.hwnd;
     attached_view_id = kWindowOverlayViewId;
     surface_attached = true;
+    attached_surface_width = width;
+    attached_surface_height = height;
+    attached_surface_scale = scale;
     start_time_seconds = NowSeconds();
   }
 
@@ -1423,9 +1431,19 @@ struct ErikaFlutterPlugin::PlayerHost {
     if (!surface_attached || attached_hwnd != overlay.hwnd) {
       return;
     }
-    Check(library->resize_surface(handle, overlay.PixelWidth(),
-                                  overlay.PixelHeight(), overlay.scale),
+    const uint32_t width = overlay.PixelWidth();
+    const uint32_t height = overlay.PixelHeight();
+    const double scale = overlay.scale;
+    if (width == attached_surface_width &&
+        height == attached_surface_height &&
+        std::abs(scale - attached_surface_scale) < 0.0001) {
+      return;
+    }
+    Check(library->resize_surface(handle, width, height, scale),
           "resize_surface", library->TakeLastError());
+    attached_surface_width = width;
+    attached_surface_height = height;
+    attached_surface_scale = scale;
   }
 
   void Detach(std::optional<int64_t> view_id) {
@@ -1435,6 +1453,9 @@ struct ErikaFlutterPlugin::PlayerHost {
     attached_hwnd = nullptr;
     attached_view_id = 0;
     surface_attached = false;
+    attached_surface_width = 0;
+    attached_surface_height = 0;
+    attached_surface_scale = 0.0;
     library->detach_surface(handle);
   }
 
@@ -1611,6 +1632,9 @@ struct ErikaFlutterPlugin::PlayerHost {
   HWND attached_hwnd = nullptr;
   int64_t attached_view_id = 0;
   bool surface_attached = false;
+  uint32_t attached_surface_width = 0;
+  uint32_t attached_surface_height = 0;
+  double attached_surface_scale = 0.0;
   double start_time_seconds = NowSeconds();
   ErikaDanmakuConfig current_danmaku_config = DefaultDanmakuConfig();
   ErikaPresenterStats latest_presenter_stats{};
@@ -2074,7 +2098,19 @@ int64_t ErikaFlutterPlugin::CreatePlayer(const EncodableValue* arguments) {
 }
 
 void ErikaFlutterPlugin::RemovePlayer(int64_t player_id) {
-  players_.erase(player_id);
+  const auto it = players_.find(player_id);
+  if (it == players_.end()) {
+    return;
+  }
+  // Hide the shared HWND before destroying the presenter. Presenter teardown
+  // may wait for decoder threads, and leaving the overlay visible during that
+  // wait exposes the transparent Flutter cutout as an apparently frozen app.
+  if (overlay_window_ && overlay_window_->owner_player_id == player_id) {
+    overlay_window_->SetFrame(0.0, 0.0, 0.0, 0.0, false, std::nullopt,
+                              std::nullopt);
+    overlay_window_->owner_player_id = 0;
+  }
+  players_.erase(it);
 }
 
 void ErikaFlutterPlugin::SendEvent(EncodableValue event) {
@@ -2235,7 +2271,9 @@ void ErikaFlutterPlugin::HandleMethodCall(
         throw PluginError("Erika video view " + std::to_string(view_id) +
                           " was not found.");
       }
-      host.AttachOverlay(EnsureOverlayWindow());
+      auto& overlay = EnsureOverlayWindow();
+      host.AttachOverlay(overlay);
+      overlay.owner_player_id = host.id;
       OnFrameTimer();
       result->Success();
     } else if (method == "detachView") {
@@ -2244,7 +2282,9 @@ void ErikaFlutterPlugin::HandleMethodCall(
       result->Success();
     } else if (method == "attachOverlay") {
       auto& host = PlayerFromArgs(args);
-      host.AttachOverlay(EnsureOverlayWindow());
+      auto& overlay = EnsureOverlayWindow();
+      host.AttachOverlay(overlay);
+      overlay.owner_player_id = host.id;
       OnFrameTimer();
       result->Success(EncodableValue(kWindowOverlayViewId));
     } else if (method == "detachOverlay") {
@@ -2260,17 +2300,34 @@ void ErikaFlutterPlugin::HandleMethodCall(
       if (overlay_window_) {
         overlay_window_->SetFrame(0.0, 0.0, 0.0, 0.0, false, generation,
                                   std::nullopt);
+        if (overlay_window_->owner_player_id == host.id) {
+          overlay_window_->owner_player_id = 0;
+        }
       }
       result->Success();
     } else if (method == "setOverlayFrame") {
       auto& overlay = EnsureOverlayWindow();
+      const int64_t player_id = RequiredInt64(args, "playerId");
+      PlayerFromArgs(args);
+      const bool visible = BoolValue(FindArg(args, "visible")).value_or(true);
+      if (!visible && overlay.owner_player_id != 0 &&
+          overlay.owner_player_id != player_id) {
+        result->Success();
+        return;
+      }
+      if (visible) {
+        overlay.owner_player_id = player_id;
+      }
       overlay.SetFrame(DoubleValue(FindArg(args, "x")).value_or(0.0),
                        DoubleValue(FindArg(args, "y")).value_or(0.0),
                        DoubleValue(FindArg(args, "width")).value_or(0.0),
                        DoubleValue(FindArg(args, "height")).value_or(0.0),
-                       BoolValue(FindArg(args, "visible")).value_or(true),
+                       visible,
                        Int64Value(FindArg(args, "generation")),
                        StringValue(FindArg(args, "debugLabel")));
+      if (!visible && overlay.owner_player_id == player_id) {
+        overlay.owner_player_id = 0;
+      }
       ResizeAttachedOverlay();
       OnFrameTimer();
       result->Success();

--- a/third_party/patches/ffmpeg-8.1.2/0002-windows-msvc-awk-backslash.patch
+++ b/third_party/patches/ffmpeg-8.1.2/0002-windows-msvc-awk-backslash.patch
@@ -1,5 +1,16 @@
 --- a/configure
 +++ b/configure
+@@ -5364,8 +5364,9 @@
+         _ld_o='-out:$@'
+         _flags_filter=msvc_flags_link
+         _ld_lib='%.lib'
+         _ld_path='-libpath:'
+-    elif VSLANG=1033 $_cc -nologo- 2>&1 | grep -q ^Microsoft || { $_cc -v 2>&1 | grep -q clang && $_cc -? > /dev/null 2>&1; }; then
++    elif test "$toolchain" = "msvc" || \
++         VSLANG=1033 $_cc -nologo- 2>&1 | grep -q ^Microsoft || { $_cc -v 2>&1 | grep -q clang && $_cc -? > /dev/null 2>&1; }; then
+         _type=msvc
+         if VSLANG=1033 $_cc -nologo- 2>&1 | grep -q ^Microsoft; then
+             # Depending on the tool (cl.exe or link.exe), the version number
 @@ -5378,7 +5378,7 @@
              _DEPCMD='$(DEP$(1)) $(DEP$(1)FLAGS) $($(1)DEP_FLAGS) $< 2>&1 | awk '\''/including/ { sub(/^.*file: */, ""); if (!match($$0, / /)) { print $$0 } }'\'' | xargs -r -d\\n -n1 wslpath -u | awk '\''BEGIN { printf "%s:", "$@" }; { sub(/\r/,""); printf " %s", $$0 }; END { print "" }'\'' > $(@:.o=.d)'
  


### PR DESCRIPTION
## Summary

- preserve an initial pending seek when subtitle/audio stream selection races playback startup, preventing a long black screen until the user seeks manually
- make the shared Windows overlay lifecycle generation- and player-aware, hide it before presenter teardown, and skip redundant surface resizes
- composite subtitles through the video's aspect-fit viewport while keeping danmaku on the full-window viewport
- use non-blocking D3D11 presentation to reduce platform-thread stalls during live window movement
- make Windows source builds reliable under non-English MSVC locales

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p erika --target x86_64-pc-windows-msvc`
- full `flutter build windows --debug` from current NipaPlay `main`, using this Erika checkout as a source dependency
- live D3D11VA playback validation: resume seek produces a frame directly, player exit restores the Flutter surface, and subtitles keep the video aspect ratio

Window dragging during active playback can still drop presentation frames on this system, but no longer blocks playback teardown or the Windows platform thread.