### PR TITLE
docs: clarify Erika platform coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Erika
 
-> 「GOOD！我是Erika，是NipaPlay里继mdk、video player、libmpv、media kit之后的第五个播放器内核。」
-> 「即便算上你，也只有四个播放器内核！」
+> 「GOOD！我是Erika，是NipaPlay里继mdk、video player、Media Kit（libmpv）之后的第四个播放器内核。」
+> 「即便算上你，也只有三个播放器内核！」
 
 **NipaPlay 的自研播放内核。** Rust 实现，可嵌入，从解码到渲染一手包办。
 

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -77,7 +77,7 @@ iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を ap
 
 ## tvOS Build Path
 
-tvOS plugin は CocoaPod script phase 経由で Apple TV 実機と simulator 向けに Erika C ABI static library をビルド・リンクします。tvOS 13+、arm64 実機、arm64/x86_64 simulator に対応します。Rust nightly、prebuilt bundle、source build の詳細は [`packages/erika_flutter/README.ja.md`](../packages/erika_flutter/README.ja.md) を参照してください。
+tvOS plugin は CocoaPod script phase 経由で Apple TV 実機と simulator 向けに Erika C ABI static library をビルド・リンクします。tvOS 13+、arm64 実機、arm64/x86_64 simulator に対応します。NipaPlay の television target は Erika を強制選択するため、tvOS では Media Kit（libmpv）、MDK、Video Player へ切り替えられません。Rust nightly、prebuilt bundle、source build の詳細は [`packages/erika_flutter/README.ja.md`](../packages/erika_flutter/README.ja.md) を参照してください。
 
 ## Minimal Presenter Flow
 

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -104,7 +104,9 @@ architecture.
 
 The tvOS plugin links the Erika C ABI static library through its CocoaPod script
 phase and builds it for tvOS devices and simulators. It supports tvOS 13+,
-arm64 devices, and arm64/x86_64 simulators. See
+arm64 devices, and arm64/x86_64 simulators. NipaPlay forces Erika for its
+television targets, so tvOS cannot switch to Media Kit (libmpv), MDK, or Video
+Player. See
 [`packages/erika_flutter/README.md`](../packages/erika_flutter/README.md) for
 nightly, prebuilt-bundle, and source-build options.
 

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -71,7 +71,7 @@ iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进
 
 ## tvOS Build Path
 
-tvOS plugin 通过 CocoaPod script phase 为 Apple TV 真机和模拟器构建并链接 Erika C ABI static library；支持 tvOS 13+、arm64 真机，以及 arm64/x86_64 模拟器。详细的 Rust nightly、预构建包和源码构建选项见 [`packages/erika_flutter/README.zh.md`](../packages/erika_flutter/README.zh.md)。
+tvOS plugin 通过 CocoaPod script phase 为 Apple TV 真机和模拟器构建并链接 Erika C ABI static library；支持 tvOS 13+、arm64 真机，以及 arm64/x86_64 模拟器。NipaPlay 的电视设备路径会强制选择 Erika，不能切换到 Media Kit（libmpv）、MDK 或 Video Player。详细的 Rust nightly、预构建包和源码构建选项见 [`packages/erika_flutter/README.zh.md`](../packages/erika_flutter/README.zh.md)。
 
 ## Minimal Presenter Flow
 

--- a/docs/platform_matrix.zh.md
+++ b/docs/platform_matrix.zh.md
@@ -1,12 +1,12 @@
 # Erika 平台能力矩阵
 
-本文把“能编译”“CI 构建覆盖”“真机验收”和“有可下载预编译包”分开描述。任何一项为真，都不自动代表其它三项为真。
+本文把“能编译”“CI 构建覆盖”“真机验收”和“有可下载预编译包”分开描述。任何一项为真，都不自动代表其它三项为真。Erika 当前已支持 NipaPlay 的所有原生客户端目标，**仅 Linux 尚未支持**；在 NipaPlay 的电视设备（包括 tvOS）上，播放器工厂会强制选择 Erika。
 
 | 平台 | 主要解码/渲染 | C ABI presenter | CI/产物 | 真机验收状态 |
 |---|---|---|---|---|
 | macOS | VideoToolbox + Metal | 是 | CI 与预编译包 | 持续维护；HDR/EDR 依显示器和系统而定 |
 | iOS | VideoToolbox + Metal | 是 | CI 与 XCFramework | 持续维护；需使用真机验证 HDR/后台行为 |
-| tvOS | VideoToolbox + Metal | 是 | CI 与 XCFramework | 开发者预览；真机与模拟器分别记录 |
+| tvOS | VideoToolbox + Metal | 是 | CI 与 XCFramework | 支持；NipaPlay 电视端强制使用 Erika，真机与模拟器分别记录 |
 | Windows x64/ARM64 | D3D11VA + D3D11 | 是 | CI 与预编译包 | 持续维护；HDR10 受显示器、驱动和系统设置影响 |
 | Android | MediaCodec/软解 + wgpu | 是 | CI 与预编译包 | SDR 已验证；API 35 HDR active path 仍需真机验收 |
 | HarmonyOS | AVCodec/软解 + wgpu Vulkan | 是 | 预编译包；CI 覆盖需以 workflow 为准 | 已有真机验证，尚未纳入完整 CI 验收 |

--- a/readme/README.en.md
+++ b/readme/README.en.md
@@ -2,8 +2,8 @@
 
 # Erika
 
-> "GOOD! I'm Erika, the fifth player kernel in NipaPlay after mdk, video player, libmpv, and media kit."
-> "Even counting you, there are only four player kernels!"
+> "GOOD! I'm Erika, the fourth player kernel in NipaPlay after MDK, Video Player, and Media Kit (libmpv)."
+> "Even counting you, there are only three player kernels!"
 
 **The in-house playback core of NipaPlay.** Written in Rust, embeddable, handling everything from decode to render.
 

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -2,8 +2,8 @@
 
 # Erika
 
-> 「GOOD！私はErika、NipaPlayにおいてmdk、video player、libmpv、media kitに次ぐ5番目のプレイヤーカーネルです。」
-> 「あなたを数えても、プレイヤーカーネルは4つだけ！」
+> 「GOOD！私はErika、NipaPlayにおいてmdk、video player、Media Kit（libmpv）に次ぐ4番目のプレイヤーカーネルです。」
+> 「あなたを数えても、プレイヤーカーネルは3つだけ！」
 
 **NipaPlay の自社開発再生コア。** Rust 実装、組み込み可能、デコードからレンダリングまで一手に引き受けます。
 


### PR DESCRIPTION
## Summary

Clarifies the product-facing platform statements around Erika.

- States that Erika supports all current native NipaPlay targets except Linux.
- States that NipaPlay television targets, including tvOS, force Erika.
- Corrects the root README wording so Media Kit/libmpv is not counted twice as separate NipaPlay kernels.
- Updates English, Chinese, and Japanese embedding/readme wording.

## Validation

- git diff --check
- Local Markdown-link validation for all 7 changed Markdown files

No Rust, C ABI, Flutter plugin, or NipaPlay application code was changed.