### PR TITLE
Add automated pub.dev publishing

### DIFF
--- a/.github/workflows/pub-publish.yml
+++ b/.github/workflows/pub-publish.yml
@@ -1,0 +1,35 @@
+name: Publish erika_flutter to pub.dev
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  verify:
+    name: Verify package version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Match tag and package versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          package_version="$(awk -F': ' '$1 == "version" {print $2; exit}' packages/erika_flutter/pubspec.yaml)"
+          if [[ -z "$package_version" || "$package_version" != "$tag_version" ]]; then
+            echo "Tag version ($tag_version) does not match package version ($package_version)." >&2
+            exit 1
+          fi
+
+  publish:
+    name: Publish to pub.dev
+    needs: verify
+    permissions:
+      contents: read
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/erika_flutter


### PR DESCRIPTION
## 变更
- 新增基于 GitHub Actions OIDC 的 erika_flutter 自动发布流程
- 仅在推送 v1.2.3 格式 tag 时触发
- 发布前校验 tag 版本与 packages/erika_flutter/pubspec.yaml 一致

## 影响
启用 pub.dev 的 GitHub Actions publishing 后，后续版本只需更新 pubspec、推送匹配版本 tag，即可由 GitHub Actions 发布。