### PR TITLE
fix(ohos): restore ohos cfg gate on set_danmaku_config

### DIFF
--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -2180,7 +2180,8 @@ pub unsafe extern "C" fn erika_presenter_set_debug_hud_enabled(
     target_os = "macos",
     target_os = "ios",
     target_os = "windows",
-    target_os = "android"
+    target_os = "android",
+    target_env = "ohos"
 ))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_set_danmaku_config(
@@ -4156,7 +4157,8 @@ mod tests {
         target_os = "macos",
         target_os = "ios",
         target_os = "windows",
-        target_os = "android"
+        target_os = "android",
+        target_env = "ohos"
     ))]
     #[test]
     fn c_presenter_set_upscaler_accepts_valid_handle() {


### PR DESCRIPTION
`main` currently fails the `OpenHarmony native (arm64)` job (see run on 204cdd7).

In `crates/erika_capi/src/lib.rs` every platform API is a pair: the real implementation under `#[cfg(any(macos, ios, windows, android, target_env = "ohos"))]` and a no-op stub under `#[cfg(not(any(...same five...)))]`. The two lists have to be exact complements — OpenHarmony reports `target_os = "linux"`, so `target_env = "ohos"` is the only predicate that matches it.

Two gates lost that predicate:

- `erika_presenter_set_danmaku_config` — implementation gated on four targets, stub gated on `not(any(five))`, so OpenHarmony got neither definition and `erika_presenter_set_danmaku_config_ptr` failed to resolve it (`E0425`).
- `c_presenter_set_upscaler_accepts_valid_handle` — same predicate missing on the test.

Both came in through #58, whose branch predated OpenHarmony support; the merge kept the branch side of those hunks.

This restores the predicate on both. No behaviour change on any other target.

## Note on #56 and #67

Those two PRs fail the same job for the same reason and are **not** fixed by this PR — they carry their own dropped predicates (9 and 19 gates respectively, including `luma_upscaler_mode_from_c`, the `SubtitleStyleConfig` import, the `erika_presenter_get_upscaler_status` stub, and the whole new subtitle/memory-font API surface). They will need the same treatment after rebasing on this.

## Verification

- `cargo check -p erika_capi --all-targets`
- `cargo fmt --all -- --check`
- Audited all 112 platform cfg blocks in `erika_capi`: every list mentioning `android` also mentions `target_env = "ohos"`, and every impl/stub pair now has identical predicate sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)