### PR TITLE
Separate pub.dev publishing from native releases

### DIFF
--- a/.github/workflows/pub-publish.yml
+++ b/.github/workflows/pub-publish.yml
@@ -1,0 +1,72 @@
+name: Publish erika_flutter to pub.dev
+
+on:
+  push:
+    tags:
+      - "erika_flutter-v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  verify:
+    name: Verify package and native release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify versions and native artifact checksums
+        shell: bash
+        env:
+          RELEASE_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#erika_flutter-v}"
+          package_version="$(awk -F': ' '$1 == "version" {print $2; exit}' packages/erika_flutter/pubspec.yaml)"
+          source packages/erika_flutter/native_artifacts.properties
+
+          if [[ -z "$package_version" || "$package_version" != "$tag_version" ]]; then
+            echo "Tag version ($tag_version) does not match package version ($package_version)." >&2
+            exit 1
+          fi
+          if [[ -z "$ERIKA_NATIVE_VERSION" || "$ERIKA_NATIVE_VERSION" != "$tag_version" ]]; then
+            echo "Tag version ($tag_version) does not match native artifact version ($ERIKA_NATIVE_VERSION)." >&2
+            exit 1
+          fi
+
+          checksums="$RUNNER_TEMP/SHA256SUMS"
+          curl --fail --location --retry 5 --retry-all-errors \
+            "https://github.com/$RELEASE_REPOSITORY/releases/download/v$ERIKA_NATIVE_VERSION/SHA256SUMS" \
+            --output "$checksums"
+
+          verify_checksum() {
+            local expected="$1"
+            local asset="$2"
+            local actual
+            actual="$(awk -v asset="$asset" '$2 == asset {print $1; exit}' "$checksums")"
+            if [[ -z "$expected" || "$actual" != "$expected" ]]; then
+              echo "Checksum mismatch for $asset: expected $expected, release has $actual." >&2
+              exit 1
+            fi
+          }
+
+          verify_checksum "$ERIKA_ANDROID_ARM64_V8A_SHA256" "erika-flutter-android-arm64-v8a.zip"
+          verify_checksum "$ERIKA_ANDROID_ARMEABI_V7A_SHA256" "erika-flutter-android-armeabi-v7a.zip"
+          verify_checksum "$ERIKA_ANDROID_X86_64_SHA256" "erika-flutter-android-x86_64.zip"
+          verify_checksum "$ERIKA_ANDROID_X86_SHA256" "erika-flutter-android-x86.zip"
+          verify_checksum "$ERIKA_IOS_SHA256" "erika-capi-ios.zip"
+          verify_checksum "$ERIKA_TVOS_SHA256" "erika-capi-tvos.zip"
+          verify_checksum "$ERIKA_MACOS_ARM64_SHA256" "erika-capi-macos-arm64.zip"
+          verify_checksum "$ERIKA_MACOS_X64_SHA256" "erika-capi-macos-x64.zip"
+          verify_checksum "$ERIKA_MACOS_UNIVERSAL_SHA256" "erika-capi-macos-universal.zip"
+          verify_checksum "$ERIKA_WINDOWS_X64_SHA256" "erika-capi-windows-x64.zip"
+          verify_checksum "$ERIKA_WINDOWS_ARM64_SHA256" "erika-capi-windows-arm64.zip"
+          verify_checksum "$ERIKA_OPENHARMONY_ARM64_SHA256" "erika-capi-openharmony-arm64.zip"
+
+  publish:
+    name: Publish to pub.dev
+    needs: verify
+    permissions:
+      contents: read
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: packages/erika_flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,26 +537,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Verify release versions
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag_version="${GITHUB_REF_NAME#v}"
-          package_version="$(awk -F': ' '$1 == "version" {print $2; exit}' packages/erika_flutter/pubspec.yaml)"
-          native_version="$(awk -F= '$1 == "ERIKA_NATIVE_VERSION" {print $2; exit}' packages/erika_flutter/native_artifacts.properties)"
-          if [[ ! "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release tag must use the v1.2.3 format: $GITHUB_REF_NAME" >&2
-            exit 1
-          fi
-          if [[ -z "$package_version" || "$package_version" != "$tag_version" ]]; then
-            echo "Tag version ($tag_version) does not match package version ($package_version)." >&2
-            exit 1
-          fi
-          if [[ -z "$native_version" || "$native_version" != "$tag_version" ]]; then
-            echo "Tag version ($tag_version) does not match native artifact version ($native_version)." >&2
-            exit 1
-          fi
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -591,14 +571,3 @@ jobs:
             and [docs/integration.md](https://github.com/AimesSoft/Erika/blob/${{ github.ref_name }}/docs/integration.md)
             to integrate. Review [CHANGELOG.md](https://github.com/AimesSoft/Erika/blob/${{ github.ref_name }}/CHANGELOG.md)
             before upgrading, especially the compatibility notes.
-
-  publish-pub:
-    name: Publish erika_flutter to pub.dev
-    needs: release
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: read
-      id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: packages/erika_flutter

--- a/docs/releasing.ja.md
+++ b/docs/releasing.ja.md
@@ -41,16 +41,35 @@ HarmonyOS/OpenHarmony に対応します。package archive には plugin source�
 `LICENSE`、README、example、version 固定の native artifact manifest が含まれ、platform
 build は対応する GitHub Release archive を download して SHA-256 を検証します。
 
-clean worktree から package directory で実行します：
+公開前に clean worktree の package directory で検証します：
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
-dart pub publish
 ```
 
 merge 前に [flutter-package.yml](../.github/workflows/flutter-package.yml) が isolated package
 と各 platform consumer を検証します。Linux と Web はまだ package 公開対象ではありません。
+
+pub.dev への公開は [pub-publish.yml](../.github/workflows/pub-publish.yml) が自動実行します。
+native archive には build metadata が含まれるため、package に固定する SHA-256 は対応する
+GitHub Release の作成後に更新します。公開順序は次の通りです：
+
+1. 下記の手順で `v0.1.8` を push し、native GitHub Release と `SHA256SUMS` の完了を待つ；
+2. `packages/erika_flutter/pubspec.yaml`、`native_artifacts.properties`、CHANGELOG を同じ
+   version に更新し、Release にある 12 platform archive の digest を manifest に反映する；
+3. Flutter package check の成功後に merge し、その commit に独立した package tag を push する：
+
+   ```sh
+   VERSION=0.1.8
+   git tag "erika_flutter-v${VERSION}"
+   git push origin "erika_flutter-v${VERSION}"
+   ```
+
+Action は package version、native version、GitHub Release の全 SHA-256 を検証してから
+pub.dev OIDC で公開します。long-lived upload secret は保存しません。pub.dev Admin の
+one-time 設定は repository `AimesSoft/Erika`、tag pattern
+`erika_flutter-v{{version}}` です。
 
 ### pub.dev publisher identity
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -63,17 +63,39 @@ contains the plugin sources, package `LICENSE`, README files, examples, and the
 version-pinned native artifact manifest; platform builds fetch the matching
 GitHub Release archives and verify their SHA-256 values.
 
-From a clean worktree, validate and publish the package from its directory:
+From a clean worktree, validate the package from its directory:
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
-dart pub publish
 ```
 
 The isolated package and platform consumer checks run from
 [`.github/workflows/flutter-package.yml`](../.github/workflows/flutter-package.yml)
 before a package release is merged. Linux and Web are not package targets yet.
+
+Publishing to pub.dev is automated by
+[`.github/workflows/pub-publish.yml`](../.github/workflows/pub-publish.yml).
+Native archives include build metadata, so the package-pinned SHA-256 values can
+only be updated after the corresponding GitHub Release exists. Use this order:
+
+1. Push `v0.1.8` as described below and wait for the native GitHub Release and
+   its `SHA256SUMS` asset.
+2. Update `packages/erika_flutter/pubspec.yaml`, `native_artifacts.properties`,
+   and the changelog to the same version. Copy all 12 platform archive digests
+   from the Release into the native artifact manifest.
+3. Merge after the Flutter package checks pass, then tag that package commit:
+
+   ```sh
+   VERSION=0.1.8
+   git tag "erika_flutter-v${VERSION}"
+   git push origin "erika_flutter-v${VERSION}"
+   ```
+
+The action verifies the package version, native version, and every pinned
+SHA-256 against the GitHub Release before publishing through pub.dev OIDC. The
+one-time pub.dev Admin configuration is repository `AimesSoft/Erika` with tag
+pattern `erika_flutter-v{{version}}`; no long-lived upload secret is stored.
 
 ### Pub.dev publisher identity
 

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -38,16 +38,33 @@ Flutter Android 构建按实际请求的 ABI 下载对应
 和 HarmonyOS/OpenHarmony。package archive 包含插件源码、package `LICENSE`、README、
 example 和固定 native artifact manifest；平台构建会下载匹配的 GitHub Release 归档并校验 SHA-256。
 
-在干净工作树中从 package 目录执行：
+发布前先在干净工作树中从 package 目录验证：
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
-dart pub publish
 ```
 
 合并前由 [flutter-package.yml](../.github/workflows/flutter-package.yml) 执行 isolated
 package 和各平台 consumer 检查。Linux 和 Web 目前还不是 package 发布目标。
+
+pub.dev 发布由 [pub-publish.yml](../.github/workflows/pub-publish.yml) 自动执行。原生归档包含
+构建时间，因此 package 固定的 SHA-256 只能在对应 GitHub Release 创建后更新。发布顺序为：
+
+1. 按下文步骤推送 `v0.1.8`，等待原生 GitHub Release 和 `SHA256SUMS` 完成；
+2. 将 `packages/erika_flutter/pubspec.yaml`、`native_artifacts.properties` 和 CHANGELOG
+   更新到同一版本，并把 Release 中 12 个平台归档的哈希写入 manifest；
+3. 合并并确认 Flutter package 检查通过后，在该提交上推送独立 package tag：
+
+   ```sh
+   VERSION=0.1.8
+   git tag "erika_flutter-v${VERSION}"
+   git push origin "erika_flutter-v${VERSION}"
+   ```
+
+Action 会先校验 package 版本、native 版本和 GitHub Release 的全部 SHA-256，再通过
+pub.dev OIDC 发布，不保存长期上传密钥。pub.dev Admin 的一次性配置为 repository
+`AimesSoft/Erika`、tag pattern `erika_flutter-v{{version}}`。
 
 ### pub.dev publisher 身份
 


### PR DESCRIPTION
## 变更
- 使用 `erika_flutter-v<version>` 独立 tag 自动发布 pub.dev
- 发布前校验 pubspec、原生版本和 GitHub Release 中 12 个平台归档的 SHA256
- 继续使用 Dart 官方 OIDC 可复用 workflow，不保存长期密钥
- 原生 `v<version>` Release 与 Flutter package 发布分成两个明确阶段
- 同步中英日发布文档

## 原因
原生归档含构建时间，固定 SHA256 只能在 GitHub Release 生成后写入 package。独立 package tag 能保证 pub.dev 上线时所有平台产物已经存在且哈希一致。

## 验证
- actionlint 通过
- `0.1.7` 的 12 个 package 固定哈希全部与 GitHub Release `SHA256SUMS` 匹配