### PR TITLE
Add per-ABI Flutter Android release assets

### DIFF
--- a/.github/workflows/android-flutter-assets.yml
+++ b/.github/workflows/android-flutter-assets.yml
@@ -1,0 +1,77 @@
+name: Android Flutter release assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Erika release tag to augment
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Package per-ABI Flutter runtimes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Download the verified release build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/android-release" "$RUNNER_TEMP/android-unpacked"
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern erika-capi-android.zip \
+            --dir "$RUNNER_TEMP/android-release"
+          unzip -q "$RUNNER_TEMP/android-release/erika-capi-android.zip" \
+            -d "$RUNNER_TEMP/android-unpacked"
+      - name: Package one runtime per ABI
+        env:
+          TAG: ${{ inputs.tag }}
+          ERIKA_NATIVE_PROFILE: lgpl
+        run: |
+          set -euo pipefail
+          android_root="$(find "$RUNNER_TEMP/android-unpacked" \
+            -type d -path '*/lib/android' -print -quit)"
+          test -n "$android_root"
+          for ABI in arm64-v8a armeabi-v7a x86_64 x86; do
+            runtime="$android_root/$ABI/liberika_capi.so"
+            cxx="$android_root/$ABI/libc++_shared.so"
+            test -s "$runtime"
+            test -s "$cxx"
+            GITHUB_REF_NAME="$TAG" bash packaging/bundle.sh \
+              "erika-flutter-android-$ABI" \
+              "dist/erika-flutter-android-$ABI.zip" \
+              "$runtime" "$cxx"
+          done
+          for archive in dist/erika-flutter-android-*.zip; do
+            unzip -Z1 "$archive" | grep -Eq '/lib/liberika_capi\.so$'
+            unzip -Z1 "$archive" | grep -Eq '/lib/libc\+\+_shared\.so$'
+            if unzip -Z1 "$archive" | grep -Eq '\.a$|/android/'; then
+              echo "error: unexpected static library or nested ABI in $archive" >&2
+              exit 1
+            fi
+          done
+          shasum -a 256 dist/erika-flutter-android-*.zip | tee -a "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: erika-flutter-android-${{ inputs.tag }}
+          path: dist/erika-flutter-android-*.zip
+          if-no-files-found: error
+      - name: Attach runtimes to the existing release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: >-
+          gh release upload "$TAG" dist/erika-flutter-android-*.zip
+          --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,8 +398,16 @@ jobs:
       - name: Package
         shell: bash
         run: |
+          set -euo pipefail
           ERIKA_NATIVE_PROFILE="$PROFILE" bash packaging/bundle.sh \
             erika-capi-android dist/erika-capi-android.zip out/android
+          for ABI in arm64-v8a armeabi-v7a x86_64 x86; do
+            ERIKA_NATIVE_PROFILE="$PROFILE" bash packaging/bundle.sh \
+              "erika-flutter-android-$ABI" \
+              "dist/erika-flutter-android-$ABI.zip" \
+              "out/android/$ABI/liberika_capi.so" \
+              "out/android/$ABI/libc++_shared.so"
+          done
       - uses: actions/upload-artifact@v4
         with:
           name: erika-capi-android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Made verified, version-pinned native release bundles the default on Android,
   Apple platforms, Windows, and OpenHarmony; source builds are now explicitly
   selected with `ERIKA_FORCE_SOURCE_BUILD=1`.
+- Added per-ABI Flutter Android runtime archives so app builds download only
+  the requested architecture and omit the native-embedder static library.
 - Added isolated GitHub Actions consumers for Android, iOS, macOS, tvOS,
   Windows, and OpenHarmony so package builds cannot depend on the monorepo.
 

--- a/docs/releasing.ja.md
+++ b/docs/releasing.ja.md
@@ -16,6 +16,7 @@
 | iOS | `erika-capi-ios.zip`、device と simulator の XCFramework slice |
 | tvOS | `erika-capi-tvos.zip`、device と arm64/x86_64 simulator の XCFramework slice |
 | Android | `erika-capi-android.zip`、`arm64-v8a`、`armeabi-v7a`、`x86_64`、`x86` |
+| Flutter Android | `erika-flutter-android-<abi>.zip`、1 archive あたり 1 ABI の shared runtime |
 | OpenHarmony arm64 | `erika-capi-openharmony-arm64.zip`、`liberika_capi.so` と `liberika_flutter.so` |
 
 OpenHarmony archive は OpenHarmony 5.1.0 Native SDK、compatible SDK 18 で
@@ -26,6 +27,11 @@ Flutter plugin は package で固定された release を既定で download し�
 `ERIKA_FORCE_SOURCE_BUILD=1` を設定した場合だけ有効になります。
 
 各 archive には `include/erika.h`、`LICENSE`、`THIRD_PARTY_NOTICES.md`、dependency license、tag/commit を記録する `MANIFEST.txt` も含まれます。native dependency は `lgpl` profile で static link され、Android は ABI に対応する `libc++_shared.so` も含みます。
+
+Flutter Android build は要求された ABI の
+`erika-flutter-android-<abi>.zip` だけを download し、他 architecture や native
+embedder 専用の static `.a` は download しません。combined
+`erika-capi-android.zip` は multi-ABI / static link の C/C++ consumer 向けに維持します。
 
 ## Release の作成
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,7 @@ license files:
 | iOS | `erika-capi-ios.zip` | `erika_capi.xcframework` (device + simulator) |
 | tvOS | `erika-capi-tvos.zip` | `erika_capi.xcframework` (device + arm64/x86_64 simulator) |
 | Android | `erika-capi-android.zip` | `liberika_capi.so`, `liberika_capi.a`, and `libc++_shared.so` for `arm64-v8a`, `armeabi-v7a`, `x86_64`, and `x86` |
+| Flutter Android | `erika-flutter-android-<abi>.zip` | `liberika_capi.so` and `libc++_shared.so` for one requested ABI |
 | OpenHarmony arm64 | `erika-capi-openharmony-arm64.zip` | `liberika_capi.so`, `liberika_flutter.so` |
 
 The OpenHarmony archive is built against the OpenHarmony 5.1.0 native SDK with
@@ -30,9 +31,11 @@ locally linked N-API bridge. Download and verification failures are explicit;
 source builds are enabled only with `ERIKA_FORCE_SOURCE_BUILD=1`.
 
 The Android archive stores each ABI at `lib/android/<abi>/`. Flutter/Gradle
-consumers package `liberika_capi.so` together with the matching NDK
-`libc++_shared.so`; `liberika_capi.a` is included for native embedders that
-prefer static linkage.
+consumers instead download one `erika-flutter-android-<abi>.zip` per requested
+ABI and package `liberika_capi.so` together with the matching NDK
+`libc++_shared.so`. They do not download other architectures or the static
+library. The combined C API archive retains `liberika_capi.a` for native
+embedders that prefer static linkage.
 
 Every archive also includes `include/erika.h`, `LICENSE` (Erika, MPL-2.0),
 `THIRD_PARTY_NOTICES.md`, applicable dependency and embedded asset license texts
@@ -135,10 +138,11 @@ The following environment variables customize that behavior:
   `Contents/Frameworks` (`install_name @rpath`, codesigned). With
   `ERIKA_FORCE_SOURCE_BUILD=1`, the same phase builds the selected architecture from source.
   `ERIKA_MACOS_CAPI_DYLIB` can point at an explicit dylib instead.
-- **Android** (`erika-native.gradle`): downloads `erika-capi-android.zip` and
-  stages `liberika_capi.so` plus `libc++_shared.so` for the requested Flutter
-  ABIs. Native C/C++ embedders may instead link the bundled static archive and
-  provide the matching C++ runtime themselves.
+- **Android** (`erika-native.gradle`): downloads only the ABI-specific
+  `erika-flutter-android-<abi>.zip` assets requested by the Flutter build and
+  stages `liberika_capi.so` plus `libc++_shared.so`. Native C/C++ embedders may
+  instead use the combined `erika-capi-android.zip`, link its static archive,
+  and provide the matching C++ runtime themselves.
 
 The package pins its native tag and SHA-256 values. If you override the tag,
 provide the matching digest so the C ABI in the package header and the prebuilt

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -16,6 +16,7 @@
 | iOS | `erika-capi-ios.zip`，包含 device 和 simulator XCFramework slice |
 | tvOS | `erika-capi-tvos.zip`，包含 device 和 arm64/x86_64 simulator XCFramework slice |
 | Android | `erika-capi-android.zip`，包含 `arm64-v8a`、`armeabi-v7a`、`x86_64`、`x86` |
+| Flutter Android | `erika-flutter-android-<abi>.zip`，每个归档只包含一个 ABI 的 shared runtime |
 | OpenHarmony arm64 | `erika-capi-openharmony-arm64.zip`，包含 `liberika_capi.so` 和 `liberika_flutter.so` |
 
 OpenHarmony 归档使用 OpenHarmony 5.1.0 Native SDK、compatible SDK 18 构建，
@@ -25,6 +26,10 @@ release、校验 SHA-256、链接预构建 runtime，并把它与本地链接的
 `ERIKA_FORCE_SOURCE_BUILD=1` 才会从源码构建。
 
 每个归档还包含 `include/erika.h`、`LICENSE`、`THIRD_PARTY_NOTICES.md`、依赖许可证和记录 tag/commit 的 `MANIFEST.txt`。原生依赖使用 `lgpl` profile 静态链接；Android 同时携带匹配 ABI 的 `libc++_shared.so`。
+
+Flutter Android 构建按实际请求的 ABI 下载对应
+`erika-flutter-android-<abi>.zip`，不会下载其他架构或仅供原生嵌入使用的静态 `.a`。
+合并的 `erika-capi-android.zip` 继续提供给需要多 ABI 或静态链接的 C/C++ 使用者。
 
 ## 创建 Release
 


### PR DESCRIPTION
## What changed

- keep the combined Android C API archive for native embedders
- generate one slim Flutter runtime archive per Android ABI
- add a manual GitHub Actions workflow to augment an existing release from its already-built Android archive
- document that Flutter builds avoid unrelated ABIs and the static library

## Why

The combined Android release is about 513 MB. A Flutter build targeting one ABI should not download all four architectures or the native-only static archive.

## Validation

- parsed both workflow YAML files
- ran git diff --check
- the manual workflow verifies both required shared libraries and rejects static libraries or nested ABI directories before upload