### PR TITLE
修复 Apple Silicon Android 构建并支持多 FlutterView 覆盖层定位

### DIFF
--- a/crates/erika/build.rs
+++ b/crates/erika/build.rs
@@ -177,7 +177,8 @@ fn android_glslc() -> PathBuf {
         ("windows", _) => "windows-x86_64",
         ("linux", "aarch64") => "linux-aarch64",
         ("linux", _) => "linux-x86_64",
-        ("macos", "aarch64") => "darwin-arm64",
+        // The macOS NDK package keeps the historical directory name even
+        // though its glslc executable is a universal x86_64/arm64 binary.
         ("macos", _) => "darwin-x86_64",
         (os, arch) => panic!("unsupported Android shader compiler host {os}/{arch}"),
     };

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -1358,11 +1358,22 @@ class ErikaPlayer {
     });
   }
 
-  Future<int> attachWindowOverlay() async {
+  /// Attaches the shared native overlay to this player.
+  ///
+  /// Multi-view embedders can use [flutterViewId] and [secondaryWindow] to
+  /// identify the Flutter view that currently hosts the player widget.
+  Future<int> attachWindowOverlay({
+    int? flutterViewId,
+    bool secondaryWindow = false,
+  }) async {
     final playerId = await ensureCreated();
     final viewId = await _channel.invokeMethod<int>(
       'attachOverlay',
-      <String, Object?>{'playerId': playerId},
+      <String, Object?>{
+        'playerId': playerId,
+        if (flutterViewId != null) 'flutterViewId': flutterViewId,
+        'secondaryWindow': secondaryWindow,
+      },
     );
     return viewId ?? windowOverlayViewId;
   }
@@ -1382,6 +1393,8 @@ class ErikaPlayer {
     required Rect frame,
     required bool visible,
     required int generation,
+    int? flutterViewId,
+    bool secondaryWindow = false,
     String? debugLabel,
   }) async {
     final playerId = await ensureCreated();
@@ -1394,6 +1407,8 @@ class ErikaPlayer {
       'width': frame.width,
       'height': frame.height,
       'visible': visible,
+      if (flutterViewId != null) 'flutterViewId': flutterViewId,
+      'secondaryWindow': secondaryWindow,
       if (debugLabel != null) 'debugLabel': debugLabel,
     });
   }

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -437,11 +437,16 @@ void main() {
     });
     final player = ErikaPlayer();
 
-    final viewId = await player.attachWindowOverlay();
+    final viewId = await player.attachWindowOverlay(
+      flutterViewId: 17,
+      secondaryWindow: true,
+    );
     await player.setWindowOverlayFrame(
       frame: const Rect.fromLTWH(10, 20, 320, 180),
       visible: true,
       generation: 42,
+      flutterViewId: 17,
+      secondaryWindow: true,
       debugLabel: 'episode.mkv',
     );
     await player.detachWindowOverlay(generation: 42);
@@ -451,7 +456,11 @@ void main() {
       playerCalls
           .singleWhere((MethodCall call) => call.method == 'attachOverlay')
           .arguments,
-      <String, Object?>{'playerId': 7},
+      <String, Object?>{
+        'playerId': 7,
+        'flutterViewId': 17,
+        'secondaryWindow': true,
+      },
     );
     expect(
       playerCalls
@@ -466,6 +475,8 @@ void main() {
         'width': 320.0,
         'height': 180.0,
         'visible': true,
+        'flutterViewId': 17,
+        'secondaryWindow': true,
         'debugLabel': 'episode.mkv',
       },
     );
@@ -474,6 +485,38 @@ void main() {
           .singleWhere((MethodCall call) => call.method == 'detachOverlay')
           .arguments,
       <String, Object?>{'playerId': 7, 'generation': 42},
+    );
+
+    await player.dispose();
+  });
+
+  test('window overlay explicitly targets the main window by default',
+      () async {
+    final player = ErikaPlayer();
+
+    await player.attachWindowOverlay(flutterViewId: 3);
+    await player.setWindowOverlayFrame(
+      frame: const Rect.fromLTWH(0, 0, 640, 360),
+      visible: true,
+      generation: 7,
+      flutterViewId: 3,
+    );
+
+    expect(
+      playerCalls
+          .singleWhere((MethodCall call) => call.method == 'attachOverlay')
+          .arguments,
+      <String, Object?>{
+        'playerId': 7,
+        'flutterViewId': 3,
+        'secondaryWindow': false,
+      },
+    );
+    expect(
+      playerCalls
+          .singleWhere((MethodCall call) => call.method == 'setOverlayFrame')
+          .arguments,
+      containsPair('secondaryWindow', false),
     );
 
     await player.dispose();


### PR DESCRIPTION
# 修复 Apple Silicon Android 构建并支持多 FlutterView 覆盖层定位

## 修改内容

本次修改解决以下两个兼容性问题：

1. 修复 Apple Silicon Mac 上构建 Android 版本时找不到 NDK `glslc` 的问题。
2. 为窗口覆盖层 API 增加多 FlutterView 和副窗口定位参数。

具体改动如下：

- macOS 构建 Android 时，使用 NDK 实际存在的 `darwin-x86_64` shader-tools 目录。
- 为 `attachWindowOverlay` 增加可选的 `flutterViewId` 和 `secondaryWindow` 参数。
- 为 `setWindowOverlayFrame` 增加相同的窗口定位参数。
- 通过现有 MethodChannel 将窗口信息传递给原生端。
- 增加主窗口和副窗口覆盖层参数的回归测试。

## Apple Silicon Android 构建问题

Android NDK r29 在 Apple Silicon 设备上没有提供以下目录：

```text
shader-tools/darwin-arm64
```

它仍然沿用历史目录名称：

```text
shader-tools/darwin-x86_64
```

但该目录中的 `glslc` 实际是 Universal Mach-O 文件，同时包含以下两种架构：

- `x86_64`
- `arm64`

原来的代码会根据 macOS 宿主机架构选择目录：

```rust
("macos", "aarch64") => "darwin-arm64",
("macos", _) => "darwin-x86_64",
```

因此在 Apple Silicon Mac 上会尝试访问不存在的路径，并出现以下错误：

```text
Android NDK glslc was not found at .../shader-tools/darwin-arm64/glslc
```

本次修改统一使用 NDK 实际提供的目录：

```rust
("macos", _) => "darwin-x86_64",
```

这里选择的是构建机器上的 NDK 工具目录，与最终生成的 Android ABI 无关，不会影响 `arm64-v8a`、`armeabi-v7a` 或 `x86_64` 目标架构。

## 多 FlutterView 覆盖层支持

多窗口应用中，同一个播放器组件可能在不同的 FlutterView 之间移动。

为了让原生视频覆盖层能够识别当前目标窗口，本次为以下 API 增加了两个可选参数：

```dart
Future<int> attachWindowOverlay({
  int? flutterViewId,
  bool secondaryWindow = false,
})
```

以及：

```dart
Future<void> setWindowOverlayFrame({
  required Rect frame,
  required bool visible,
  required int generation,
  int? flutterViewId,
  bool secondaryWindow = false,
  String? debugLabel,
})
```

参数含义：

- `flutterViewId`：当前承载播放器组件的 FlutterView ID。
- `secondaryWindow`：当前 FlutterView 是否属于副窗口，默认值为 `false`。

这些参数会通过现有 MethodChannel 传递给原生端：

```dart
<String, Object?>{
  'playerId': playerId,
  if (flutterViewId != null) 'flutterViewId': flutterViewId,
  'secondaryWindow': secondaryWindow,
}
```

## 兼容性

本次 API 修改保持向后兼容：

- 现有调用不需要修改。
- `flutterViewId` 为可选参数。
- `secondaryWindow` 默认值为 `false`。
- 暂未处理新增字段的原生实现可以安全忽略这些 MethodChannel 参数。
- 不影响现有单窗口播放器覆盖层逻辑。

## 测试覆盖

新增和更新的测试覆盖以下场景：

- 将指定的 `flutterViewId` 传递给原生端。
- 将 `secondaryWindow: true` 传递给原生端。
- 未指定 `secondaryWindow` 时显式传递默认值 `false`。
- 窗口覆盖层尺寸、位置和可见性参数保持不变。
- 原有播放器 MethodChannel 行为不受影响。

## 验证结果

以下检查均已通过：

```text
cargo +stable fmt --all -- --check
```

```text
flutter analyze --no-pub
```

```text
flutter test --no-pub
```

Flutter 测试结果：

```text
40 项测试全部通过
```

同时使用以下 Android NDK 完成了 Android arm64 Release 原生构建：

```text
29.0.14206865
```

生成的原生库：

```text
target/aarch64-linux-android/release/liberika_capi.so
```

文件格式验证结果：

```text
ELF 64-bit LSB shared object, ARM aarch64
```