### PR TITLE
补充 erika_flutter pub.dev 发布文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ ErikaWindowOverlayVideoView(player: player)
 ErikaVideoView(player: player)
 ```
 
+### Flutter package
+
+`erika_flutter` 0.1.7 is published on [pub.dev](https://pub.dev/packages/erika_flutter)
+for macOS, iOS, tvOS, Windows, Android, and HarmonyOS/OpenHarmony. Add it to a
+Flutter app with:
+
+```sh
+flutter pub add erika_flutter
+```
+
+The package downloads the matching verified native runtime during the platform
+build. Android downloads only the selected ABI archive; Linux and Web are not
+published targets yet.
+
 ## C ABI 接口族
 
 Erika 提供两组 C ABI 入口，适配不同嵌入场景：

--- a/docs/releasing.ja.md
+++ b/docs/releasing.ja.md
@@ -33,13 +33,40 @@ Flutter Android build は要求された ABI の
 embedder 専用の static `.a` は download しません。combined
 `erika-capi-android.zip` は multi-ABI / static link の C/C++ consumer 向けに維持します。
 
+## Flutter package の公開
+
+`erika_flutter` は [pub.dev](https://pub.dev/packages/erika_flutter) で独立して公開します。
+`0.1.7` は最初の standalone package release で、macOS、iOS、tvOS、Windows、Android、
+HarmonyOS/OpenHarmony に対応します。package archive には plugin source、package
+`LICENSE`、README、example、version 固定の native artifact manifest が含まれ、platform
+build は対応する GitHub Release archive を download して SHA-256 を検証します。
+
+clean worktree から package directory で実行します：
+
+```sh
+cd packages/erika_flutter
+dart pub publish --dry-run
+dart pub publish
+```
+
+merge 前に [flutter-package.yml](../.github/workflows/flutter-package.yml) が isolated package
+と各 platform consumer を検証します。Linux と Web はまだ package 公開対象ではありません。
+
+### pub.dev publisher identity
+
+`unverified uploader` は、検証済み pub.dev publisher に紐付いていない account が package を
+upload したことを示します。package validation、License、build の失敗ではありません。検証済み
+publisher を表示するには、管理している domain の pub.dev publisher を作成または参加し、domain
+verification を完了してから package ownership をその publisher に移します。
+
 ## Release の作成
 
 Release は [release.yml](../.github/workflows/release.yml) で自動化されています。GitHub Release を作成するには `v*` tag を push します：
 
 ```sh
-git tag v0.1.7
-git push origin v0.1.7
+VERSION=0.1.8
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
 ```
 
 `workflow_dispatch` の手動実行は Actions Artifact のみを生成し、`ERIKA_PREBUILT_TAG` から取得できる GitHub Release は公開しません。

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,6 +54,35 @@ Linux is **not yet published**. Android is cross-built with NDK r29 at API 26;
 the four ABI archives are reproducible through the same `xtask` dependency
 pipeline as Apple and Windows.
 
+## Publishing the Flutter package
+
+`erika_flutter` is published separately on [pub.dev](https://pub.dev/packages/erika_flutter).
+Version `0.1.7` is the first standalone package release and supports macOS,
+iOS, tvOS, Windows, Android, and HarmonyOS/OpenHarmony. The package archive
+contains the plugin sources, package `LICENSE`, README files, examples, and the
+version-pinned native artifact manifest; platform builds fetch the matching
+GitHub Release archives and verify their SHA-256 values.
+
+From a clean worktree, validate and publish the package from its directory:
+
+```sh
+cd packages/erika_flutter
+dart pub publish --dry-run
+dart pub publish
+```
+
+The isolated package and platform consumer checks run from
+[`.github/workflows/flutter-package.yml`](../.github/workflows/flutter-package.yml)
+before a package release is merged. Linux and Web are not package targets yet.
+
+### Pub.dev publisher identity
+
+`unverified uploader` means the package was uploaded by a pub.dev account that
+is not associated with a verified pub.dev publisher. It does not indicate a
+package validation, license, or build failure. To show a verified publisher,
+create or join a pub.dev publisher for a domain you control and complete the
+domain verification, then transfer ownership of the package to that publisher.
+
 ## How to cut a release
 
 The release is fully automated by
@@ -64,8 +93,9 @@ The release is fully automated by
    section, and bump `version` in the root `Cargo.toml` if appropriate.
 2. Tag and push:
    ```sh
-   git tag v0.1.7
-   git push origin v0.1.7
+   VERSION=0.1.8
+   git tag "v${VERSION}"
+   git push origin "v${VERSION}"
    ```
 3. The workflow cross-builds macOS arm64 and x64 on `macos-26`, then combines
    those outputs into the universal bundle. iOS and tvOS XCFrameworks also use

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -31,13 +31,38 @@ Flutter Android 构建按实际请求的 ABI 下载对应
 `erika-flutter-android-<abi>.zip`，不会下载其他架构或仅供原生嵌入使用的静态 `.a`。
 合并的 `erika-capi-android.zip` 继续提供给需要多 ABI 或静态链接的 C/C++ 使用者。
 
+## 发布 Flutter package
+
+`erika_flutter` 独立发布在 [pub.dev](https://pub.dev/packages/erika_flutter)。
+`0.1.7` 是首个 standalone package release，支持 macOS、iOS、tvOS、Windows、Android
+和 HarmonyOS/OpenHarmony。package archive 包含插件源码、package `LICENSE`、README、
+example 和固定 native artifact manifest；平台构建会下载匹配的 GitHub Release 归档并校验 SHA-256。
+
+在干净工作树中从 package 目录执行：
+
+```sh
+cd packages/erika_flutter
+dart pub publish --dry-run
+dart pub publish
+```
+
+合并前由 [flutter-package.yml](../.github/workflows/flutter-package.yml) 执行 isolated
+package 和各平台 consumer 检查。Linux 和 Web 目前还不是 package 发布目标。
+
+### pub.dev publisher 身份
+
+`unverified uploader` 表示 package 由未关联已验证 pub.dev publisher 的账号上传。
+这不表示 package 校验、License 或构建失败。要显示已验证 publisher，需要创建或加入
+自己控制域名对应的 pub.dev publisher，完成域名验证后，再把 package ownership 转移给该 publisher。
+
 ## 创建 Release
 
 Release 由 [release.yml](../.github/workflows/release.yml) 自动执行。推送 `v*` tag 才会创建 GitHub Release：
 
 ```sh
-git tag v0.1.7
-git push origin v0.1.7
+VERSION=0.1.8
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
 ```
 
 手动运行 `workflow_dispatch` 只生成 Actions Artifact，不发布可供 `ERIKA_PREBUILT_TAG` 下载的 GitHub Release。

--- a/readme/README.en.md
+++ b/readme/README.en.md
@@ -70,6 +70,20 @@ ErikaWindowOverlayVideoView(player: player)
 ErikaVideoView(player: player)
 ```
 
+### Flutter package
+
+`erika_flutter` 0.1.7 is available on [pub.dev](https://pub.dev/packages/erika_flutter)
+for macOS, iOS, tvOS, Windows, Android, and HarmonyOS/OpenHarmony. Add it to a
+Flutter app with:
+
+```sh
+flutter pub add erika_flutter
+```
+
+The package downloads the matching verified native runtime during the platform
+build. Android downloads only the selected ABI archive; Linux and Web are not
+published targets yet.
+
 ## C ABI Families
 
 Erika provides two C ABI entrypoint families for different embedding scenarios:

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -70,6 +70,19 @@ ErikaWindowOverlayVideoView(player: player)
 ErikaVideoView(player: player)
 ```
 
+### Flutter パッケージ
+
+`erika_flutter` 0.1.7 は [pub.dev](https://pub.dev/packages/erika_flutter) で公開されています。
+macOS、iOS、tvOS、Windows、Android、HarmonyOS/OpenHarmony に対応しています。
+Flutter アプリには次のコマンドで追加できます：
+
+```sh
+flutter pub add erika_flutter
+```
+
+platform build 時に対応する検証済み native runtime を download します。Android
+では選択された ABI の archive だけを download します。Linux と Web はまだ公開対象ではありません。
+
 ## C ABI インターフェースファミリー
 
 異なる組み込みシナリオに対応する二つの C ABI エントリーポイントファミリーを提供します：


### PR DESCRIPTION
## 更新内容

- 根 README 及中英文日文入口增加 pub.dev 安装方式
- 发布指南补充 pub.dev package、平台范围、License 和 publisher 说明
- GitHub Release v0.1.7 已同步为中文用户向说明

不改动已发布的 `erika_flutter 0.1.7` 包内容。