### PR TITLE
Disable danmaku scroll overwrite by default

### DIFF
--- a/crates/erika/src/danmaku.rs
+++ b/crates/erika/src/danmaku.rs
@@ -247,7 +247,7 @@ impl Default for DanmakuLayoutConfig {
             custom_font_face_index: 0,
             merge_duplicates: false,
             allow_stacking: false,
-            allow_scroll_overwrite: true,
+            allow_scroll_overwrite: false,
             max_quantity: None,
             max_lines_per_mode: None,
             block_top: false,
@@ -3044,6 +3044,44 @@ mod tests {
         assert!(
             max_y < 360.0,
             "scroll rows should still stay inside the viewport, got max y {max_y}"
+        );
+    }
+
+    #[test]
+    fn dense_default_layout_keeps_using_the_full_display_area() {
+        let timeline = DanmakuTimeline::new(
+            (0..960)
+                .map(|index| {
+                    let mut entry = item(
+                        index as f64 / 80.0,
+                        &format!("dense default {index}"),
+                        DanmakuMode::Scroll,
+                    );
+                    entry.id = index + 1;
+                    entry
+                })
+                .collect(),
+        )
+        .unwrap();
+        let config = DanmakuLayoutConfig {
+            merge_duplicates: false,
+            display_area: 1.0,
+            ..DanmakuLayoutConfig::default()
+        };
+        let mut engine = DfmLayoutEngine::new(timeline, config);
+        let viewport = DanmakuViewport::new(640, 360);
+        let prepared = engine.prepare(viewport, 7);
+        let frame = prepared.frame_layout(Duration::from_secs_f64(10.0), 7);
+        let max_y = frame
+            .items
+            .iter()
+            .filter(|item| item.mode == DanmakuMode::Scroll)
+            .map(|item| item.y)
+            .fold(0.0, f32::max);
+
+        assert!(
+            max_y > viewport.height as f32 * 0.75,
+            "dense default layout must keep using the full display area; max y={max_y}"
         );
     }
 


### PR DESCRIPTION
## What changed

- Disable scroll-track overwrite in Erika's default danmaku layout configuration.
- Add a dense 80-comments-per-second regression test that verifies the default layout continues to use the full display area during sustained playback.

## Why

NipaPlay forwards `allowStacking = false`, but Erika still enabled its independent scroll-overwrite policy by default. During whole-timeline preparation, high-density comments repeatedly displaced lower overflow tracks. Depending on how displaced entries were retained, playback either collapsed to the protected upper tracks or accumulated unreadable overlaps in the lower tracks.

With overwrite disabled by default, non-stacking layout uses all available tracks and drops excess comments when every track is busy. Explicit overwrite behavior remains available through `DanmakuLayoutConfig` for callers that opt into it.

## Validation

- `cargo test -p erika dense_default_layout_keeps_using_the_full_display_area`
- `cargo fmt --check`
- `git diff --check`
- NipaPlay macOS 4K60 HEVC benchmark with 80 comments/s and 4,800 comments: full-screen track coverage, no lower-track overlap wall, real-time playback with zero stalls.