### PR TITLE
Use source-aware SDR/EDR output on Apple platforms

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -778,6 +778,10 @@ pub trait RendererBackend {
         RendererRuntimeStats::default()
     }
 
+    fn resource_stats(&self) -> RendererResourceStats {
+        RendererResourceStats::default()
+    }
+
     fn output_status(&self) -> crate::renderer::output::OutputRuntimeStatus {
         crate::renderer::output::OutputRuntimeStatus::default()
     }
@@ -852,6 +856,25 @@ pub struct RendererRuntimeStats {
     pub hdr10_metadata_failures: u64,
     pub hdr10_output_failures: u64,
     pub hdr10_output_active: bool,
+}
+
+/// Snapshot of memory visible from the renderer. Individual fields describe
+/// resources tracked by Erika; `device_current_allocated_bytes` is Metal's
+/// process-wide device counter and can therefore include driver allocations
+/// that do not belong to a single presenter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RendererResourceStats {
+    pub device_current_allocated_bytes: u64,
+    pub device_recommended_working_set_bytes: u64,
+    pub drawable_estimated_bytes: u64,
+    pub video_frame_bytes: u64,
+    pub overlay_atlas_bytes: u64,
+    pub danmaku_atlas_bytes: u64,
+    pub danmaku_vertex_buffer_bytes: u64,
+    pub upscaler_bytes: u64,
+    pub renderer_tracked_bytes: u64,
+    pub drawable_count: u32,
+    pub output_mode_switches: u64,
 }
 
 struct PlayerInner {

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -235,6 +235,7 @@ pub struct PresenterStats {
 pub struct PresenterRuntimeSnapshot {
     pub stats: PresenterStats,
     pub renderer: RendererRuntimeStats,
+    pub resources: crate::core::RendererResourceStats,
     pub output: crate::renderer::output::OutputRuntimeStatus,
     pub audio_output_queued_duration: Option<Duration>,
     pub audio_output_queued_frames: usize,
@@ -1606,6 +1607,7 @@ impl PresenterRuntime {
 
     pub fn runtime_snapshot(&self) -> PresenterRuntimeSnapshot {
         let renderer = self.renderer.runtime_stats();
+        let resources = self.renderer.resource_stats();
         let output = self.renderer.output_status();
         let (current_danmaku_items, current_danmaku_atlas_version, current_danmaku_atlas_bytes) =
             self.current_danmaku.as_ref().map_or((0, 0, 0), |plan| {
@@ -1624,6 +1626,7 @@ impl PresenterRuntime {
         PresenterRuntimeSnapshot {
             stats: self.stats,
             renderer,
+            resources,
             output,
             audio_output_queued_duration: audio_snapshot
                 .and_then(|snapshot| snapshot.queued_duration),

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -36,7 +36,7 @@ use objc2_metal::{
 };
 use objc2_metal::{
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
-    MTLCommandQueue, MTLDevice, MTLDrawable, MTLRenderPassDescriptor, MTLTexture,
+    MTLCommandQueue, MTLDevice, MTLDrawable, MTLRenderPassDescriptor, MTLResource, MTLTexture,
 };
 use objc2_metal::{
     MTLLibrary, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPipelineDescriptor,
@@ -44,8 +44,10 @@ use objc2_metal::{
 };
 use objc2_metal::{MTLSamplerDescriptor, MTLSamplerMinMagFilter, MTLSamplerState};
 use objc2_quartz_core::{CAMetalDrawable, CAMetalLayer};
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+use objc2_quartz_core::{kCAContentsFormatRGBA8Uint, kCAContentsFormatRGBA16Float};
 
-use crate::core::{ColorPrimaries, SurfaceMetrics, TransferFunction};
+use crate::core::{ColorPrimaries, RendererResourceStats, SurfaceMetrics, TransferFunction};
 use crate::danmaku::{DanmakuAtlasUpdate, DanmakuGlyphAtlas, DanmakuRenderPlan};
 use crate::renderer::metal::upscaler::LumaUpscaler;
 use crate::renderer::metal::{
@@ -54,8 +56,8 @@ use crate::renderer::metal::{
     MetalRendererStats, OverlayRenderFrame, PreparedOverlayFrameInfo, VideoFrameTextureSource,
     VideoRenderFrame, fourcc_string, metal_drawable_pixel_format, metal_target_color,
 };
-use crate::renderer::pipeline::TargetColorState;
 use crate::renderer::pipeline::{ColorRange, LumaUpscalerMode, ToneMapOperator};
+use crate::renderer::pipeline::{SourceColorState, TargetColorState};
 use crate::renderer::presentation::PresentationLayout as VideoPresentationLayout;
 use crate::subtitle::{AssColor, SubtitleAlphaBitmap};
 use crate::trace;
@@ -78,6 +80,12 @@ pub struct ImportedVideoFrameTextures {
 impl ImportedVideoFrameTextures {
     pub fn plane_count(&self) -> usize {
         self.planes.len()
+    }
+
+    pub fn allocated_bytes(&self) -> u64 {
+        self.planes.iter().fold(0, |total, plane| {
+            total.saturating_add(plane.metal_texture.allocatedSize() as u64)
+        })
     }
 }
 
@@ -108,6 +116,7 @@ pub struct ImportedVideoFrameResult {
 pub struct MetalRendererImpl {
     device: Retained<ProtocolObject<dyn MTLDevice>>,
     queue: Retained<ProtocolObject<dyn MTLCommandQueue>>,
+    requested_output_mode: MetalOutputMode,
     output_mode: MetalOutputMode,
     drawable_pixel_format: MetalDrawablePixelFormat,
     layer: Option<Retained<CAMetalLayer>>,
@@ -122,6 +131,7 @@ pub struct MetalRendererImpl {
     danmaku_vertex_buffer_cursor: usize,
     danmaku_vertex_buffer_acquisitions: u64,
     upscaler: LumaUpscaler,
+    last_submitted_command_buffer: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
     pending_gpu_timing: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
     stats: MetalRendererStats,
     layer_color_space_label: &'static str,
@@ -148,11 +158,13 @@ impl MetalRendererImpl {
         let queue = device
             .newCommandQueue()
             .ok_or_else(|| PlayerError::Renderer("newCommandQueue returned nil".to_string()))?;
+        let initial_output_mode = config.output_mode.resolve_for_source(false);
         Ok(Self {
             device,
             queue,
-            output_mode: config.output_mode,
-            drawable_pixel_format: metal_drawable_pixel_format(config.output_mode),
+            requested_output_mode: config.output_mode,
+            output_mode: initial_output_mode,
+            drawable_pixel_format: metal_drawable_pixel_format(initial_output_mode),
             layer: None,
             texture_cache: None,
             video_pipeline: None,
@@ -169,6 +181,7 @@ impl MetalRendererImpl {
                 upscaler.set_mode(config.luma_upscaler);
                 upscaler
             },
+            last_submitted_command_buffer: None,
             pending_gpu_timing: None,
             stats: MetalRendererStats::default(),
             layer_color_space_label: "unconfigured",
@@ -220,10 +233,122 @@ impl MetalRendererImpl {
         stats
     }
 
+    pub fn resource_stats(&self) -> RendererResourceStats {
+        let drawable_count = self.layer.as_ref().map_or(0, |layer| {
+            layer.maximumDrawableCount().min(u32::MAX as usize) as u32
+        });
+        let drawable_bytes_per_pixel = match self.drawable_pixel_format {
+            MetalDrawablePixelFormat::Bgra8Unorm => 4u64,
+            MetalDrawablePixelFormat::Rgba16Float => 8u64,
+        };
+        let drawable_estimated_bytes = u64::from(self.stats.drawable_width)
+            .saturating_mul(u64::from(self.stats.drawable_height))
+            .saturating_mul(drawable_bytes_per_pixel)
+            .saturating_mul(u64::from(drawable_count));
+        let overlay_atlas_bytes = self
+            .overlay_alpha_atlas_cache
+            .as_ref()
+            .map_or(0, |cache| cache.texture.allocatedSize() as u64);
+        let danmaku_atlas_bytes = self.danmaku_alpha_atlas_cache.as_ref().map_or(0, |cache| {
+            (cache.fill_texture.allocatedSize() as u64)
+                .saturating_add(cache.outline_texture.allocatedSize() as u64)
+        });
+        let danmaku_vertex_buffer_bytes =
+            self.danmaku_vertex_buffers
+                .iter()
+                .fold(0u64, |total, slot| {
+                    total.saturating_add(
+                        slot.buffer
+                            .as_ref()
+                            .map_or(0, |buffer| buffer.allocatedSize() as u64),
+                    )
+                });
+        let upscaler_bytes = self.upscaler.allocated_bytes();
+        let renderer_tracked_bytes = drawable_estimated_bytes
+            .saturating_add(overlay_atlas_bytes)
+            .saturating_add(danmaku_atlas_bytes)
+            .saturating_add(danmaku_vertex_buffer_bytes)
+            .saturating_add(upscaler_bytes);
+
+        let device_recommended_working_set_bytes = if self
+            .device
+            .respondsToSelector(objc2::sel!(recommendedMaxWorkingSetSize))
+        {
+            self.device.recommendedMaxWorkingSetSize()
+        } else {
+            0
+        };
+
+        RendererResourceStats {
+            device_current_allocated_bytes: self.device.currentAllocatedSize() as u64,
+            device_recommended_working_set_bytes,
+            drawable_estimated_bytes,
+            overlay_atlas_bytes,
+            danmaku_atlas_bytes,
+            danmaku_vertex_buffer_bytes,
+            upscaler_bytes,
+            renderer_tracked_bytes,
+            drawable_count,
+            output_mode_switches: self.stats.output_mode_switches,
+            ..RendererResourceStats::default()
+        }
+    }
+
+    pub fn active_output_mode(&self) -> MetalOutputMode {
+        self.output_mode
+    }
+
+    fn select_output_mode_for_source(&mut self, source: SourceColorState) {
+        let source_is_hdr = source.is_hdr();
+        if source_is_hdr {
+            self.stats.hdr_source_frames = self.stats.hdr_source_frames.saturating_add(1);
+        }
+        let selected = self.requested_output_mode.resolve_for_source(source_is_hdr);
+        if selected != self.output_mode {
+            self.set_output_mode(selected);
+        }
+        if source_is_hdr && !self.output_mode.is_edr() {
+            self.stats.sdr_tonemap_frames = self.stats.sdr_tonemap_frames.saturating_add(1);
+        }
+    }
+
+    fn set_output_mode(&mut self, output_mode: MetalOutputMode) {
+        if self.output_mode == output_mode {
+            return;
+        }
+        // CAMetalLayer requires all drawables using the old pixel format to be
+        // released before its format changes. Waiting for the most recently
+        // submitted buffer is sufficient because this renderer uses one FIFO
+        // Metal command queue.
+        if let Some(submitted) = self.last_submitted_command_buffer.take() {
+            submitted.waitUntilCompleted();
+        }
+        if let Some(pending) = self.pending_gpu_timing.take() {
+            pending.waitUntilCompleted();
+            if pending.status() == MTLCommandBufferStatus::Completed {
+                let seconds = (pending.GPUEndTime() - pending.GPUStartTime()).max(0.0);
+                self.stats.last_gpu_duration = Duration::from_secs_f64(seconds);
+            }
+        }
+        let previous = self.output_mode;
+        self.output_mode = output_mode;
+        self.stats.output_mode_switches = self.stats.output_mode_switches.saturating_add(1);
+        self.logged_first_video_frame = false;
+        if let Some(layer) = self.layer.as_ref().cloned() {
+            self.configure_layer_output(&layer);
+        }
+        if hdr_debug_enabled() {
+            eprintln!(
+                "ErikaHDR: automatic output switch requested={:?} previous={:?} active={:?}",
+                self.requested_output_mode, previous, self.output_mode,
+            );
+        }
+    }
+
     fn configure_layer_output(&mut self, layer: &CAMetalLayer) {
         self.drawable_pixel_format = metal_drawable_pixel_format(self.output_mode);
         layer.setPixelFormat(metal_pixel_format(self.drawable_pixel_format));
-        set_layer_edr_enabled(layer, self.output_mode.is_edr());
+        configure_layer_dynamic_range(layer, self.output_mode.is_edr());
         let (color_space_name, color_space_label) = if self.output_mode.is_edr() {
             edr_layer_color_space(None)
         } else {
@@ -342,6 +467,7 @@ impl MetalRendererImpl {
                 ProtocolObject::from_ref(&*drawable);
             command_buffer.presentDrawable(drawable_ref);
             command_buffer.commit();
+            self.last_submitted_command_buffer = Some(command_buffer);
         }
 
         self.stats.rendered_frames += 1;
@@ -441,6 +567,7 @@ impl MetalRendererImpl {
                 ProtocolObject::from_ref(&*drawable);
             command_buffer.presentDrawable(drawable_ref);
             command_buffer.commit();
+            self.last_submitted_command_buffer = Some(command_buffer);
         }
 
         self.stats.rendered_frames += 1;
@@ -488,6 +615,7 @@ impl MetalRendererImpl {
         };
 
         let source_color = frame.pipeline.source;
+        self.select_output_mode_for_source(source_color);
         self.configure_layer_source_color(&layer, source_color);
         frame.pipeline = frame
             .pipeline
@@ -665,10 +793,14 @@ impl MetalRendererImpl {
                 ProtocolObject::from_ref(&*drawable);
             command_buffer.presentDrawable(drawable_ref);
             command_buffer.commit();
+            self.last_submitted_command_buffer = Some(command_buffer.clone());
             self.pending_gpu_timing = Some(command_buffer);
         }
 
         self.stats.rendered_frames += 1;
+        if self.output_mode.is_edr() {
+            self.stats.edr_rendered_frames = self.stats.edr_rendered_frames.saturating_add(1);
+        }
         if danmaku_item_count > 0 {
             self.stats.danmaku_passes += 1;
             self.stats.danmaku_items += danmaku_item_count as u64;
@@ -1853,7 +1985,22 @@ impl MetalRendererImpl {
     }
 }
 
-fn set_layer_edr_enabled(layer: &CAMetalLayer, enabled: bool) {
+fn configure_layer_dynamic_range(layer: &CAMetalLayer, enabled: bool) {
+    // On macOS, CAMetalLayer scales `drawableSize` through its Retina backing
+    // scale. Setting CALayer.contentsFormat there makes Core Animation treat
+    // the drawable like 1x layer contents and clips the right/bottom at 2x.
+    // UIKit/tvOS layers need contentsFormat to stay aligned with pixelFormat.
+    #[cfg(any(target_os = "ios", target_os = "tvos"))]
+    {
+        let contents_format = unsafe {
+            if enabled {
+                kCAContentsFormatRGBA16Float
+            } else {
+                kCAContentsFormatRGBA8Uint
+            }
+        };
+        layer.setContentsFormat(contents_format);
+    }
     if layer.respondsToSelector(objc2::sel!(setWantsExtendedDynamicRangeContent:)) {
         layer.setWantsExtendedDynamicRangeContent(enabled);
     }

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use crate::core::{
     ColorPrimaries, LumaUpscalerBackendStatus, PlatformSurface, PlayerError, PlayerVideoFrame,
-    RenderFrameContext, RendererBackend, RendererFrameCapture, RendererRuntimeStats, Result,
-    SurfaceMetrics, TransferFunction,
+    RenderFrameContext, RendererBackend, RendererFrameCapture, RendererResourceStats,
+    RendererRuntimeStats, Result, SurfaceMetrics, TransferFunction,
 };
 use crate::danmaku::DanmakuRenderPlan;
 use crate::ffmpeg::{Frame, PlanarFrame};
@@ -88,7 +88,7 @@ impl Default for MetalRendererConfig {
 #[allow(dead_code)]
 pub(crate) fn metal_drawable_pixel_format(mode: MetalOutputMode) -> MetalDrawablePixelFormat {
     match mode {
-        MetalOutputMode::Sdr => MetalDrawablePixelFormat::Bgra8Unorm,
+        MetalOutputMode::Sdr | MetalOutputMode::Auto { .. } => MetalDrawablePixelFormat::Bgra8Unorm,
         MetalOutputMode::AppleEdr { .. } | MetalOutputMode::ExtendedLinear { .. } => {
             MetalDrawablePixelFormat::Rgba16Float
         }
@@ -101,7 +101,7 @@ pub(crate) fn metal_target_color(
     source: SourceColorState,
 ) -> crate::renderer::pipeline::TargetColorState {
     match mode {
-        MetalOutputMode::Sdr => {
+        MetalOutputMode::Sdr | MetalOutputMode::Auto { .. } => {
             crate::renderer::pipeline::TargetColorState::sdr(ColorPrimaries::Bt709)
         }
         MetalOutputMode::AppleEdr { headroom } | MetalOutputMode::ExtendedLinear { headroom } => {
@@ -170,6 +170,10 @@ pub struct MetalRendererStats {
     pub upscaled_frames: u64,
     pub last_upscaler_encode_duration: Duration,
     pub last_gpu_duration: Duration,
+    pub hdr_source_frames: u64,
+    pub edr_rendered_frames: u64,
+    pub sdr_tonemap_frames: u64,
+    pub output_mode_switches: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -225,6 +229,19 @@ impl ImportedVideoFrame {
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         {
             self.inner.as_ref().map_or(0, |inner| inner.plane_count())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+        {
+            0
+        }
+    }
+
+    fn allocated_bytes(&self) -> u64 {
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            self.inner
+                .as_ref()
+                .map_or(0, |inner| inner.allocated_bytes())
         }
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         {
@@ -875,9 +892,9 @@ impl RendererBackend for MetalRenderer {
                 .saturating_sub(self.software_upload_counter),
             shared_handle_video_frames: 0,
             cpu_video_frame_fallbacks: self.software_upload_counter,
-            hdr_source_frames: 0,
+            hdr_source_frames: stats.hdr_source_frames,
             hdr10_output_frames: 0,
-            sdr_tonemap_frames: 0,
+            sdr_tonemap_frames: stats.sdr_tonemap_frames,
             hdr10_metadata_updates: 0,
             hdr10_metadata_failures: 0,
             hdr10_output_failures: 0,
@@ -885,10 +902,33 @@ impl RendererBackend for MetalRenderer {
         }
     }
 
+    fn resource_stats(&self) -> RendererResourceStats {
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            let mut stats = self.inner.resource_stats();
+            stats.video_frame_bytes = self
+                .current_frame
+                .as_ref()
+                .map_or(0, ImportedVideoFrame::allocated_bytes);
+            stats.renderer_tracked_bytes = stats
+                .renderer_tracked_bytes
+                .saturating_add(stats.video_frame_bytes);
+            stats
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+        {
+            RendererResourceStats::default()
+        }
+    }
+
     fn output_status(&self) -> OutputRuntimeStatus {
         let stats = self.stats();
         let attached = stats.drawable_width > 0 && stats.drawable_height > 0;
-        let extended = attached && self.output_mode.is_edr();
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        let active_output_mode = self.inner.active_output_mode();
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+        let active_output_mode = self.output_mode.resolve_for_source(false);
+        let extended = attached && active_output_mode.is_edr();
         OutputRuntimeStatus {
             requested_mode: self.output_mode,
             active_encoding: if extended {
@@ -904,7 +944,7 @@ impl RendererBackend for MetalRenderer {
             native_data_space: -1,
             requested_headroom: self.output_mode.headroom(),
             active_headroom: if extended {
-                self.output_mode.headroom()
+                active_output_mode.headroom()
             } else {
                 1.0
             },
@@ -914,7 +954,7 @@ impl RendererBackend for MetalRenderer {
             fallback_count: 0,
             data_space_failures: 0,
             headroom_updates: 0,
-            extended_linear_frames: if extended { stats.rendered_frames } else { 0 },
+            extended_linear_frames: stats.edr_rendered_frames,
         }
     }
 
@@ -1049,6 +1089,21 @@ mod tests {
         assert_eq!(target.transfer, TransferFunction::Srgb);
         assert_eq!(target.peak_nits, 100.0);
         assert_eq!(target.edr_headroom, 1.0);
+    }
+
+    #[test]
+    fn metal_auto_output_starts_sdr_and_promotes_for_hdr() {
+        let automatic = MetalOutputMode::auto(4.0);
+
+        assert_eq!(
+            metal_drawable_pixel_format(automatic),
+            MetalDrawablePixelFormat::Bgra8Unorm
+        );
+        assert_eq!(automatic.resolve_for_source(false), MetalOutputMode::Sdr);
+        assert_eq!(
+            automatic.resolve_for_source(true),
+            MetalOutputMode::apple_edr(4.0)
+        );
     }
 
     #[test]

--- a/crates/erika/src/renderer/metal/upscaler.rs
+++ b/crates/erika/src/renderer/metal/upscaler.rs
@@ -29,8 +29,9 @@ use objc2::runtime::ProtocolObject;
 use objc2_foundation::NSString;
 use objc2_metal::{
     MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLComputeCommandEncoder,
-    MTLComputePipelineState, MTLDevice, MTLLibrary, MTLPixelFormat, MTLResourceOptions, MTLSize,
-    MTLStorageMode, MTLTexture, MTLTextureDescriptor, MTLTextureType, MTLTextureUsage,
+    MTLComputePipelineState, MTLDevice, MTLLibrary, MTLPixelFormat, MTLResource,
+    MTLResourceOptions, MTLSize, MTLStorageMode, MTLTexture, MTLTextureDescriptor, MTLTextureType,
+    MTLTextureUsage,
 };
 
 use crate::core::{LumaUpscalerBackendStatus, PlayerError, Result};
@@ -184,6 +185,23 @@ impl LumaUpscaler {
 
     pub fn auto_matmul_fallbacks(&self) -> u64 {
         self.auto_matmul_fallbacks
+    }
+
+    pub fn allocated_bytes(&self) -> u64 {
+        match self.resources.as_ref() {
+            Some(BackendResources::Scalar(resources)) => {
+                let pool_bytes = resources.pool.as_ref().map_or(0, |pool| {
+                    pool.features
+                        .iter()
+                        .fold(pool.output.allocatedSize() as u64, |total, texture| {
+                            total.saturating_add(texture.allocatedSize() as u64)
+                        })
+                });
+                (resources.weights.allocatedSize() as u64).saturating_add(pool_bytes)
+            }
+            Some(BackendResources::Matmul(resources)) => resources.allocated_bytes(),
+            None => 0,
+        }
     }
 
     fn record_auto_matmul_failure(&mut self, error: &PlayerError) {

--- a/crates/erika/src/renderer/metal/upscaler_matmul.rs
+++ b/crates/erika/src/renderer/metal/upscaler_matmul.rs
@@ -24,7 +24,8 @@ use objc2_foundation::{NSRange, NSString};
 use objc2_metal::{
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandEncoder,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLDevice, MTLLibrary, MTLPixelFormat,
-    MTLResourceOptions, MTLSize, MTLStorageMode, MTLTexture, MTLTextureDescriptor, MTLTextureUsage,
+    MTLResource, MTLResourceOptions, MTLSize, MTLStorageMode, MTLTexture, MTLTextureDescriptor,
+    MTLTextureUsage,
 };
 
 use crate::core::{PlayerError, Result};
@@ -91,6 +92,17 @@ pub(super) struct Resources {
 impl Resources {
     pub(super) fn mode(&self) -> LumaUpscalerMode {
         self.mode
+    }
+
+    pub(super) fn allocated_bytes(&self) -> u64 {
+        let pool_bytes = self.pool.as_ref().map_or(0, |pool| {
+            pool.features
+                .iter()
+                .fold(pool.output.allocatedSize() as u64, |total, buffer| {
+                    total.saturating_add(buffer.allocatedSize() as u64)
+                })
+        });
+        (self.weights.allocatedSize() as u64).saturating_add(pool_bytes)
     }
 }
 

--- a/crates/erika/src/renderer/output.rs
+++ b/crates/erika/src/renderer/output.rs
@@ -17,6 +17,12 @@ pub enum OutputMode {
     ExtendedLinear {
         headroom: f32,
     },
+    /// Selects SDR or Apple EDR from the decoded source color state. The
+    /// renderer starts with an 8-bit SDR surface and promotes it only for a
+    /// genuine HDR source (PQ, HLG, or HDR luminance metadata).
+    Auto {
+        headroom: f32,
+    },
 }
 
 impl OutputMode {
@@ -33,6 +39,20 @@ impl OutputMode {
         }
     }
 
+    pub fn auto(headroom: f32) -> Self {
+        Self::Auto {
+            headroom: normalized_headroom(headroom),
+        }
+    }
+
+    pub fn resolve_for_source(self, source_is_hdr: bool) -> Self {
+        match self {
+            Self::Auto { headroom } if source_is_hdr && headroom > 1.0 => Self::apple_edr(headroom),
+            Self::Auto { .. } => Self::Sdr,
+            explicit => explicit,
+        }
+    }
+
     pub fn is_edr(self) -> bool {
         matches!(self, Self::AppleEdr { .. } | Self::ExtendedLinear { .. })
     }
@@ -44,9 +64,9 @@ impl OutputMode {
     pub fn headroom(self) -> f32 {
         match self {
             Self::Sdr => 1.0,
-            Self::AppleEdr { headroom } | Self::ExtendedLinear { headroom } => {
-                normalized_headroom(headroom)
-            }
+            Self::AppleEdr { headroom }
+            | Self::ExtendedLinear { headroom }
+            | Self::Auto { headroom } => normalized_headroom(headroom),
         }
     }
 }
@@ -268,6 +288,7 @@ impl OutputDescription {
             OutputMode::Sdr => Self::sdr(),
             OutputMode::AppleEdr { headroom } => Self::apple_edr(headroom),
             OutputMode::ExtendedLinear { headroom } => Self::extended_linear(headroom),
+            OutputMode::Auto { .. } => Self::sdr(),
         }
     }
 
@@ -311,6 +332,25 @@ mod tests {
         assert_eq!(OutputMode::extended_linear(f32::NAN).headroom(), 1.0);
         assert_eq!(OutputMode::extended_linear(0.25).headroom(), 1.0);
         assert_eq!(OutputMode::extended_linear(20_000.0).headroom(), 10_000.0);
+    }
+
+    #[test]
+    fn automatic_output_promotes_only_real_hdr_sources() {
+        let automatic = OutputMode::auto(4.0);
+
+        assert_eq!(automatic.resolve_for_source(false), OutputMode::Sdr);
+        assert_eq!(
+            automatic.resolve_for_source(true),
+            OutputMode::apple_edr(4.0)
+        );
+        assert_eq!(
+            OutputMode::auto(1.0).resolve_for_source(true),
+            OutputMode::Sdr
+        );
+        assert_eq!(
+            OutputDescription::requested(automatic),
+            OutputDescription::sdr()
+        );
     }
 
     #[test]

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -581,7 +581,7 @@ fn select_wgpu_surface_output(
 ) -> Option<WgpuSurfaceOutputSelection> {
     let sdr_format = preferred_sdr_surface_format(formats)?;
     let fallback_reason = match requested {
-        OutputMode::Sdr => OutputFallbackReason::None,
+        OutputMode::Sdr | OutputMode::Auto { .. } => OutputFallbackReason::None,
         OutputMode::AppleEdr { .. } => OutputFallbackReason::LegacyAppleEdrUnsupported,
         OutputMode::ExtendedLinear { .. } if !capabilities.extended_linear => {
             if capabilities.fallback_reason == OutputFallbackReason::None {

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -124,6 +124,7 @@ typedef enum ErikaPresenterOutputMode {
   ErikaPresenterOutputMode_Sdr = 0,
   ErikaPresenterOutputMode_AppleEdr = 1,
   ErikaPresenterOutputMode_ExtendedLinear = 2,
+  ErikaPresenterOutputMode_Auto = 3,
 } ErikaPresenterOutputMode;
 
 typedef enum ErikaActiveOutputEncoding {
@@ -241,6 +242,24 @@ typedef struct ErikaOutputStatus {
   uint64_t headroom_updates;
   uint64_t extended_linear_frames;
 } ErikaOutputStatus;
+
+/* Renderer memory snapshot. Per-resource fields are allocations tracked by
+ * one presenter. device_current_allocated_bytes is Metal's device-wide
+ * process counter and may include allocations owned by other presenters. */
+typedef struct ErikaPresenterResourceStatus {
+  uint64_t device_current_allocated_bytes;
+  uint64_t device_recommended_working_set_bytes;
+  uint64_t drawable_estimated_bytes;
+  uint64_t video_frame_bytes;
+  uint64_t overlay_atlas_bytes;
+  uint64_t danmaku_atlas_bytes;
+  uint64_t danmaku_vertex_buffer_bytes;
+  uint64_t upscaler_bytes;
+  uint64_t renderer_tracked_bytes;
+  uint64_t presenter_cpu_danmaku_atlas_bytes;
+  uint32_t drawable_count;
+  uint64_t output_mode_switches;
+} ErikaPresenterResourceStatus;
 
 typedef struct ErikaSubtitleMemoryFontStatus {
   uintptr_t registered_count;
@@ -544,6 +563,9 @@ ErikaStatus erika_presenter_get_upscaler_status(
 ErikaStatus erika_presenter_get_output_status(
     ErikaPresenterHandle *handle,
     ErikaOutputStatus *out_status);
+ErikaStatus erika_presenter_get_resource_status(
+    ErikaPresenterHandle *handle,
+    ErikaPresenterResourceStatus *out_status);
 ErikaStatus erika_presenter_add_external_subtitle(
     ErikaPresenterHandle *handle,
     const char *uri,

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -364,6 +364,7 @@ pub enum ErikaPresenterOutputMode {
     Sdr = 0,
     AppleEdr = 1,
     ExtendedLinear = 2,
+    Auto = 3,
 }
 
 #[repr(C)]
@@ -385,6 +386,7 @@ impl ErikaPresenterOutputMode {
         match value {
             1 => Self::AppleEdr,
             2 => Self::ExtendedLinear,
+            3 => Self::Auto,
             _ => Self::Sdr,
         }
     }
@@ -544,6 +546,23 @@ pub struct ErikaOutputStatus {
     pub data_space_failures: u64,
     pub headroom_updates: u64,
     pub extended_linear_frames: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ErikaPresenterResourceStatus {
+    pub device_current_allocated_bytes: u64,
+    pub device_recommended_working_set_bytes: u64,
+    pub drawable_estimated_bytes: u64,
+    pub video_frame_bytes: u64,
+    pub overlay_atlas_bytes: u64,
+    pub danmaku_atlas_bytes: u64,
+    pub danmaku_vertex_buffer_bytes: u64,
+    pub upscaler_bytes: u64,
+    pub renderer_tracked_bytes: u64,
+    pub presenter_cpu_danmaku_atlas_bytes: u64,
+    pub drawable_count: u32,
+    pub output_mode_switches: u64,
 }
 
 impl Default for ErikaOutputStatus {
@@ -1328,6 +1347,14 @@ fn presenter_config_from_c(config: ErikaPresenterConfig) -> PresenterConfig {
             };
             MetalOutputMode::extended_linear(headroom)
         }
+        ErikaPresenterOutputMode::Auto => {
+            let headroom = if config.edr_headroom.is_finite() {
+                config.edr_headroom
+            } else {
+                1.0
+            };
+            MetalOutputMode::auto(headroom)
+        }
         ErikaPresenterOutputMode::Sdr => MetalOutputMode::Sdr,
     };
 
@@ -1447,6 +1474,7 @@ fn output_status_to_c(status: OutputRuntimeStatus) -> ErikaOutputStatus {
         OutputMode::Sdr => ErikaPresenterOutputMode::Sdr as i32,
         OutputMode::AppleEdr { .. } => ErikaPresenterOutputMode::AppleEdr as i32,
         OutputMode::ExtendedLinear { .. } => ErikaPresenterOutputMode::ExtendedLinear as i32,
+        OutputMode::Auto { .. } => ErikaPresenterOutputMode::Auto as i32,
     };
     let active_encoding = match status.active_encoding {
         ActiveOutputEncoding::SdrSrgb => 0,
@@ -1473,6 +1501,33 @@ fn output_status_to_c(status: OutputRuntimeStatus) -> ErikaOutputStatus {
         data_space_failures: status.data_space_failures,
         headroom_updates: status.headroom_updates,
         extended_linear_frames: status.extended_linear_frames,
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+))]
+fn resource_status_to_c(snapshot: PresenterRuntimeSnapshot) -> ErikaPresenterResourceStatus {
+    let resources = snapshot.resources;
+    ErikaPresenterResourceStatus {
+        device_current_allocated_bytes: resources.device_current_allocated_bytes,
+        device_recommended_working_set_bytes: resources.device_recommended_working_set_bytes,
+        drawable_estimated_bytes: resources.drawable_estimated_bytes,
+        video_frame_bytes: resources.video_frame_bytes,
+        overlay_atlas_bytes: resources.overlay_atlas_bytes,
+        danmaku_atlas_bytes: resources.danmaku_atlas_bytes,
+        danmaku_vertex_buffer_bytes: resources.danmaku_vertex_buffer_bytes,
+        upscaler_bytes: resources.upscaler_bytes,
+        renderer_tracked_bytes: resources.renderer_tracked_bytes,
+        presenter_cpu_danmaku_atlas_bytes: snapshot
+            .current_danmaku_atlas_bytes
+            .min(u64::MAX as usize) as u64,
+        drawable_count: resources.drawable_count,
+        output_mode_switches: resources.output_mode_switches,
     }
 }
 
@@ -2087,6 +2142,28 @@ pub unsafe extern "C" fn erika_presenter_get_output_status(
     target_env = "ohos"
 ))]
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_get_resource_status(
+    handle: *mut ErikaPresenterHandle,
+    out_status: *mut ErikaPresenterResourceStatus,
+) -> ErikaStatus {
+    if out_status.is_null() {
+        return ErikaStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        let status = resource_status_to_c(handle.presenter.runtime_snapshot());
+        unsafe { *out_status = status };
+        ErikaStatus::Ok
+    })
+}
+
+#[cfg(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+))]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_add_external_subtitle(
     handle: *mut ErikaPresenterHandle,
     uri: *const c_char,
@@ -2123,6 +2200,24 @@ pub unsafe extern "C" fn erika_presenter_add_external_subtitle(
     _uri: *const c_char,
     _out_track_id: *mut i64,
 ) -> ErikaStatus {
+    ErikaStatus::PlayerError
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+)))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_get_resource_status(
+    _handle: *mut std::ffi::c_void,
+    out_status: *mut ErikaPresenterResourceStatus,
+) -> ErikaStatus {
+    if out_status.is_null() {
+        return ErikaStatus::NullPointer;
+    }
     ErikaStatus::PlayerError
 }
 
@@ -4726,6 +4821,37 @@ mod tests {
         target_env = "ohos"
     ))]
     #[test]
+    fn c_presenter_reports_resource_status_without_changing_stats_abi() {
+        assert_eq!(
+            unsafe {
+                erika_presenter_get_resource_status(std::ptr::null_mut(), std::ptr::null_mut())
+            },
+            ErikaStatus::NullPointer
+        );
+
+        let handle = erika_presenter_create();
+        assert!(!handle.is_null());
+        let mut status = ErikaPresenterResourceStatus::default();
+        assert_eq!(
+            unsafe { erika_presenter_get_resource_status(handle, &mut status) },
+            ErikaStatus::Ok
+        );
+        assert_eq!(status.drawable_estimated_bytes, 0);
+        assert_eq!(status.video_frame_bytes, 0);
+        assert_eq!(status.renderer_tracked_bytes, 0);
+        assert_eq!(status.drawable_count, 0);
+        assert_eq!(status.output_mode_switches, 0);
+        unsafe { erika_presenter_destroy(handle) };
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        any(target_os = "ios", target_os = "tvos"),
+        target_os = "windows",
+        target_os = "android",
+        target_env = "ohos"
+    ))]
+    #[test]
     fn c_presenter_can_be_created_with_edr_config() {
         let handle = erika_presenter_create_with_config(ErikaPresenterConfig {
             output_mode: ErikaPresenterOutputMode::AppleEdr as i32,
@@ -4800,6 +4926,14 @@ mod tests {
                 ..ErikaPresenterConfig::default()
             }),
             MetalOutputMode::extended_linear(3.0)
+        );
+        assert_eq!(
+            metal_output_mode_from_c(ErikaPresenterConfig {
+                output_mode: ErikaPresenterOutputMode::Auto as i32,
+                edr_headroom: 2.5,
+                ..ErikaPresenterConfig::default()
+            }),
+            MetalOutputMode::auto(2.5)
         );
         assert_eq!(
             metal_output_mode_from_c(ErikaPresenterConfig {

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -35,9 +35,16 @@ private func erikaHdrEnvironmentEnabled() -> Bool {
 }
 
 private func erikaOutputModeLabel(_ config: ErikaPresenterConfigC) -> String {
-  config.outputMode == 1
-    ? String(format: "AppleEdr(headroom=%.2f)", config.edrHeadroom)
-    : "Sdr"
+  switch config.outputMode {
+  case 1:
+    return String(format: "AppleEdr(headroom=%.2f)", config.edrHeadroom)
+  case 2:
+    return String(format: "ExtendedLinear(headroom=%.2f)", config.edrHeadroom)
+  case 3:
+    return String(format: "Auto(headroom=%.2f)", config.edrHeadroom)
+  default:
+    return "Sdr"
+  }
 }
 
 private func erikaScreenSummary(_ screen: UIScreen?) -> String {
@@ -66,7 +73,7 @@ private func erikaLayerValue(_ layer: CAMetalLayer, selector name: String) -> St
 }
 
 private func erikaConfigureLayerDynamicRange(_ layer: CAMetalLayer, config: ErikaPresenterConfigC) {
-  if config.outputMode == 1 {
+  if config.outputMode == 1 || config.outputMode == 2 {
     layer.contentsFormat = .RGBA16Float
     if #available(iOS 16.0, *) {
       layer.wantsExtendedDynamicRangeContent = true
@@ -83,15 +90,20 @@ private func erikaConfigureLayerDynamicRange(_ layer: CAMetalLayer, config: Erik
       layer.preferredDynamicRange = .high
       layer.contentsHeadroom = CGFloat(max(config.edrHeadroom, 1.0))
     }
-  } else {
-    layer.contentsFormat = .RGBA8Uint
-    if #available(iOS 16.0, *) {
-      layer.wantsExtendedDynamicRangeContent = false
-      layer.edrMetadata = nil
-    }
-    if #available(iOS 18.0, *) {
-      layer.toneMapMode = .automatic
-    }
+    return
+  }
+
+  layer.contentsFormat = .RGBA8Uint
+  if #available(iOS 16.0, *) {
+    layer.wantsExtendedDynamicRangeContent = false
+    layer.edrMetadata = nil
+  }
+  if #available(iOS 18.0, *) {
+    layer.toneMapMode = .automatic
+  }
+  // Auto is initialized in SDR, but the native renderer owns later changes.
+  // Do not pin preferredDynamicRange/contentsHeadroom to SDR here.
+  if config.outputMode != 3 {
     if #available(iOS 26.0, *) {
       layer.preferredDynamicRange = .standard
       layer.contentsHeadroom = 0.0
@@ -189,6 +201,10 @@ private struct ErikaPresenterConfigC {
 
   static func appleEdr(headroom: Float) -> ErikaPresenterConfigC {
     ErikaPresenterConfigC(outputMode: 1, edrHeadroom: max(1.0, headroom))
+  }
+
+  static func auto(headroom: Float) -> ErikaPresenterConfigC {
+    ErikaPresenterConfigC(outputMode: 3, edrHeadroom: max(1.0, headroom))
   }
 }
 
@@ -306,6 +322,22 @@ private struct ErikaOutputStatusC {
   var extendedLinearFrames: UInt64 = 0
 }
 
+// Keep field order and types aligned with `ErikaPresenterResourceStatus` in erika.h.
+private struct ErikaPresenterResourceStatusC {
+  var deviceCurrentAllocatedBytes: UInt64 = 0
+  var deviceRecommendedWorkingSetBytes: UInt64 = 0
+  var drawableEstimatedBytes: UInt64 = 0
+  var videoFrameBytes: UInt64 = 0
+  var overlayAtlasBytes: UInt64 = 0
+  var danmakuAtlasBytes: UInt64 = 0
+  var danmakuVertexBufferBytes: UInt64 = 0
+  var upscalerBytes: UInt64 = 0
+  var rendererTrackedBytes: UInt64 = 0
+  var presenterCpuDanmakuAtlasBytes: UInt64 = 0
+  var drawableCount: UInt32 = 0
+  var outputModeSwitches: UInt64 = 0
+}
+
 private let erikaDefaultDisplayFps = 60
 
 private struct ErikaDanmakuConfigC {
@@ -407,6 +439,7 @@ private final class ErikaNativeLibrary {
   typealias FreeSubtitleMemoryFontStatusFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias GetOutputStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias GetResourceStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -480,6 +513,7 @@ private final class ErikaNativeLibrary {
   let freeSubtitleMemoryFontStatus: FreeSubtitleMemoryFontStatusFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let getOutputStatus: GetOutputStatusFn?
+  let getResourceStatus: GetResourceStatusFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -549,6 +583,7 @@ private final class ErikaNativeLibrary {
     freeSubtitleMemoryFontStatus = Self.loadOptional("erika_subtitle_memory_font_status_free", from: libraryHandle, as: FreeSubtitleMemoryFontStatusFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     getOutputStatus = Self.loadOptional("erika_presenter_get_output_status", from: libraryHandle, as: GetOutputStatusFn.self)
+    getResourceStatus = Self.loadOptional("erika_presenter_get_resource_status", from: libraryHandle, as: GetResourceStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("erika_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("erika_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -1053,6 +1088,20 @@ private final class ErikaPlayerHost {
     return status.toFlutterMap()
   }
 
+  func resourceStatus() throws -> [String: Any] {
+    guard let getStatus = library.getResourceStatus else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_get_resource_status")
+    }
+    var status = ErikaPresenterResourceStatusC()
+    let result = withNativeCall {
+      withUnsafeMutablePointer(to: &status) { pointer in
+        getStatus(handle, UnsafeMutableRawPointer(pointer))
+      }
+    }
+    try check(result, operation: "get_resource_status")
+    return status.toFlutterMap()
+  }
+
   func presenterStats() -> [String: Any] {
     nativeCallLock.lock()
     defer { nativeCallLock.unlock() }
@@ -1507,7 +1556,9 @@ private final class ErikaPlayerHost {
   private func attachOrResize(view: ErikaMetalSurfaceView, attach: Bool) throws {
     nativeCallLock.lock()
     defer { nativeCallLock.unlock() }
-    erikaConfigureLayerDynamicRange(view.metalLayer, config: presenterConfig)
+    if attach || presenterConfig.outputMode != 3 {
+      erikaConfigureLayerDynamicRange(view.metalLayer, config: presenterConfig)
+    }
     view.updateDrawableSize()
     let width = UInt32(max(1.0, view.metalLayer.drawableSize.width).rounded())
     let height = UInt32(max(1.0, view.metalLayer.drawableSize.height).rounded())
@@ -2124,6 +2175,9 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "getOutputStatus":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).outputStatus())
+      case "getResourceStatus":
+        let args = try dictionaryArgs(call.arguments)
+        result(try playerHost(from: args).resourceStatus())
       case "getPresenterStats":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).presenterStats())
@@ -2709,7 +2763,17 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   private func presenterConfigForNewPlayer(arguments: Any?, hdrDebug: Bool) -> ErikaPresenterConfigC {
     if let args = arguments as? [String: Any], let explicitMode = int32Value(args["outputMode"]) {
       let headroom = floatValue(args["edrHeadroom"]) ?? 4.0
-      let config = explicitMode == 1 ? ErikaPresenterConfigC.appleEdr(headroom: headroom) : .sdr
+      let config: ErikaPresenterConfigC
+      switch explicitMode {
+      case 1:
+        config = .appleEdr(headroom: headroom)
+      case 2:
+        config = ErikaPresenterConfigC(outputMode: 2, edrHeadroom: max(1.0, headroom))
+      case 3:
+        config = .auto(headroom: headroom)
+      default:
+        config = .sdr
+      }
       erikaHdrLog(
         hdrDebug,
         "create explicit outputMode=\(explicitMode) requestedHeadroom=\(String(format: "%.3f", headroom)) selected=\(erikaOutputModeLabel(config))"
@@ -2717,7 +2781,7 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       return config
     }
     let headroom = resolvedEdrHeadroom(hdrDebug: hdrDebug)
-    let config = headroom > 1.0 ? ErikaPresenterConfigC.appleEdr(headroom: headroom) : .sdr
+    let config = ErikaPresenterConfigC.auto(headroom: headroom)
     erikaHdrLog(
       hdrDebug,
       "create auto selected=\(erikaOutputModeLabel(config)) resolvedHeadroom=\(String(format: "%.3f", headroom))"
@@ -3011,6 +3075,25 @@ private extension ErikaOutputStatusC {
       "dataSpaceFailures": Int64(clamping: dataSpaceFailures),
       "headroomUpdates": Int64(clamping: headroomUpdates),
       "extendedLinearFrames": Int64(clamping: extendedLinearFrames),
+    ]
+  }
+}
+
+private extension ErikaPresenterResourceStatusC {
+  func toFlutterMap() -> [String: Any] {
+    [
+      "deviceCurrentAllocatedBytes": Int64(clamping: deviceCurrentAllocatedBytes),
+      "deviceRecommendedWorkingSetBytes": Int64(clamping: deviceRecommendedWorkingSetBytes),
+      "drawableEstimatedBytes": Int64(clamping: drawableEstimatedBytes),
+      "videoFrameBytes": Int64(clamping: videoFrameBytes),
+      "overlayAtlasBytes": Int64(clamping: overlayAtlasBytes),
+      "danmakuAtlasBytes": Int64(clamping: danmakuAtlasBytes),
+      "danmakuVertexBufferBytes": Int64(clamping: danmakuVertexBufferBytes),
+      "upscalerBytes": Int64(clamping: upscalerBytes),
+      "rendererTrackedBytes": Int64(clamping: rendererTrackedBytes),
+      "presenterCpuDanmakuAtlasBytes": Int64(clamping: presenterCpuDanmakuAtlasBytes),
+      "drawableCount": Int(drawableCount),
+      "outputModeSwitches": Int64(clamping: outputModeSwitches),
     ]
   }
 }

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -60,7 +60,8 @@ const int kErikaSubtitleOverrideAll = kErikaSubtitleOverrideFontSizeFields |
 enum ErikaOutputMode {
   sdr(0),
   appleEdr(1),
-  extendedLinear(2);
+  extendedLinear(2),
+  auto(3);
 
   const ErikaOutputMode(this.nativeValue);
 
@@ -70,6 +71,7 @@ enum ErikaOutputMode {
     return switch (value) {
       1 => ErikaOutputMode.appleEdr,
       2 => ErikaOutputMode.extendedLinear,
+      3 => ErikaOutputMode.auto,
       _ => ErikaOutputMode.sdr,
     };
   }
@@ -206,6 +208,61 @@ class ErikaOutputStatus {
       dataSpaceFailures: (map['dataSpaceFailures'] as num?)?.toInt() ?? 0,
       headroomUpdates: (map['headroomUpdates'] as num?)?.toInt() ?? 0,
       extendedLinearFrames: (map['extendedLinearFrames'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class ErikaPresenterResourceStatus {
+  const ErikaPresenterResourceStatus({
+    required this.deviceCurrentAllocatedBytes,
+    required this.deviceRecommendedWorkingSetBytes,
+    required this.drawableEstimatedBytes,
+    required this.videoFrameBytes,
+    required this.overlayAtlasBytes,
+    required this.danmakuAtlasBytes,
+    required this.danmakuVertexBufferBytes,
+    required this.upscalerBytes,
+    required this.rendererTrackedBytes,
+    required this.presenterCpuDanmakuAtlasBytes,
+    required this.drawableCount,
+    required this.outputModeSwitches,
+  });
+
+  /// Metal's process-wide counter for the current device. This can include
+  /// allocations from other Erika presenters and other Metal users.
+  final int deviceCurrentAllocatedBytes;
+  final int deviceRecommendedWorkingSetBytes;
+  final int drawableEstimatedBytes;
+  final int videoFrameBytes;
+  final int overlayAtlasBytes;
+  final int danmakuAtlasBytes;
+  final int danmakuVertexBufferBytes;
+  final int upscalerBytes;
+  final int rendererTrackedBytes;
+  final int presenterCpuDanmakuAtlasBytes;
+  final int drawableCount;
+  final int outputModeSwitches;
+
+  factory ErikaPresenterResourceStatus.fromMap(Map<dynamic, dynamic> map) {
+    int value(String key) => (map[key] as num?)?.toInt() ?? 0;
+
+    return ErikaPresenterResourceStatus(
+      deviceCurrentAllocatedBytes: value('deviceCurrentAllocatedBytes'),
+      deviceRecommendedWorkingSetBytes: value(
+        'deviceRecommendedWorkingSetBytes',
+      ),
+      drawableEstimatedBytes: value('drawableEstimatedBytes'),
+      videoFrameBytes: value('videoFrameBytes'),
+      overlayAtlasBytes: value('overlayAtlasBytes'),
+      danmakuAtlasBytes: value('danmakuAtlasBytes'),
+      danmakuVertexBufferBytes: value('danmakuVertexBufferBytes'),
+      upscalerBytes: value('upscalerBytes'),
+      rendererTrackedBytes: value('rendererTrackedBytes'),
+      presenterCpuDanmakuAtlasBytes: value(
+        'presenterCpuDanmakuAtlasBytes',
+      ),
+      drawableCount: value('drawableCount'),
+      outputModeSwitches: value('outputModeSwitches'),
     );
   }
 }
@@ -1084,6 +1141,18 @@ class ErikaPlayer {
       throw StateError('Erika output status returned null.');
     }
     return ErikaOutputStatus.fromMap(status);
+  }
+
+  Future<ErikaPresenterResourceStatus> getResourceStatus() async {
+    final playerId = await ensureCreated();
+    final status = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      'getResourceStatus',
+      <String, Object?>{'playerId': playerId},
+    );
+    if (status == null) {
+      throw StateError('Erika resource status returned null.');
+    }
+    return ErikaPresenterResourceStatus.fromMap(status);
   }
 
   Future<ErikaPresenterStats> getPresenterStats() async {

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -172,6 +172,10 @@ private struct ErikaPresenterConfigC {
   static func appleEdr(headroom: Float) -> ErikaPresenterConfigC {
     ErikaPresenterConfigC(outputMode: 1, edrHeadroom: max(1.0, headroom))
   }
+
+  static func auto(headroom: Float) -> ErikaPresenterConfigC {
+    ErikaPresenterConfigC(outputMode: 3, edrHeadroom: max(1.0, headroom))
+  }
 }
 
 private struct ErikaSubtitleStyleC {
@@ -288,6 +292,22 @@ private struct ErikaOutputStatusC {
   var extendedLinearFrames: UInt64 = 0
 }
 
+// Keep field order and types aligned with `ErikaPresenterResourceStatus` in erika.h.
+private struct ErikaPresenterResourceStatusC {
+  var deviceCurrentAllocatedBytes: UInt64 = 0
+  var deviceRecommendedWorkingSetBytes: UInt64 = 0
+  var drawableEstimatedBytes: UInt64 = 0
+  var videoFrameBytes: UInt64 = 0
+  var overlayAtlasBytes: UInt64 = 0
+  var danmakuAtlasBytes: UInt64 = 0
+  var danmakuVertexBufferBytes: UInt64 = 0
+  var upscalerBytes: UInt64 = 0
+  var rendererTrackedBytes: UInt64 = 0
+  var presenterCpuDanmakuAtlasBytes: UInt64 = 0
+  var drawableCount: UInt32 = 0
+  var outputModeSwitches: UInt64 = 0
+}
+
 private struct ErikaDanmakuConfigC {
   var enabled: UInt8 = 1
   // NipaPlay/Flutter logical font size; Erika applies the surface scale internally.
@@ -393,6 +413,7 @@ private final class ErikaNativeLibrary {
   typealias FreeSubtitleMemoryFontStatusFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias GetOutputStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias GetResourceStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -465,6 +486,7 @@ private final class ErikaNativeLibrary {
   let freeSubtitleMemoryFontStatus: FreeSubtitleMemoryFontStatusFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let getOutputStatus: GetOutputStatusFn?
+  let getResourceStatus: GetResourceStatusFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -527,6 +549,7 @@ private final class ErikaNativeLibrary {
     freeSubtitleMemoryFontStatus = Self.loadOptional("erika_subtitle_memory_font_status_free", from: libraryHandle, as: FreeSubtitleMemoryFontStatusFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     getOutputStatus = Self.loadOptional("erika_presenter_get_output_status", from: libraryHandle, as: GetOutputStatusFn.self)
+    getResourceStatus = Self.loadOptional("erika_presenter_get_resource_status", from: libraryHandle, as: GetResourceStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("erika_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("erika_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -1021,6 +1044,20 @@ private final class ErikaPlayerHost {
       }
     }
     try check(result, operation: "get_output_status")
+    return status.toFlutterMap()
+  }
+
+  func resourceStatus() throws -> [String: Any] {
+    guard let getStatus = library.getResourceStatus else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_get_resource_status")
+    }
+    var status = ErikaPresenterResourceStatusC()
+    let result = withNativeCall {
+      withUnsafeMutablePointer(to: &status) { pointer in
+        getStatus(handle, UnsafeMutableRawPointer(pointer))
+      }
+    }
+    try check(result, operation: "get_resource_status")
     return status.toFlutterMap()
   }
 
@@ -1711,6 +1748,25 @@ private extension ErikaOutputStatusC {
   }
 }
 
+private extension ErikaPresenterResourceStatusC {
+  func toFlutterMap() -> [String: Any] {
+    [
+      "deviceCurrentAllocatedBytes": Int64(clamping: deviceCurrentAllocatedBytes),
+      "deviceRecommendedWorkingSetBytes": Int64(clamping: deviceRecommendedWorkingSetBytes),
+      "drawableEstimatedBytes": Int64(clamping: drawableEstimatedBytes),
+      "videoFrameBytes": Int64(clamping: videoFrameBytes),
+      "overlayAtlasBytes": Int64(clamping: overlayAtlasBytes),
+      "danmakuAtlasBytes": Int64(clamping: danmakuAtlasBytes),
+      "danmakuVertexBufferBytes": Int64(clamping: danmakuVertexBufferBytes),
+      "upscalerBytes": Int64(clamping: upscalerBytes),
+      "rendererTrackedBytes": Int64(clamping: rendererTrackedBytes),
+      "presenterCpuDanmakuAtlasBytes": Int64(clamping: presenterCpuDanmakuAtlasBytes),
+      "drawableCount": Int(drawableCount),
+      "outputModeSwitches": Int64(clamping: outputModeSwitches),
+    ]
+  }
+}
+
 private extension ErikaPresenterStatsC {
   func toFlutterMap() -> [String: Any] {
     [
@@ -2310,6 +2366,9 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "getOutputStatus":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).outputStatus())
+      case "getResourceStatus":
+        let args = try dictionaryArgs(call.arguments)
+        result(try playerHost(from: args).resourceStatus())
       case "getPresenterStats":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).presenterStats())
@@ -2961,17 +3020,18 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       switch explicitMode {
       case 1:
         return .appleEdr(headroom: headroom)
+      case 2:
+        return ErikaPresenterConfigC(outputMode: 2, edrHeadroom: max(1.0, headroom))
+      case 3:
+        return .auto(headroom: headroom)
       default:
         return .sdr
       }
     }
 
     let headroom = resolvedEdrHeadroom()
-    if headroom > 1.0 {
-      NSLog("ErikaFlutterPlugin: using Apple EDR output, headroom \(headroom)x")
-      return .appleEdr(headroom: headroom)
-    }
-    return .sdr
+    NSLog("ErikaFlutterPlugin: using automatic Apple output, headroom \(headroom)x")
+    return .auto(headroom: headroom)
   }
 
   private func resolvedEdrHeadroom() -> Float {

--- a/packages/erika_flutter/test/apple_output_mode_contract_test.dart
+++ b/packages/erika_flutter/test/apple_output_mode_contract_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('automatic output mode keeps the native ABI value 3', () {
+    final header = File(
+      '../../crates/erika_capi/include/erika.h',
+    ).readAsStringSync();
+    final dart = File('lib/src/erika_player.dart').readAsStringSync();
+
+    expect(header, contains('ErikaPresenterOutputMode_Auto = 3'));
+    expect(dart, contains('auto(3)'));
+    expect(dart, contains('3 => ErikaOutputMode.auto'));
+  });
+
+  for (final platform in <String>['macos', 'ios', 'tvos']) {
+    test('$platform defaults Apple output to source-aware auto mode', () {
+      final plugin = File(
+        '$platform/Classes/ErikaFlutterPlugin.swift',
+      ).readAsStringSync();
+
+      expect(
+        plugin,
+        anyOf(
+          contains(
+              'let config = ErikaPresenterConfigC.auto(headroom: headroom)'),
+          contains('return .auto(headroom: headroom)'),
+        ),
+      );
+      expect(plugin, contains('case 3:'));
+      expect(plugin, contains('getResourceStatus'));
+      expect(plugin, contains('erika_presenter_get_resource_status'));
+    });
+  }
+
+  for (final platform in <String>['ios', 'tvos']) {
+    test('$platform does not reset active auto output during resize', () {
+      final plugin = File(
+        '$platform/Classes/ErikaFlutterPlugin.swift',
+      ).readAsStringSync();
+
+      expect(plugin, contains('if attach || presenterConfig.outputMode != 3'));
+    });
+  }
+
+  test('Metal limits contentsFormat switching to UIKit and tvOS', () {
+    final renderer = File(
+      '../../crates/erika/src/renderer/metal/apple.rs',
+    ).readAsStringSync();
+
+    expect(renderer, contains('layer.setPixelFormat('));
+    expect(
+      renderer,
+      contains(
+        '#[cfg(any(target_os = "ios", target_os = "tvos"))]\n'
+        '    {\n'
+        '        let contents_format',
+      ),
+    );
+    expect(renderer, contains('layer.setContentsFormat(contents_format)'));
+    expect(renderer, contains('kCAContentsFormatRGBA16Float'));
+    expect(renderer, contains('kCAContentsFormatRGBA8Uint'));
+    expect(renderer, contains('clips the right/bottom at 2x'));
+  });
+}

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -60,6 +60,11 @@ void main() {
     await player.dispose();
   });
 
+  test('automatic output mode keeps the C ABI value 3', () {
+    expect(ErikaOutputMode.auto.nativeValue, 3);
+    expect(ErikaOutputMode.fromNativeValue(3), ErikaOutputMode.auto);
+  });
+
   test('background playback is opt-in at player creation', () async {
     final player = ErikaPlayer(allowBackgroundPlayback: true);
 
@@ -1128,6 +1133,49 @@ void main() {
       await player.dispose();
     },
   );
+
+  test('renderer resource status is decoded from native presenter', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(playerChannel, (MethodCall call) async {
+      playerCalls.add(call);
+      return switch (call.method) {
+        'create' => 7,
+        'getResourceStatus' => <String, Object?>{
+            'deviceCurrentAllocatedBytes': 1000000000,
+            'deviceRecommendedWorkingSetBytes': 8000000000,
+            'drawableEstimatedBytes': 99532800,
+            'videoFrameBytes': 24883200,
+            'overlayAtlasBytes': 2097152,
+            'danmakuAtlasBytes': 4194304,
+            'danmakuVertexBufferBytes': 65536,
+            'upscalerBytes': 0,
+            'rendererTrackedBytes': 130772992,
+            'presenterCpuDanmakuAtlasBytes': 4194304,
+            'drawableCount': 3,
+            'outputModeSwitches': 1,
+          },
+        'dispose' => null,
+        _ => null,
+      };
+    });
+
+    final player = ErikaPlayer();
+    final status = await player.getResourceStatus();
+
+    expect(status.deviceCurrentAllocatedBytes, 1000000000);
+    expect(status.drawableEstimatedBytes, 99532800);
+    expect(status.videoFrameBytes, 24883200);
+    expect(status.rendererTrackedBytes, 130772992);
+    expect(status.drawableCount, 3);
+    expect(status.outputModeSwitches, 1);
+
+    final call = playerCalls.singleWhere(
+      (MethodCall call) => call.method == 'getResourceStatus',
+    );
+    expect(call.arguments, <String, Object?>{'playerId': 7});
+
+    await player.dispose();
+  });
 
   test('subtitle style forwards font and colors with defaults', () async {
     final player = ErikaPlayer();

--- a/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
@@ -35,9 +35,16 @@ private func erikaHdrEnvironmentEnabled() -> Bool {
 }
 
 private func erikaOutputModeLabel(_ config: ErikaPresenterConfigC) -> String {
-  config.outputMode == 1
-    ? String(format: "AppleEdr(headroom=%.2f)", config.edrHeadroom)
-    : "Sdr"
+  switch config.outputMode {
+  case 1:
+    return String(format: "AppleEdr(headroom=%.2f)", config.edrHeadroom)
+  case 2:
+    return String(format: "ExtendedLinear(headroom=%.2f)", config.edrHeadroom)
+  case 3:
+    return String(format: "Auto(headroom=%.2f)", config.edrHeadroom)
+  default:
+    return "Sdr"
+  }
 }
 
 private func erikaScreenSummary(_ screen: UIScreen?) -> String {
@@ -65,7 +72,7 @@ private func erikaLayerValue(_ layer: CAMetalLayer, selector name: String) -> St
 }
 
 private func erikaConfigureLayerDynamicRange(_ layer: CAMetalLayer, config: ErikaPresenterConfigC) {
-  if config.outputMode == 1 {
+  if config.outputMode == 1 || config.outputMode == 2 {
     layer.contentsFormat = .RGBA16Float
     if #available(tvOS 18.0, *) {
       layer.toneMapMode = .ifSupported
@@ -74,11 +81,16 @@ private func erikaConfigureLayerDynamicRange(_ layer: CAMetalLayer, config: Erik
       layer.preferredDynamicRange = .high
       layer.contentsHeadroom = CGFloat(max(config.edrHeadroom, 1.0))
     }
-  } else {
-    layer.contentsFormat = .RGBA8Uint
-    if #available(tvOS 18.0, *) {
-      layer.toneMapMode = .automatic
-    }
+    return
+  }
+
+  layer.contentsFormat = .RGBA8Uint
+  if #available(tvOS 18.0, *) {
+    layer.toneMapMode = .automatic
+  }
+  // Auto is initialized in SDR, but the native renderer owns later changes.
+  // Do not pin preferredDynamicRange/contentsHeadroom to SDR here.
+  if config.outputMode != 3 {
     if #available(tvOS 26.0, *) {
       layer.preferredDynamicRange = .standard
       layer.contentsHeadroom = 0.0
@@ -171,6 +183,10 @@ private struct ErikaPresenterConfigC {
 
   static func appleEdr(headroom: Float) -> ErikaPresenterConfigC {
     ErikaPresenterConfigC(outputMode: 1, edrHeadroom: max(1.0, headroom))
+  }
+
+  static func auto(headroom: Float) -> ErikaPresenterConfigC {
+    ErikaPresenterConfigC(outputMode: 3, edrHeadroom: max(1.0, headroom))
   }
 }
 
@@ -288,6 +304,22 @@ private struct ErikaOutputStatusC {
   var extendedLinearFrames: UInt64 = 0
 }
 
+// Keep field order and types aligned with `ErikaPresenterResourceStatus` in erika.h.
+private struct ErikaPresenterResourceStatusC {
+  var deviceCurrentAllocatedBytes: UInt64 = 0
+  var deviceRecommendedWorkingSetBytes: UInt64 = 0
+  var drawableEstimatedBytes: UInt64 = 0
+  var videoFrameBytes: UInt64 = 0
+  var overlayAtlasBytes: UInt64 = 0
+  var danmakuAtlasBytes: UInt64 = 0
+  var danmakuVertexBufferBytes: UInt64 = 0
+  var upscalerBytes: UInt64 = 0
+  var rendererTrackedBytes: UInt64 = 0
+  var presenterCpuDanmakuAtlasBytes: UInt64 = 0
+  var drawableCount: UInt32 = 0
+  var outputModeSwitches: UInt64 = 0
+}
+
 private let erikaDefaultDisplayFps = 60
 
 private struct ErikaDanmakuConfigC {
@@ -392,6 +424,7 @@ private final class ErikaNativeLibrary {
   typealias FreeSubtitleMemoryFontStatusFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias GetUpscalerStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias GetOutputStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
+  typealias GetResourceStatusFn = @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?) -> Int32
   typealias SelectTrackFn = @convention(c) (UnsafeMutableRawPointer?, Int64) -> Int32
   typealias AddExternalSubtitleFn = @convention(c) (
     UnsafeMutableRawPointer?,
@@ -464,6 +497,7 @@ private final class ErikaNativeLibrary {
   let freeSubtitleMemoryFontStatus: FreeSubtitleMemoryFontStatusFn?
   let getUpscalerStatus: GetUpscalerStatusFn?
   let getOutputStatus: GetOutputStatusFn?
+  let getResourceStatus: GetResourceStatusFn?
   let selectAudioTrack: SelectTrackFn
   let selectSubtitleTrack: SelectTrackFn
   let addExternalSubtitle: AddExternalSubtitleFn
@@ -532,6 +566,7 @@ private final class ErikaNativeLibrary {
     freeSubtitleMemoryFontStatus = Self.loadOptional("erika_subtitle_memory_font_status_free", from: libraryHandle, as: FreeSubtitleMemoryFontStatusFn.self)
     getUpscalerStatus = Self.loadOptional("erika_presenter_get_upscaler_status", from: libraryHandle, as: GetUpscalerStatusFn.self)
     getOutputStatus = Self.loadOptional("erika_presenter_get_output_status", from: libraryHandle, as: GetOutputStatusFn.self)
+    getResourceStatus = Self.loadOptional("erika_presenter_get_resource_status", from: libraryHandle, as: GetResourceStatusFn.self)
     selectAudioTrack = try Self.load("erika_presenter_select_audio_track", from: libraryHandle, as: SelectTrackFn.self)
     selectSubtitleTrack = try Self.load("erika_presenter_select_subtitle_track", from: libraryHandle, as: SelectTrackFn.self)
     addExternalSubtitle = try Self.load("erika_presenter_add_external_subtitle", from: libraryHandle, as: AddExternalSubtitleFn.self)
@@ -1003,6 +1038,20 @@ private final class ErikaPlayerHost {
     return status.toFlutterMap()
   }
 
+  func resourceStatus() throws -> [String: Any] {
+    guard let getStatus = library.getResourceStatus else {
+      throw ErikaPluginError.symbolMissing("erika_presenter_get_resource_status")
+    }
+    var status = ErikaPresenterResourceStatusC()
+    let result = withNativeCall {
+      withUnsafeMutablePointer(to: &status) { pointer in
+        getStatus(handle, UnsafeMutableRawPointer(pointer))
+      }
+    }
+    try check(result, operation: "get_resource_status")
+    return status.toFlutterMap()
+  }
+
   func presenterStats() -> [String: Any] {
     nativeCallLock.lock()
     defer { nativeCallLock.unlock() }
@@ -1434,7 +1483,9 @@ private final class ErikaPlayerHost {
   private func attachOrResize(view: ErikaMetalSurfaceView, attach: Bool) throws {
     nativeCallLock.lock()
     defer { nativeCallLock.unlock() }
-    erikaConfigureLayerDynamicRange(view.metalLayer, config: presenterConfig)
+    if attach || presenterConfig.outputMode != 3 {
+      erikaConfigureLayerDynamicRange(view.metalLayer, config: presenterConfig)
+    }
     view.updateDrawableSize()
     let width = UInt32(max(1.0, view.metalLayer.drawableSize.width).rounded())
     let height = UInt32(max(1.0, view.metalLayer.drawableSize.height).rounded())
@@ -2023,6 +2074,9 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       case "getOutputStatus":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).outputStatus())
+      case "getResourceStatus":
+        let args = try dictionaryArgs(call.arguments)
+        result(try playerHost(from: args).resourceStatus())
       case "getPresenterStats":
         let args = try dictionaryArgs(call.arguments)
         result(try playerHost(from: args).presenterStats())
@@ -2559,7 +2613,17 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   private func presenterConfigForNewPlayer(arguments: Any?, hdrDebug: Bool) -> ErikaPresenterConfigC {
     if let args = arguments as? [String: Any], let explicitMode = int32Value(args["outputMode"]) {
       let headroom = floatValue(args["edrHeadroom"]) ?? 4.0
-      let config = explicitMode == 1 ? ErikaPresenterConfigC.appleEdr(headroom: headroom) : .sdr
+      let config: ErikaPresenterConfigC
+      switch explicitMode {
+      case 1:
+        config = .appleEdr(headroom: headroom)
+      case 2:
+        config = ErikaPresenterConfigC(outputMode: 2, edrHeadroom: max(1.0, headroom))
+      case 3:
+        config = .auto(headroom: headroom)
+      default:
+        config = .sdr
+      }
       erikaHdrLog(
         hdrDebug,
         "create explicit outputMode=\(explicitMode) requestedHeadroom=\(String(format: "%.3f", headroom)) selected=\(erikaOutputModeLabel(config))"
@@ -2567,7 +2631,7 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       return config
     }
     let headroom = resolvedEdrHeadroom(hdrDebug: hdrDebug)
-    let config = headroom > 1.0 ? ErikaPresenterConfigC.appleEdr(headroom: headroom) : .sdr
+    let config = ErikaPresenterConfigC.auto(headroom: headroom)
     erikaHdrLog(
       hdrDebug,
       "create auto selected=\(erikaOutputModeLabel(config)) resolvedHeadroom=\(String(format: "%.3f", headroom))"
@@ -2861,6 +2925,25 @@ private extension ErikaOutputStatusC {
       "dataSpaceFailures": Int64(clamping: dataSpaceFailures),
       "headroomUpdates": Int64(clamping: headroomUpdates),
       "extendedLinearFrames": Int64(clamping: extendedLinearFrames),
+    ]
+  }
+}
+
+private extension ErikaPresenterResourceStatusC {
+  func toFlutterMap() -> [String: Any] {
+    [
+      "deviceCurrentAllocatedBytes": Int64(clamping: deviceCurrentAllocatedBytes),
+      "deviceRecommendedWorkingSetBytes": Int64(clamping: deviceRecommendedWorkingSetBytes),
+      "drawableEstimatedBytes": Int64(clamping: drawableEstimatedBytes),
+      "videoFrameBytes": Int64(clamping: videoFrameBytes),
+      "overlayAtlasBytes": Int64(clamping: overlayAtlasBytes),
+      "danmakuAtlasBytes": Int64(clamping: danmakuAtlasBytes),
+      "danmakuVertexBufferBytes": Int64(clamping: danmakuVertexBufferBytes),
+      "upscalerBytes": Int64(clamping: upscalerBytes),
+      "rendererTrackedBytes": Int64(clamping: rendererTrackedBytes),
+      "presenterCpuDanmakuAtlasBytes": Int64(clamping: presenterCpuDanmakuAtlasBytes),
+      "drawableCount": Int(drawableCount),
+      "outputModeSwitches": Int64(clamping: outputModeSwitches),
     ]
   }
 }


### PR DESCRIPTION
## Summary

- add source-aware `Auto` output mode (stable C/Dart ABI value `3`) for Apple presenters
- keep SDR/Main10 sources on BGRA8 sRGB and promote PQ, HLG, or HDR-metadata sources to RGBA16F Apple EDR
- synchronize Metal before changing drawable format and rebuild format-dependent renderer caches
- expose a separate presenter resource-status API without changing the existing stats ABI
- default macOS, iOS, and tvOS Flutter players to automatic output selection

## Impact

For the same 4K60 HEVC Main10 SDR source and real NipaPlay presentation path:

- forced EDR renderer-tracked resources: 160,378,368 bytes
- Auto SDR renderer-tracked resources: 105,623,808 bytes
- saved: 54,754,560 bytes (about 52.2 MiB / 34%)
- VideoToolbox zero-copy: 100%
- render failures / backpressure drops: 0 / 0

For the equivalent BT.2020/PQ source:

- HDR source frames: 355
- EDR frames: 357
- output-mode switches: 1
- active output: Apple EDR / RGBA16F
- realtime factor: 1.0004
- VideoToolbox zero-copy: 100%
- render failures: 0

## Retina regression and root cause

UIKit and tvOS need `CALayer.contentsFormat` synchronized with the Metal pixel format. Applying that rule to macOS made Core Animation treat a Retina drawable as 1x layer contents, clipping the right and bottom halves of a 2x drawable.

The fix limits `contentsFormat` updates to iOS and tvOS. macOS changes only the Metal pixel format, colorspace, and EDR state. A source-contract test locks this platform boundary.

## Resource diagnostics

`erika_presenter_get_resource_status` reports Metal device allocation, recommended working set, estimated drawables, current video-frame allocation, overlay/danmaku resources, upscaler resources, CPU danmaku atlas usage, drawable count, and output-mode switch count. Flutter exposes this as `ErikaPlayer.getResourceStatus()`.

## Validation

- `cargo fmt --check`
- `cargo test -p erika -p erika_capi --lib`: 480 + 31 passed
- `flutter test --no-pub`: 67 passed
- `flutter analyze --no-pub`: no issues
- Swift frontend parse for macOS, iOS, and tvOS
- `git diff --check`
- manual macOS Retina window verification with full-frame edge markers

## Platform coverage

- macOS was exercised through NipaPlay with SDR and PQ sources.
- iOS and tvOS were statically checked but not run on devices.
- This is stacked on #85 because it builds on the off-main Apple presenter scheduler.