### PR TITLE
Publish checksums for release assets

### DIFF
--- a/.github/workflows/release-checksums.yml
+++ b/.github/workflows/release-checksums.yml
@@ -1,0 +1,55 @@
+name: Release checksums
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Erika release tag to verify
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  checksums:
+    name: Verify and publish SHA256SUMS
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          gh release download "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern '*.zip' \
+            --dir release-assets
+          test -n "$(find release-assets -maxdepth 1 -type f -name '*.zip' -print -quit)"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          (
+            cd release-assets
+            shasum -a 256 *.zip
+          ) > release-assets/SHA256SUMS
+          test -s release-assets/SHA256SUMS
+          cat release-assets/SHA256SUMS
+          cat release-assets/SHA256SUMS >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SHA256SUMS-${{ inputs.tag }}
+          path: release-assets/SHA256SUMS
+          if-no-files-found: error
+      - name: Attach checksums to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: >-
+          gh release upload "$TAG" release-assets/SHA256SUMS
+          --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,10 +540,23 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+      - name: Create release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' archive; do
+            digest="$(shasum -a 256 "$archive" | cut -d ' ' -f1)"
+            printf '%s  %s\n' "$digest" "$(basename "$archive")"
+          done < <(find artifacts -type f -name '*.zip' -print0 | sort -z) \
+            > SHA256SUMS
+          test -s SHA256SUMS
+          cat SHA256SUMS
       - name: Publish to GitHub Releases
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**/*.zip
+          files: |
+            artifacts/**/*.zip
+            SHA256SUMS
           generate_release_notes: true
           body: |
             Prebuilt `erika_capi` C ABI bundles (static `lgpl` profile),
@@ -552,7 +565,8 @@ jobs:
             x86_64, and x86, plus OpenHarmony arm64.
 
             Each archive contains the library, `include/erika.h`, `LICENSE`
-            (MPL-2.0), and `THIRD_PARTY_NOTICES.md`. See
+            (MPL-2.0), and `THIRD_PARTY_NOTICES.md`. `SHA256SUMS` in this
+            release records the digest of every archive. See
             [docs/capi_reference.md](https://github.com/AimesSoft/Erika/blob/${{ github.ref_name }}/docs/capi_reference.md)
             and [docs/integration.md](https://github.com/AimesSoft/Erika/blob/${{ github.ref_name }}/docs/integration.md)
             to integrate. Review [CHANGELOG.md](https://github.com/AimesSoft/Erika/blob/${{ github.ref_name }}/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   selected with `ERIKA_FORCE_SOURCE_BUILD=1`.
 - Added per-ABI Flutter Android runtime archives so app builds download only
   the requested architecture and omit the native-embedder static library.
+- Added a release-level `SHA256SUMS` manifest covering every published native
+  archive.
 - Added isolated GitHub Actions consumers for Android, iOS, macOS, tvOS,
   Windows, and OpenHarmony so package builds cannot depend on the monorepo.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -40,6 +40,7 @@ embedders that prefer static linkage.
 Every archive also includes `include/erika.h`, `LICENSE` (Erika, MPL-2.0),
 `THIRD_PARTY_NOTICES.md`, applicable dependency and embedded asset license texts
 under `licenses/`, and a `MANIFEST.txt` recording the tag/commit.
+Every GitHub Release also includes `SHA256SUMS` with the digest of each archive.
 
 The native dependencies (FFmpeg, libass, FreeType, HarfBuzz, FriBidi, zlib, and
 Android's dav1d AV1 software decoder) are **statically linked** via the `lgpl`


### PR DESCRIPTION
## What changed

- generate SHA256SUMS from the exact zip files before every GitHub Release upload
- add a manual workflow that verifies all archives on an existing release and attaches its checksum manifest
- document the release-level checksum file

## Why

GitHub release assets uploaded by the current action do not expose a digest through the API. Computing the manifest on GitHub avoids relying on a local network stream and gives package maintainers and users one auditable source of archive hashes.

## Validation

- parsed both workflow YAML files
- ran git diff --check