### PR TITLE
fix(ohos): add explicit ArkTS plugin types

### DIFF
--- a/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
+++ b/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
@@ -258,7 +258,7 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
   }
 
   private openPlayer(args: Map<string, ESObject>, result: MethodResult): void {
-    const metadataValue = args.get('metadata');
+    const metadataValue: ESObject = args.get('metadata');
     let metadata: ErikaMediaMetadata | null = null;
     if (metadataValue !== undefined && metadataValue !== null) {
       metadata = this.parseMediaMetadata(metadataValue);
@@ -268,7 +268,7 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
       }
     }
     const playerId = this.numberArg(args, 'playerId', 0);
-    const nativeArgs = new Map<string, ESObject>(args);
+    const nativeArgs: Map<string, ESObject> = new Map<string, ESObject>(args);
     nativeArgs.delete('metadata');
     if (!this.invokePlayerNative('open', nativeArgs, result)) {
       return;
@@ -530,15 +530,15 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
     if (!(value instanceof Map)) {
       return null;
     }
-    const metadata = value as Map<string, ESObject>;
-    const titleValue = metadata.get('title');
+    const metadata: Map<string, ESObject> = value as Map<string, ESObject>;
+    const titleValue: ESObject = metadata.get('title');
     if (typeof titleValue !== 'string' || titleValue.length === 0) {
       return null;
     }
     const parsed: ErikaMediaMetadata = { title: titleValue };
-    const artist = metadata.get('artist');
-    const album = metadata.get('album');
-    const artwork = metadata.get('artwork');
+    const artist: ESObject = metadata.get('artist');
+    const album: ESObject = metadata.get('album');
+    const artwork: ESObject = metadata.get('artwork');
     if (typeof artist === 'string') {
       parsed.artist = artist;
     }
@@ -631,7 +631,8 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
     if (!this.players.has(playerId)) {
       return;
     }
-    const args = extra ?? new Map<string, ESObject>();
+    const args: Map<string, ESObject> =
+      extra ?? new Map<string, ESObject>();
     args.set('playerId', playerId);
     const raw = erikaNative.nativeInvoke(
       playerId,

--- a/packages/erika_flutter/test/ohos_screenshot_contract_test.dart
+++ b/packages/erika_flutter/test/ohos_screenshot_contract_test.dart
@@ -84,4 +84,23 @@ void main() {
       contains(r'$<TARGET_FILE_DIR:${PLUGIN_NAME}>/liberika_capi.so'),
     );
   });
+
+  test('OpenHarmony media controls avoid implicit ESObject types', () {
+    final plugin = File(
+      'ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets',
+    ).readAsStringSync();
+
+    for (final declaration in <String>[
+      "const metadataValue: ESObject = args.get('metadata');",
+      'const nativeArgs: Map<string, ESObject> =',
+      'const metadata: Map<string, ESObject> =',
+      "const titleValue: ESObject = metadata.get('title');",
+      "const artist: ESObject = metadata.get('artist');",
+      "const album: ESObject = metadata.get('album');",
+      "const artwork: ESObject = metadata.get('artwork');",
+      'const args: Map<string, ESObject> =',
+    ]) {
+      expect(plugin, contains(declaration));
+    }
+  });
 }


### PR DESCRIPTION
## Summary

Fix the HarmonyOS ArkTS build failure caused by strict `arkts-no-any-unknown` checks in `ErikaFlutterPlugin.ets`.

The affected expressions read `ESObject` values from `Map<string, ESObject>` or construct typed maps, but ArkTS inferred them as implicit `any`/`unknown` in the NipaPlay HarmonyOS build.

## Changes

- Add explicit `ESObject` types to media metadata values.
- Add explicit `Map<string, ESObject>` types to copied/native argument maps.
- Add a regression contract test covering all affected declarations.
- Keep runtime behavior and the Flutter API unchanged.

## Validation

- `flutter test --no-pub --reporter expanded test/ohos_screenshot_contract_test.dart`
  - 4 tests passed.
- Built NipaPlay from its current main branch with the fixed local Erika plugin:
  - Flutter `3.35.8-ohos-1.0.1`
  - `flutter build hap --release --no-pub --no-codesign --target-platform ohos-arm64`
  - Build succeeded and produced a 133.9 MB unsigned HAP.
  - Verified the HAP contains both `liberika_capi.so` and `liberika_flutter.so`.

This fixes the failure seen in [AimesSoft/NipaPlay-Reload Actions run 30883242192](https://github.com/AimesSoft/NipaPlay-Reload/actions/runs/30883242192/job/91908888662).

## Compatibility

This change only touches the HarmonyOS ArkTS plugin implementation and its contract test. Android, iOS, macOS, Windows, and Linux code paths are unchanged.
