### PR TITLE
feat: wire getResourceStatus on Android, Windows and OpenHarmony

### DIFF
--- a/crates/erika_capi/src/android_jni.rs
+++ b/crates/erika_capi/src/android_jni.rs
@@ -918,6 +918,13 @@ unsafe fn invoke_presenter(
             Ok(output_status_to_json(status_value))
         }
         "getPresenterStats" => Ok(stats_to_json(presenter.latest_stats)),
+        "getResourceStatus" => {
+            let mut status_value = ErikaPresenterResourceStatus::default();
+            call_status(unsafe {
+                erika_presenter_get_resource_status(handle, &mut status_value)
+            })?;
+            Ok(resource_status_to_json(status_value))
+        }
         "setDebugHudEnabled" => {
             let enabled =
                 optional_bool(args, "enabled").ok_or_else(|| "enabled is required".to_string())?;
@@ -1319,6 +1326,23 @@ fn output_status_to_json(status: ErikaOutputStatus) -> Value {
         "dataSpaceFailures": status.data_space_failures,
         "headroomUpdates": status.headroom_updates,
         "extendedLinearFrames": status.extended_linear_frames,
+    })
+}
+
+fn resource_status_to_json(status: ErikaPresenterResourceStatus) -> Value {
+    json!({
+        "deviceCurrentAllocatedBytes": status.device_current_allocated_bytes,
+        "deviceRecommendedWorkingSetBytes": status.device_recommended_working_set_bytes,
+        "drawableEstimatedBytes": status.drawable_estimated_bytes,
+        "videoFrameBytes": status.video_frame_bytes,
+        "overlayAtlasBytes": status.overlay_atlas_bytes,
+        "danmakuAtlasBytes": status.danmaku_atlas_bytes,
+        "danmakuVertexBufferBytes": status.danmaku_vertex_buffer_bytes,
+        "upscalerBytes": status.upscaler_bytes,
+        "rendererTrackedBytes": status.renderer_tracked_bytes,
+        "presenterCpuDanmakuAtlasBytes": status.presenter_cpu_danmaku_atlas_bytes,
+        "drawableCount": status.drawable_count,
+        "outputModeSwitches": status.output_mode_switches,
     })
 }
 

--- a/crates/erika_capi/src/presenter_json.rs
+++ b/crates/erika_capi/src/presenter_json.rs
@@ -144,6 +144,13 @@ unsafe fn invoke(
             call_status(unsafe { erika_presenter_get_stats(handle, &mut stats) })?;
             Ok(stats_json(stats))
         }
+        "getResourceStatus" => {
+            let mut status = ErikaPresenterResourceStatus::default();
+            call_status(unsafe {
+                erika_presenter_get_resource_status(handle, &mut status)
+            })?;
+            Ok(resource_status_json(status))
+        }
         "addExternalSubtitle" => {
             let uri = required_c_string(required_string(args, "uri")?, "uri")?;
             let mut track_id = -1;
@@ -485,6 +492,23 @@ fn output_status_json(status: ErikaOutputStatus) -> Value {
     })
 }
 
+fn resource_status_json(status: ErikaPresenterResourceStatus) -> Value {
+    json!({
+        "deviceCurrentAllocatedBytes": status.device_current_allocated_bytes,
+        "deviceRecommendedWorkingSetBytes": status.device_recommended_working_set_bytes,
+        "drawableEstimatedBytes": status.drawable_estimated_bytes,
+        "videoFrameBytes": status.video_frame_bytes,
+        "overlayAtlasBytes": status.overlay_atlas_bytes,
+        "danmakuAtlasBytes": status.danmaku_atlas_bytes,
+        "danmakuVertexBufferBytes": status.danmaku_vertex_buffer_bytes,
+        "upscalerBytes": status.upscaler_bytes,
+        "rendererTrackedBytes": status.renderer_tracked_bytes,
+        "presenterCpuDanmakuAtlasBytes": status.presenter_cpu_danmaku_atlas_bytes,
+        "drawableCount": status.drawable_count,
+        "outputModeSwitches": status.output_mode_switches,
+    })
+}
+
 fn response_string(result: std::thread::Result<Result<Value, String>>) -> *mut c_char {
     match result {
         Ok(Ok(value)) => owned_json(success_response(value)),
@@ -654,6 +678,50 @@ mod tests {
         unsafe { erika_string_free(response) };
         assert_eq!(value.get("ok"), Some(&Value::Bool(true)));
         assert!(value.get("value").is_some_and(Value::is_object));
+
+        unsafe { erika_presenter_destroy(handle) };
+    }
+
+    #[test]
+    fn json_bridge_exposes_resource_status() {
+        let handle = erika_presenter_create();
+        assert!(!handle.is_null());
+
+        let response = unsafe {
+            erika_presenter_invoke_json(
+                handle,
+                c"getResourceStatus".as_ptr(),
+                c"{}".as_ptr(),
+            )
+        };
+        assert!(!response.is_null());
+        let value: Value = unsafe { CStr::from_ptr(response) }
+            .to_str()
+            .ok()
+            .and_then(|response| serde_json::from_str(response).ok())
+            .expect("JSON bridge returns valid UTF-8 JSON");
+        unsafe { erika_string_free(response) };
+        assert_eq!(value.get("ok"), Some(&Value::Bool(true)));
+        let status = value
+            .get("value")
+            .and_then(Value::as_object)
+            .expect("getResourceStatus returns an object");
+        for field in [
+            "deviceCurrentAllocatedBytes",
+            "deviceRecommendedWorkingSetBytes",
+            "drawableEstimatedBytes",
+            "videoFrameBytes",
+            "overlayAtlasBytes",
+            "danmakuAtlasBytes",
+            "danmakuVertexBufferBytes",
+            "upscalerBytes",
+            "rendererTrackedBytes",
+            "presenterCpuDanmakuAtlasBytes",
+            "drawableCount",
+            "outputModeSwitches",
+        ] {
+            assert!(status.contains_key(field), "missing field: {field}");
+        }
 
         unsafe { erika_presenter_destroy(handle) };
     }

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
@@ -3085,6 +3085,7 @@ class ErikaFlutterPlugin :
             "getUpscalerStatus",
             "getOutputStatus",
             "getPresenterStats",
+            "getResourceStatus",
             "setDebugHudEnabled",
             "addExternalSubtitle",
             "removeSubtitleTrack",

--- a/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
+++ b/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
@@ -903,6 +903,7 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
       'selectSubtitleMemoryFonts', 'clearSubtitleMemoryFonts',
       'getSubtitleMemoryFontStatus',
       'getUpscalerStatus', 'getOutputStatus', 'getPresenterStats',
+      'getResourceStatus',
       'addExternalSubtitle', 'removeSubtitleTrack',
       'loadDanmakuFile', 'loadDanmakuJson',
       'addDanmakuTrackFile', 'addDanmakuTrackJson',

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -658,6 +658,36 @@ EncodableValue OutputStatusToMap(const ErikaOutputStatus& status) {
   return EncodableValue(std::move(map));
 }
 
+EncodableValue ResourceStatusToMap(const ErikaPresenterResourceStatus& status) {
+  EncodableMap map;
+  map[EncodableValue("deviceCurrentAllocatedBytes")] =
+      EncodableValue(static_cast<int64_t>(status.device_current_allocated_bytes));
+  map[EncodableValue("deviceRecommendedWorkingSetBytes")] =
+      EncodableValue(
+          static_cast<int64_t>(status.device_recommended_working_set_bytes));
+  map[EncodableValue("drawableEstimatedBytes")] =
+      EncodableValue(static_cast<int64_t>(status.drawable_estimated_bytes));
+  map[EncodableValue("videoFrameBytes")] =
+      EncodableValue(static_cast<int64_t>(status.video_frame_bytes));
+  map[EncodableValue("overlayAtlasBytes")] =
+      EncodableValue(static_cast<int64_t>(status.overlay_atlas_bytes));
+  map[EncodableValue("danmakuAtlasBytes")] =
+      EncodableValue(static_cast<int64_t>(status.danmaku_atlas_bytes));
+  map[EncodableValue("danmakuVertexBufferBytes")] =
+      EncodableValue(static_cast<int64_t>(status.danmaku_vertex_buffer_bytes));
+  map[EncodableValue("upscalerBytes")] =
+      EncodableValue(static_cast<int64_t>(status.upscaler_bytes));
+  map[EncodableValue("rendererTrackedBytes")] =
+      EncodableValue(static_cast<int64_t>(status.renderer_tracked_bytes));
+  map[EncodableValue("presenterCpuDanmakuAtlasBytes")] =
+      EncodableValue(static_cast<int64_t>(status.presenter_cpu_danmaku_atlas_bytes));
+  map[EncodableValue("drawableCount")] =
+      EncodableValue(static_cast<int64_t>(status.drawable_count));
+  map[EncodableValue("outputModeSwitches")] =
+      EncodableValue(static_cast<int64_t>(status.output_mode_switches));
+  return EncodableValue(std::move(map));
+}
+
 EncodableValue SubtitleMemoryFontStatusToMap(
     const ErikaSubtitleMemoryFontStatus& status) {
   EncodableList selected_ids;
@@ -707,6 +737,8 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
       ErikaStatus (*)(ErikaPresenterHandle*, ErikaUpscalerStatus*);
   using GetOutputStatusFn =
       ErikaStatus (*)(ErikaPresenterHandle*, ErikaOutputStatus*);
+  using GetResourceStatusFn =
+      ErikaStatus (*)(ErikaPresenterHandle*, ErikaPresenterResourceStatus*);
   using SelectTrackFn = ErikaStatus (*)(ErikaPresenterHandle*, int64_t);
   using AddExternalSubtitleFn =
       ErikaStatus (*)(ErikaPresenterHandle*, const char*, int64_t*);
@@ -821,6 +853,7 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   void (*free_subtitle_memory_font_status)(ErikaSubtitleMemoryFontStatus*) = nullptr;
   GetUpscalerStatusFn get_upscaler_status = nullptr;
   GetOutputStatusFn get_output_status = nullptr;
+  GetResourceStatusFn get_resource_status = nullptr;
   SelectTrackFn select_audio_track = nullptr;
   SelectTrackFn select_subtitle_track = nullptr;
   AddExternalSubtitleFn add_external_subtitle = nullptr;
@@ -897,6 +930,8 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         "erika_presenter_get_upscaler_status");
     get_output_status = LoadOptional<GetOutputStatusFn>(
         "erika_presenter_get_output_status");
+    get_resource_status = LoadOptional<GetResourceStatusFn>(
+        "erika_presenter_get_resource_status");
     select_audio_track =
         LoadRequired<SelectTrackFn>("erika_presenter_select_audio_track");
     select_subtitle_track =
@@ -1436,6 +1471,19 @@ struct ErikaFlutterPlugin::PlayerHost {
       Check(result, "get_output_status", library->TakeLastError());
     }
     return OutputStatusToMap(status);
+  }
+
+  EncodableValue GetResourceStatus() {
+    if (library->get_resource_status == nullptr) {
+      throw PluginError(
+          "Missing Erika C ABI symbol: erika_presenter_get_resource_status");
+    }
+    ErikaPresenterResourceStatus status{};
+    const ErikaStatus result = library->get_resource_status(handle, &status);
+    if (result != ErikaStatus_Ok) {
+      Check(result, "get_resource_status", library->TakeLastError());
+    }
+    return ResourceStatusToMap(status);
   }
 
   EncodableValue GetPresenterStats() const {
@@ -2692,6 +2740,8 @@ void ErikaFlutterPlugin::HandleMethodCall(
       result->Success(PlayerFromArgs(args).GetOutputStatus());
     } else if (method == "getPresenterStats") {
       result->Success(PlayerFromArgs(args).GetPresenterStats());
+    } else if (method == "getResourceStatus") {
+      result->Success(PlayerFromArgs(args).GetResourceStatus());
     } else if (method == "setDebugHudEnabled") {
       PlayerFromArgs(args).SetDebugHudEnabled(
           BoolValue(FindArg(args, "enabled")).value_or(false));


### PR DESCRIPTION
## Summary

PR #86 added the `getResourceStatus` diagnostic to the macOS/iOS/tvOS plugin, but Copilot correctly flagged that the method was never registered on Android, Windows or OpenHarmony — those plugins answered `notImplemented` even though the C ABI symbol (`erika_presenter_get_resource_status`) is available on all platforms. This PR wires it up everywhere, mirroring the existing `getPresenterStats` pattern on each platform.

## Changes

| Platform | Dispatch | Plugin allowlist |
|---|---|---|
| Android | `android_jni.rs`: `"getResourceStatus"` case + `resource_status_to_json` serializer | `ErikaFlutterPlugin.kt` `NATIVE_METHODS` allowlist |
| Windows | `erika_flutter_plugin.cpp`: `LoadOptional` for `erika_presenter_get_resource_status`, `GetResourceStatus()` method + `ResourceStatusToMap` | dispatch branch after `getPresenterStats` |
| OpenHarmony | `presenter_json.rs`: `"getResourceStatus"` case + `resource_status_json` serializer | `ErikaFlutterPlugin.ets` `isNativePlayerMethod` allowlist |

All three return the same 12-field map the Apple plugin returns (`deviceCurrentAllocatedBytes`, `deviceRecommendedWorkingSetBytes`, `drawableEstimatedBytes`, `videoFrameBytes`, `overlayAtlasBytes`, `danmakuAtlasBytes`, `danmakuVertexBufferBytes`, `upscalerBytes`, `rendererTrackedBytes`, `presenterCpuDanmakuAtlasBytes`, `drawableCount`, `outputModeSwitches`).

## Verification

- `cargo test -p erika_capi`: 34 passed, incl. new `json_bridge_exposes_resource_status` covering all 12 fields via the JSON bridge (exercises the OHOS dispatch path on the host)
- `flutter test` in `packages/erika_flutter`: 70 passed
- Android JNI dispatch is `#[cfg(target_os = "android")]`-gated and cannot compile on macOS — covered by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)