### PR TITLE
fix(flutter): restore Windows SMTC compilation

### DIFF
--- a/packages/erika_flutter/windows/erika_windows_smtc.cpp
+++ b/packages/erika_flutter/windows/erika_windows_smtc.cpp
@@ -19,9 +19,8 @@ namespace {
 
 winrt::Windows::Foundation::TimeSpan MicrosToTimeSpan(uint64_t micros) {
   using namespace std::chrono;
-  return winrt::Windows::Foundation::TimeSpan(
-      duration_cast<winrt::Windows::Foundation::TimeSpan::duration>(
-          microseconds(micros)));
+  return duration_cast<winrt::Windows::Foundation::TimeSpan>(
+      microseconds(micros));
 }
 
 winrt::Windows::Storage::Streams::IRandomAccessStream ArtworkStream(

--- a/packages/erika_flutter/windows/erika_windows_smtc.h
+++ b/packages/erika_flutter/windows/erika_windows_smtc.h
@@ -1,6 +1,9 @@
 #ifndef FLUTTER_PLUGIN_ERIKA_WINDOWS_SMTC_H_
 #define FLUTTER_PLUGIN_ERIKA_WINDOWS_SMTC_H_
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 
 #include <cstdint>


### PR DESCRIPTION
## Summary

- cast microseconds directly to `winrt::Windows::Foundation::TimeSpan`
- define `NOMINMAX` before including `windows.h` so Win32 macros do not break standard `min`/`max` calls

This restores the Windows Flutter plugin build after the SMTC support added in v0.1.5.

## Validation

- NipaPlay Windows Actions passed: https://github.com/aozaoz112233/NipaPlay-Reload/actions/runs/30887885860
- MSVC completed with 0 errors, generated `NipaPlay.exe`, and uploaded the Windows artifacts