### PR TITLE
style(erika_capi): run rustfmt on resource status dispatch

### DIFF
--- a/crates/erika_capi/src/android_jni.rs
+++ b/crates/erika_capi/src/android_jni.rs
@@ -920,9 +920,7 @@ unsafe fn invoke_presenter(
         "getPresenterStats" => Ok(stats_to_json(presenter.latest_stats)),
         "getResourceStatus" => {
             let mut status_value = ErikaPresenterResourceStatus::default();
-            call_status(unsafe {
-                erika_presenter_get_resource_status(handle, &mut status_value)
-            })?;
+            call_status(unsafe { erika_presenter_get_resource_status(handle, &mut status_value) })?;
             Ok(resource_status_to_json(status_value))
         }
         "setDebugHudEnabled" => {

--- a/crates/erika_capi/src/presenter_json.rs
+++ b/crates/erika_capi/src/presenter_json.rs
@@ -146,9 +146,7 @@ unsafe fn invoke(
         }
         "getResourceStatus" => {
             let mut status = ErikaPresenterResourceStatus::default();
-            call_status(unsafe {
-                erika_presenter_get_resource_status(handle, &mut status)
-            })?;
+            call_status(unsafe { erika_presenter_get_resource_status(handle, &mut status) })?;
             Ok(resource_status_json(status))
         }
         "addExternalSubtitle" => {
@@ -688,11 +686,7 @@ mod tests {
         assert!(!handle.is_null());
 
         let response = unsafe {
-            erika_presenter_invoke_json(
-                handle,
-                c"getResourceStatus".as_ptr(),
-                c"{}".as_ptr(),
-            )
+            erika_presenter_invoke_json(handle, c"getResourceStatus".as_ptr(), c"{}".as_ptr())
         };
         assert!(!response.is_null());
         let value: Value = unsafe { CStr::from_ptr(response) }


### PR DESCRIPTION
## What

`cargo fmt --all -- --check` (Quality check) has been failing on main since the `getResourceStatus` wiring landed unformatted in #90. This runs rustfmt on the two call sites.

## Changes

- `crates/erika_capi/src/android_jni.rs` — collapse `call_status(unsafe { ... })` to one line
- `crates/erika_capi/src/presenter_json.rs` — same, plus collapse `erika_presenter_invoke_json` args in the JSON bridge test

Pure formatting, no semantic change. Verified locally: `cargo fmt --all -- --check` passes after this commit.

## Why it matters

Every PR based on current main (e.g. #91) fails the Quality check because of this pre-existing formatting drift. Landing this restores green Quality for the whole repo.