### PR TITLE
docs: align with 0.1.7 implementation

### DIFF
--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -728,9 +728,10 @@ char *erika_presenter_render_tick_json(
     double time_seconds);
 char *erika_presenter_poll_event_json(ErikaPresenterHandle *handle);
 
-/* Screenshot: render the current composited frame (video + subtitle + danmaku)
- * off-screen into a caller-allocated RGBA8 buffer at the requested size.
- * out_capacity must be >= width*height*4. Fails if no frame is available yet. */
+/* Screenshot: render the current composited frame (video + subtitle, no
+ * danmaku) off-screen into a caller-allocated RGBA8 buffer at the requested
+ * size. out_capacity must be >= width*height*4. Fails if no frame is
+ * available yet. */
 ErikaStatus erika_presenter_capture_frame_rgba(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -30,7 +30,7 @@ Rust Player Core
 | 依存関係 | バージョン | 目的 |
 |----------|-----------|------|
 | FFmpeg | 8.1.2 | Demux、decode、audio resample、プラットフォーム HW decode |
-| dav1d | 1.5.1 | Android AV1 software fallback（8-bit / high bit depth） |
+| dav1d | 1.5.1 | 非 Windows ターゲットの AV1 software fallback（8-bit / high bit depth） |
 | libass | 0.17.5 | ASS subtitle 描画 |
 | FreeType | 2.14.3 | フォントラスタライズ（libass 依存） |
 | HarfBuzz | 14.2.1 | テキストシェーピング（libass 依存） |
@@ -153,7 +153,7 @@ Windows のネイティブ renderer（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` は 2 つの handle family で 79 関数を export します。
+`erika_capi` は 2 つの handle family で 88 関数を export します。
 
 - **`ErikaHandle`**: player control と event polling。rendering は host 管理です。
 - **`ErikaPresenterHandle`**: Erika が full stack を所有します。host は surface を渡して `render_tick` を呼びます。
@@ -180,10 +180,10 @@ embedding model と HDR strategy は `docs/flutter_embedding.md` を参照して
 
 | Platform | Decode | Render | Audio | Status |
 |----------|--------|--------|-------|--------|
-| macOS 14+ | VideoToolbox | Metal | CoreAudio | Available |
-| iOS 16+ | VideoToolbox | Metal | AudioQueue | Available |
+| macOS 11+ | VideoToolbox | Metal | CoreAudio | Available |
+| iOS 13+ | VideoToolbox | Metal | AudioQueue | Available |
 | tvOS 13+ (Apple TV) | VideoToolbox | Metal | AudioQueue | Available |
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan + GLES fallback | AAudio | Available。SDR は検証済み、extended-linear scRGB は API 35 HDR 実機 acceptance 待ち |
-| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan、`OHNativeBuffer` zero-copy import | OHAudio | Available。実機で検証済み、CI は未カバー |
+| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan、`OHNativeBuffer` zero-copy import | OHAudio | Available。実機で検証済み、CI は OpenHarmony C ABI をビルドするがデバイス側の実行検証はなし |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,9 +57,9 @@ cargo run -p xtask -- deps status
   `AVIOContext` from `MediaSource`. Supports stream selection, reference-counted
   packets, and timestamp-based seek.
 - **Decoder** — software plus VideoToolbox, D3D11VA, MediaCodec, and OpenHarmony
-  AVCodec hardware backends. Android software AV1 explicitly selects the source-built
-  `libdav1d` decoder. Hardware frames preserve color metadata for the renderer's
-  platform-specific import or upload path.
+  AVCodec hardware backends. Software AV1 on non-Windows targets selects the
+  source-built `libdav1d` decoder. Hardware frames preserve color metadata for
+  the renderer's platform-specific import or upload path.
 - **AudioResampler** — wraps `libswresample`, converts to interleaved f32 PCM
   (default 48 kHz stereo).
 - **SubtitleDecoder** — decodes embedded text and bitmap subtitle streams.
@@ -79,7 +79,8 @@ enter an audio-only false `Playing` state.
 
 `VideoPlaybackEngine` adds clocked playback:
 
-- Play, pause, stop, seek, playback rate control, EOF detection.
+- Play, pause, stop, seek, playback rate control (SoundTouch for audio),
+  EOF detection.
 - `PlaybackClock` — media-time anchor with audio-master clock discipline
   (deadband correction, bounded per-frame adjustment, large-drift snap).
 - `VideoFrameScheduler` — present/wait/drop decisions for decoded video frames.
@@ -185,7 +186,9 @@ The native renderer for Windows (`renderer/d3d11.rs`):
 
 Second renderer backend for portability:
 
-- Real `wgpu` dependency with device/surface/pipeline creation.
+- Real `wgpu` dependency with device/surface/pipeline creation. The workspace
+  vendors a small `wgpu-hal` patch (`[patch.crates-io]` in the root
+  `Cargo.toml`) that routes the OHOS NDK surface to `VK_OHOS_surface`.
 - NV12/P010 video frame upload and WGSL YCbCr conversion shader.
 - Android MediaCodec Surface import through AHardwareBuffer/Vulkan, with an
   explicit ByteBuffer/CPU-upload path when native interop is unavailable.
@@ -269,7 +272,7 @@ DanmakuEngine, and audio output. The host supplies a native surface and drives
 
 ## C ABI
 
-`erika_capi` exports 79 functions through two handle families:
+`erika_capi` exports 88 functions through two handle families:
 
 - **`ErikaHandle`** — player control and event polling. The host owns rendering.
 - **`ErikaPresenterHandle`** — Erika owns the full stack. The host provides a
@@ -321,10 +324,10 @@ See `docs/flutter_embedding.md` for the embedding model and HDR strategy.
 
 | Platform | Decode | Render | Audio | Status |
 |----------|--------|--------|-------|--------|
-| macOS 14+ | VideoToolbox | Metal | CoreAudio | Available |
-| iOS 16+ | VideoToolbox | Metal | AudioQueue | Available |
+| macOS 11+ | VideoToolbox | Metal | CoreAudio | Available |
+| iOS 13+ | VideoToolbox | Metal | AudioQueue | Available |
 | tvOS 13+ (Apple TV) | VideoToolbox | Metal | AudioQueue | Available |
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan with GLES fallback | AAudio | Available; SDR validated, extended-linear scRGB implementation awaits API 35 HDR-device acceptance |
-| HarmonyOS API 18+ | AVCodec (H.264/HEVC) / software | wgpu Vulkan, `OHNativeBuffer` zero-copy import | OHAudio | Available; validated on device, not yet covered by CI |
+| HarmonyOS API 18+ | AVCodec (H.264/HEVC) / software | wgpu Vulkan, `OHNativeBuffer` zero-copy import | OHAudio | Available; validated on device, CI builds the OpenHarmony C ABI but has no device-side run verification |

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -30,7 +30,7 @@ Rust Player Core
 | 依赖 | 版本 | 作用 |
 |------|------|------|
 | FFmpeg | 8.1.2 | Demux、decode、audio resample、平台硬解 |
-| dav1d | 1.5.1 | Android AV1 软解回退（8-bit 与高位深） |
+| dav1d | 1.5.1 | 非 Windows 目标的 AV1 软解回退（8-bit 与高位深） |
 | libass | 0.17.5 | ASS 字幕渲染 |
 | FreeType | 2.14.3 | 字体栅格化（libass 依赖） |
 | HarfBuzz | 14.2.1 | 文本 shaping（libass 依赖） |
@@ -60,7 +60,7 @@ cargo run -p xtask -- deps status
 
 `VideoPlaybackEngine` 增加时钟驱动播放：
 
-- 播放、暂停、停止、seek、倍速控制、EOF 检测。
+- 播放、暂停、停止、seek、倍速控制（音频经 SoundTouch）、EOF 检测。
 - `PlaybackClock`：带音频主时钟约束的 media-time 锚点（deadband 校正、逐帧有界调整、大漂移 snap）。
 - `VideoFrameScheduler`：为解码后的视频帧决定 present / wait / drop。
 - `DisplaySyncState`：携带残余帧时长误差的 vsync 量化器。
@@ -153,7 +153,7 @@ Windows 平台的原生渲染器（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` 通过两组 handle family 导出 79 个函数：
+`erika_capi` 通过两组 handle family 导出 88 个函数：
 
 - **`ErikaHandle`**：播放器控制与事件轮询，渲染由宿主管理。
 - **`ErikaPresenterHandle`**：Erika 持有完整栈，宿主只需提供 surface 并调用 `render_tick`。
@@ -180,10 +180,10 @@ Embedding 模型和 HDR 策略见 `docs/flutter_embedding.md`。
 
 | Platform | Decode | Render | Audio | Status |
 |----------|--------|--------|-------|--------|
-| macOS 14+ | VideoToolbox | Metal | CoreAudio | Available |
-| iOS 16+ | VideoToolbox | Metal | AudioQueue | Available |
+| macOS 11+ | VideoToolbox | Metal | CoreAudio | Available |
+| iOS 13+ | VideoToolbox | Metal | AudioQueue | Available |
 | tvOS 13+ (Apple TV) | VideoToolbox | Metal | AudioQueue | Available |
 | Windows 10+ | D3D11VA | Direct3D 11 | WASAPI | Available |
 | Linux | — | wgpu (planned) | — | Planned |
 | Android 8+ | MediaCodec / software | wgpu Vulkan + GLES fallback | AAudio | Available；SDR 已验证，extended-linear scRGB 等待 API 35 HDR 真机验收 |
-| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan，`OHNativeBuffer` 零拷贝导入 | OHAudio | Available；已在真机验证，尚未纳入 CI |
+| HarmonyOS API 18+ | AVCodec（H.264/HEVC）/ software | wgpu Vulkan，`OHNativeBuffer` 零拷贝导入 | OHAudio | Available；已在真机验证，CI 构建 OpenHarmony C ABI 但无设备侧运行验证 |

--- a/docs/building.ja.md
+++ b/docs/building.ja.md
@@ -2,7 +2,7 @@
 
 > 翻訳：[English](building.md) · [中文](building.zh.md)
 
-Erika は一連の**静的ビルドされたネイティブ依存**（FFmpeg、Android の dav1d AV1
+Erika は一連の**静的ビルドされたネイティブ依存**（FFmpeg、非 Windows ターゲットの dav1d AV1
 ソフトウェアフォールバック、オプションの libass 字幕スタック）をリンクする Rust workspace です。これらのネイティブライブラリは vendoring
 されていません——`xtask` オーケストレータで一度ビルドすると `third_party/dist/` 配下に
 配置され、Rust crate がそのステージングディレクトリをリンクします。

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,8 +3,8 @@
 > Translations: [中文](building.zh.md) · [日本語](building.ja.md)
 
 Erika is a Rust workspace that links a set of **statically built native
-dependencies** (FFmpeg, Android's dav1d AV1 fallback, and optionally the libass
-subtitle stack). Those native libraries are not vendored — you build them once with the `xtask` orchestrator,
+dependencies** (FFmpeg, dav1d as the non-Windows AV1 fallback, and optionally
+the libass subtitle stack). Those native libraries are not vendored — you build them once with the `xtask` orchestrator,
 which stages them under `third_party/dist/`, and the Rust crates link against
 that staging directory.
 
@@ -24,8 +24,9 @@ xtask deps build  ──▶  third_party/dist/<target>/<profile>/{ffmpeg,dav1d,z
 - For cross-targets, add the Rust std target, e.g.
   `rustup target add aarch64-apple-ios` or
   `rustup target add x86_64-pc-windows-msvc`.
-- Rust currently treats tvOS targets as tier 3. Install nightly with `rust-src`;
-  tvOS builds use Cargo's `-Z build-std` instead of `rustup target add`.
+- tvOS targets are tier 2 as of Rust 1.84, but Erika still builds them with
+  nightly and Cargo's `-Z build-std` (a `panic_abort` std). Install nightly
+  with `rust-src` instead of `rustup target add`.
 
 ### Build tools — macOS / Unix host
 
@@ -81,7 +82,7 @@ Erika's Android minimum is API **26**. Override it with
 cargo run -p xtask -- deps plan
 cargo run -p xtask -- deps status
 
-# Build the baseline set (zlib + FFmpeg; Android also builds dav1d) — LGPL profile
+# Build the baseline set (zlib + FFmpeg; dav1d on Android and Apple targets) — LGPL profile
 cargo run -p xtask -- deps build --profile lgpl
 
 # Build everything, including the libass subtitle stack
@@ -97,7 +98,7 @@ Subcommands: `plan` (print the plan), `fetch` (download sources only),
 |------|--------|---------|---------|
 | `--profile` | `lgpl`, `gpl-full` | `lgpl` | FFmpeg license profile (see below). |
 | `--target` | see targets table | `host` | Cross-compile target. |
-| `--all` | — | off | Also build libass + FreeType + HarfBuzz + FriBidi (subtitle rendering). The baseline is zlib + FFmpeg, plus dav1d for Android targets. |
+| `--all` | — | off | Also build libass + FreeType + HarfBuzz + FriBidi (subtitle rendering). The baseline is zlib + FFmpeg, plus dav1d for Android and Apple targets. |
 | `--force` | — | off | Rebuild even if up-to-date markers exist. |
 | `--jobs N` | integer | auto | Parallelism for the native builds. |
 
@@ -150,8 +151,8 @@ ERIKA_NATIVE_PROFILE=lgpl ERIKA_NATIVE_TARGET=aarch64-apple-darwin \
   cargo build -p erika_capi --release --target aarch64-apple-darwin
 ```
 
-Because Rust's tvOS targets are tier 3, direct tvOS builds use nightly and build
-the standard library from `rust-src`:
+Direct tvOS builds use nightly and build the standard library from `rust-src`
+(the CI pipeline runs `-Z build-std=std,panic_abort`):
 
 ```sh
 rustup toolchain install nightly --component rust-src
@@ -215,7 +216,8 @@ The native build is split into profiles so the license boundary is explicit:
 - **`lgpl`** (default) — FFmpeg configured `--disable-gpl --enable-version3`,
   static, no network, file protocol only, a curated demuxer/decoder/parser set,
   zlib enabled, plus VideoToolbox (Apple), D3D11VA/DXVA2 (Windows), or
-  JNI/MediaCodec plus source-built dav1d AV1 software fallback (Android).
+  JNI/MediaCodec plus source-built dav1d AV1 software fallback (Android and
+  Apple targets).
 - **`gpl-full`** — the same set with `--enable-gpl`. Use only if you accept GPL
   terms for the resulting binary.
 
@@ -281,8 +283,9 @@ pipeline, preserving subtitles, danmaku, and screenshots. This is hardware
 decode with a CPU upload, not a zero-copy Surface path; metrics must report it
 accordingly. If AV1 MediaCodec cannot open or fails while decoding, the software
 path explicitly selects FFmpeg's `libdav1d` decoder. `xtask` builds dav1d 1.5.1
-from source for every Android ABI with both 8-bit and high-bit-depth support;
-the 32-bit x86 slice disables assembly to preserve PIC safety.
+from source for every Android ABI and the Apple targets, with both 8-bit and
+high-bit-depth support; the 32-bit Android x86 slice disables assembly to
+preserve PIC safety.
 
 ### Verify Android output negotiation
 
@@ -352,8 +355,9 @@ decode and zero-copy interop are engaged.
   `Rgba16Float` (`4`), unavailable dataspace API (`5`), or failed
   `SCRGB_LINEAR` verification (`6`). Codes `7` and `8` identify surface
   configuration failure and an Apple-EDR request on an unsupported backend.
-- **Legacy FFmpeg rejected** — install/build the 7.x bundle; don't rely on a
-  system FFmpeg.
+- **Legacy FFmpeg rejected** — the native core requires the 8.x bundle
+  (`libavutil >= 60`) and fails at build time otherwise; the check is skipped
+  only when `ERIKA_ALLOW_LEGACY_FFMPEG=1` is set for local experiments.
 - **License check fails** — your profile mixes GPL and LGPL artifacts; rebuild
   deps with a single `--profile`.
 

--- a/docs/building.zh.md
+++ b/docs/building.zh.md
@@ -22,7 +22,8 @@ xtask deps build  ──▶  third_party/dist/<target>/<profile>/{ffmpeg,dav1d,z
 - 交叉目标需安装对应 Rust std target,如
   `rustup target add aarch64-apple-ios` 或
   `rustup target add x86_64-pc-windows-msvc`。
-- Rust 当前将 tvOS 目标列为 tier 3。请安装带 `rust-src` 的 nightly；tvOS
+- tvOS 目标自 Rust 1.84 起为 tier 2，但 Erika 仍用 nightly 与 Cargo 的 `-Z
+  build-std`（`panic_abort` std）构建。安装带 `rust-src` 的 nightly 即可，无需 `rustup target add`。
   通过 Cargo 的 `-Z build-std` 构建，不使用 `rustup target add`。
 
 ### 构建工具 —— macOS / Unix 宿主
@@ -70,7 +71,7 @@ Android 最低 API 为 **26**;只在需要更高版本时用 `ANDROID_API_LEVEL`
 cargo run -p xtask -- deps plan
 cargo run -p xtask -- deps status
 
-# 构建基础集(zlib + FFmpeg;Android 还会构建 dav1d)—— LGPL profile
+# 构建基础集(zlib + FFmpeg;dav1d 覆盖 Android 与 Apple 目标)—— LGPL profile
 cargo run -p xtask -- deps build --profile lgpl
 
 # 构建全部,含 libass 字幕栈
@@ -86,7 +87,7 @@ cargo run -p xtask -- deps build --all --profile lgpl
 |------|------|------|------|
 | `--profile` | `lgpl`、`gpl-full` | `lgpl` | FFmpeg 许可证 profile(见下)。 |
 | `--target` | 见目标表 | `host` | 交叉编译目标。 |
-| `--all` | — | 关 | 同时构建 libass + FreeType + HarfBuzz + FriBidi(字幕渲染)。基础集是 zlib + FFmpeg,Android 目标还包含 dav1d。 |
+| `--all` | — | 关 | 同时构建 libass + FreeType + HarfBuzz + FriBidi(字幕渲染)。基础集是 zlib + FFmpeg,Android 与 Apple 目标还包含 dav1d。 |
 | `--force` | — | 关 | 即使已是最新标记也重建。 |
 | `--jobs N` | 整数 | 自动 | 原生构建的并行度。 |
 
@@ -136,7 +137,7 @@ ERIKA_NATIVE_PROFILE=lgpl ERIKA_NATIVE_TARGET=aarch64-apple-darwin \
   cargo build -p erika_capi --release --target aarch64-apple-darwin
 ```
 
-Rust 的 tvOS 目标属于 tier 3，直接构建时需要 nightly 并从 `rust-src`
+tvOS 的 Rust 目标虽已是 tier 2，但 Erika 直接构建时仍用 nightly 并从 `rust-src`
 构建标准库：
 
 ```sh
@@ -198,7 +199,7 @@ cdylib 与匹配 ABI 的 NDK `libc++_shared.so`。
 
 - **`lgpl`**(默认)—— FFmpeg 配置为 `--disable-gpl --enable-version3`,静态,无网络,
   仅 file 协议,一组精选的 demuxer/decoder/parser,启用 zlib,外加 VideoToolbox(Apple)、
-  D3D11VA/DXVA2(Windows)或 JNI/MediaCodec + 源码构建的 dav1d AV1 软解回退(Android)。
+  D3D11VA/DXVA2(Windows)或 JNI/MediaCodec + 源码构建的 dav1d AV1 软解回退(Android 与 Apple 目标)。
 - **`gpl-full`** —— 同一集合加 `--enable-gpl`。仅当你接受产物的 GPL 条款时使用。
 
 Rust workspace 本身是 MPL-2.0(见 [`LICENSE`](../LICENSE))。`xtask` 与你的
@@ -256,7 +257,7 @@ Android FFmpeg 明确保留 H.264、HEVC、MPEG-2、MPEG-4、VP8、VP9、AV1 的
 MediaCodec decoder。主路径让 MediaCodec 输出软件可读 YUV,继续复用共享 wgpu 上传、
 字幕、弹幕和截图合成。这是“硬解 + CPU upload”,不是 Surface 零拷贝,统计与日志必须
 如实区分。AV1 MediaCodec 无法打开或解码失败时,软件路径会显式选择 FFmpeg 的
-`libdav1d` decoder。`xtask` 为四个 Android ABI 从源码构建 dav1d 1.5.1,同时支持
+`libdav1d` decoder。`xtask` 为全部 Android ABI 与 Apple 目标从源码构建 dav1d 1.5.1,同时支持
 8-bit 与高位深;32 位 x86 为保证 PIC 安全会禁用汇编。
 
 ### 验证 Android 输出协商
@@ -318,7 +319,7 @@ underflow)——快速确认硬解和零拷贝互操作已生效。
   Hybrid Composition（`2`）、使用 GLES（`3`）、没有 `Rgba16Float`（`4`）、dataspace
   API 不可用（`5`）或 `SCRGB_LINEAR` 验证失败（`6`）。`7` 与 `8` 分别表示 surface
   configure 失败和在不支持的 backend 上请求 Apple EDR。
-- **旧版 FFmpeg 被拒** —— 安装/构建 7.x 包;别依赖系统 FFmpeg。
+- **旧版 FFmpeg 被拒** —— 原生核心要求 8.x 依赖包(`libavutil >= 60`),否则构建期直接失败;仅当设置 `ERIKA_ALLOW_LEGACY_FFMPEG=1` 时才跳过该检查(仅限本地兼容性实验)。
 - **license 校验失败** —— 你的 profile 混了 GPL 与 LGPL 工件;用单一 `--profile` 重建 deps。
 
 开发工作流见 [CONTRIBUTING.zh.md](../CONTRIBUTING.zh.md),各部分如何拼接见

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -476,7 +476,7 @@ char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
 
 ```json
 { "ok": true,  "status": 0, "value": <result> }
-{ "ok": false, "status": 1, "error": "<message>" }
+{ "ok": false, "status": 3, "error": "<message>" }
 ```
 
 `arguments_json` は JSON オブジェクトである必要があります。`method` は操作を選び、
@@ -487,7 +487,9 @@ C エントリポイントに対応します: `open`、`play`、`pause`、`stop`
 `selectSubtitleTrack`、および danmaku 系（`loadDanmakuFile`、`loadDanmakuJson`、
 `addDanmakuTrackFile`、`addDanmakuTrackJson`、`removeDanmakuTrack`、
 `setDanmakuTrackEnabled`、`setDanmakuTrackOffset`、`setDanmakuGlobalOffset`、
-`danmakuTracks`、`clearDanmaku`、`setDanmakuEnabled`、`setDanmakuConfig`）。
+`danmakuTracks`、`clearDanmaku`、`setDanmakuEnabled`、`setDanmakuConfig`）、および
+字幕フォント・リソース状態系（`selectSubtitleMemoryFonts`、
+`clearSubtitleMemoryFonts`、`getSubtitleMemoryFontStatus`、`getResourceStatus`）。
 未知の method は abort せず `ok: false` を返します。正となる dispatch table は
 `crates/erika_capi/src/presenter_json.rs` です。
 
@@ -541,7 +543,7 @@ Fallback value は ABI-stable です。新しい reason は末尾へ追加し、
 | 7 | `SurfaceConfigureFailed` | `surface_configure_failed` | requested output surface configure failure。 |
 | 8 | `LegacyAppleEdrUnsupported` | `legacy_apple_edr_unsupported` | Apple EDR 未実装 backend でこの mode を要求。 |
 
-`capture_frame_rgba` は**スクリーンショット**です。現在の合成フレーム（映像 + 字幕 +
+`capture_frame_rgba` は**スクリーンショット**です。現在の合成フレーム（映像 + 字幕（弾幕は含みません） +
 弾幕）を、要求した `width`×`height`（表示 surface サイズとは独立）で呼び出し側確保の
 RGBA8 バッファにオフスクリーン描画します。`out_capacity` は少なくとも `width*height*4`。
 フレームがまだ無いときは `PlayerError` を返します。Metal と wgpu（Android を含む）は
@@ -563,12 +565,12 @@ free(rgba);
 | 列挙 | 値 |
 |------|----|
 | `ErikaState` | `Idle` `Opening` `Ready` `Playing` `Paused` `Stopped` `Closed` `Error` |
-| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` |
+| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `VideoDecoderChanged` `AudioOutputChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` |
 | `ErikaTrackKind` | `Video` `Audio` `Subtitle` |
 | `ErikaTrackSource` | `Embedded` `External` |
-| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` |
+| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
-| `ErikaPresenterOutputMode` | `Sdr` `AppleEdr` `ExtendedLinear` |
+| `ErikaPresenterOutputMode` | `Auto` `Sdr` `AppleEdr` `ExtendedLinear` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
 | `ErikaOutputFallbackReason` | `None` `DisplayHdrUnsupported` `HybridCompositionRequired` `WgpuBackendNotVulkan` `Rgba16FloatSurfaceFormatUnavailable` `NativeWindowDataSpaceApiUnavailable` `ScrgbDataSpaceVerificationFailed` `SurfaceConfigureFailed` `LegacyAppleEdrUnsupported` |

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -393,6 +393,25 @@ ErikaStatus erika_presenter_tracks(ErikaPresenterHandle *, ErikaTrackInfo *out_t
 
 Same semantics as the `ErikaHandle` track functions.
 
+In-memory subtitle fonts let a host register font data directly instead of
+relying on the bundled fallback font or system font providers:
+
+```c
+ErikaStatus erika_presenter_register_subtitle_memory_font(ErikaPresenterHandle *, const uint8_t *data, uintptr_t data_len, uint64_t *out_font_id);
+ErikaStatus erika_presenter_select_subtitle_memory_fonts(ErikaPresenterHandle *, const uint64_t *font_ids, uintptr_t font_count);
+ErikaStatus erika_presenter_clear_subtitle_memory_fonts(ErikaPresenterHandle *);
+ErikaStatus erika_presenter_get_subtitle_memory_font_status(ErikaPresenterHandle *, ErikaSubtitleMemoryFontStatus *out_status);
+ErikaStatus erika_presenter_get_subtitle_memory_font_info(ErikaPresenterHandle *, uint64_t font_id, ErikaSubtitleMemoryFontInfo *out_info);
+void erika_subtitle_memory_font_status_free(ErikaSubtitleMemoryFontStatus *status);
+void erika_subtitle_memory_font_info_free(ErikaSubtitleMemoryFontInfo *info);
+```
+
+Registered fonts count against a total byte limit. `select_subtitle_memory_fonts`
+replaces the active selection with the given already-registered ids (invalid or
+duplicate ids are rejected); `clear_subtitle_memory_fonts` drops both the
+selection and the registered fonts. The `*_free` helpers release the returned
+status/info buffers.
+
 ### Danmaku (bullet comments)
 
 ```c
@@ -405,6 +424,7 @@ ErikaStatus erika_presenter_set_danmaku_track_enabled(ErikaPresenterHandle *, ui
 ErikaStatus erika_presenter_set_danmaku_track_offset(ErikaPresenterHandle *, uint64_t track_id, int64_t offset_micros);
 ErikaStatus erika_presenter_set_danmaku_global_offset(ErikaPresenterHandle *, int64_t offset_micros);
 ErikaStatus erika_presenter_danmaku_tracks(ErikaPresenterHandle *, ErikaDanmakuTrackInfo *out_tracks, uintptr_t capacity, uintptr_t *out_len);
+void erika_danmaku_track_info_free(ErikaDanmakuTrackInfo *track);
 ErikaStatus erika_presenter_clear_danmaku(ErikaPresenterHandle *);
 ErikaStatus erika_presenter_set_danmaku_enabled(ErikaPresenterHandle *, bool enabled);
 ErikaStatus erika_presenter_set_debug_hud_enabled(ErikaPresenterHandle *, bool enabled);
@@ -470,10 +490,17 @@ ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_e
 
 Call `render_tick` once per display frame (e.g. from `CADisplayLink`,
 `CVDisplayLink`, or a Windows frame scheduler). `time_seconds` is the host
-display clock for the frame in seconds — Erika uses it for vsync-quantized
-scheduling, so pass the presentation timestamp, not wall-clock deltas. If
+display clock for the frame in seconds; it drives the idle test pattern
+animation, so pass the presentation timestamp, not wall-clock deltas. If
 `out_stats` is non-`NULL` it is filled with a snapshot of pipeline counters.
 `poll_event` is non-blocking and returns `NoEvent` when idle.
+
+`audio_only_tick` advances audio output without rendering, for hosts that have
+no surface attached:
+
+```c
+ErikaStatus erika_presenter_audio_only_tick(ErikaPresenterHandle *, ErikaPresenterStats *out_stats);
+```
 
 `get_stats` fills the same `ErikaPresenterStats` snapshot without rendering a
 frame. Use it when the host samples counters on a different cadence from the
@@ -500,7 +527,7 @@ All three wrap their result in an envelope:
 
 ```json
 { "ok": true,  "status": 0, "value": <result> }
-{ "ok": false, "status": 1, "error": "<message>" }
+{ "ok": false, "status": 3, "error": "<message>" }
 ```
 
 `arguments_json` must be a JSON object. `method` selects the operation and
@@ -512,7 +539,9 @@ mirrors the C entry points: `open`, `play`, `pause`, `stop`, `close`, `seek`,
 `loadDanmakuJson`, `addDanmakuTrackFile`, `addDanmakuTrackJson`,
 `removeDanmakuTrack`, `setDanmakuTrackEnabled`, `setDanmakuTrackOffset`,
 `setDanmakuGlobalOffset`, `danmakuTracks`, `clearDanmaku`, `setDanmakuEnabled`,
-`setDanmakuConfig`). An unknown method fails with `ok: false` rather than
+`setDanmakuConfig`), plus `selectSubtitleMemoryFonts`,
+`clearSubtitleMemoryFonts`, `getSubtitleMemoryFontStatus`, and
+`getResourceStatus`. An unknown method fails with `ok: false` rather than
 aborting. The authoritative dispatch table is
 `crates/erika_capi/src/presenter_json.rs`.
 
@@ -525,6 +554,7 @@ structs across their platform channel should prefer the typed entry points.
 ```c
 ErikaStatus erika_presenter_get_upscaler_status(ErikaPresenterHandle *, ErikaUpscalerStatus *out_status);
 ErikaStatus erika_presenter_get_output_status(ErikaPresenterHandle *, ErikaOutputStatus *out_status);
+ErikaStatus erika_presenter_get_resource_status(ErikaPresenterHandle *, ErikaPresenterResourceStatus *out_status);
 ErikaStatus erika_presenter_capture_frame_rgba(ErikaPresenterHandle *, uint32_t width, uint32_t height,
                                                uint8_t *out_rgba, uintptr_t out_capacity);
 ```
@@ -567,12 +597,14 @@ The fallback values are ABI-stable; append new reasons, never renumber `0..8`:
 | 8 | `LegacyAppleEdrUnsupported` | `legacy_apple_edr_unsupported` | Apple EDR was requested on a backend that does not implement it. |
 
 `capture_frame_rgba` is a **screenshot**: it renders the current composited
-frame (video + subtitle + danmaku) off-screen into a caller-allocated RGBA8
-buffer at the requested `width`×`height` (independent of the display surface
-size). `out_capacity` must be at least `width*height*4`. It returns `PlayerError`
-when no frame is available yet. Metal and wgpu (including Android) implement
-capture; the current D3D11 backend does not. Capture always uses an SDR RGBA8
-offscreen target and tone-maps HDR/extended-linear content, so the returned
+frame (video + subtitle) off-screen into a caller-allocated RGBA8 buffer at the
+requested `width`×`height` (independent of the display surface size). Danmaku
+is deliberately not included — screenshots represent the video rather than
+transient on-screen comments. `out_capacity` must be at least `width*height*4`.
+It returns `PlayerError` when no frame is available yet. Metal and wgpu
+(including Android) implement capture; the current D3D11 backend does not.
+Capture always uses an SDR RGBA8 offscreen target and tone-maps
+HDR/extended-linear content, so the returned
 bytes are SDR even when the display output is Apple EDR, HDR10, or Android
 extended-linear scRGB.
 
@@ -585,17 +617,24 @@ if (erika_presenter_capture_frame_rgba(p, w, h, rgba, (uintptr_t)w * h * 4) == E
 free(rgba);
 ```
 
+`get_resource_status` reports memory budgeting for diagnostics: current device
+allocation, recommended working set, per-bucket GPU byte estimates (video
+frames, overlay and danmaku atlases, danmaku vertex buffers, upscaler), the
+renderer-tracked total, presenter CPU-side danmaku atlas bytes, the drawable
+count, and how many times the output mode was switched. All values are
+snapshots from the same runtime state as `get_output_status`.
+
 ## Enums
 
 | Enum | Values |
 |------|--------|
 | `ErikaState` | `Idle` `Opening` `Ready` `Playing` `Paused` `Stopped` `Closed` `Error` |
-| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` |
+| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` `VideoDecoderChanged` `AudioOutputChanged` |
 | `ErikaTrackKind` | `Video` `Audio` `Subtitle` |
 | `ErikaTrackSource` | `Embedded` `External` |
-| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` |
+| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
-| `ErikaPresenterOutputMode` | `Sdr` `AppleEdr` `ExtendedLinear` |
+| `ErikaPresenterOutputMode` | `Sdr` `AppleEdr` `ExtendedLinear` `Auto` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
 | `ErikaOutputFallbackReason` | `None` `DisplayHdrUnsupported` `HybridCompositionRequired` `WgpuBackendNotVulkan` `Rgba16FloatSurfaceFormatUnavailable` `NativeWindowDataSpaceApiUnavailable` `ScrgbDataSpaceVerificationFailed` `SurfaceConfigureFailed` `LegacyAppleEdrUnsupported` |
@@ -611,6 +650,15 @@ free(rgba);
   upscaled frames, last encode/GPU micros.
 - **`ErikaOutputStatus`** — the 13-field negotiated output snapshot documented
   under [Diagnostics and capture](#diagnostics-and-capture).
+- **`ErikaPresenterResourceStatus`** — device/recommended working set bytes,
+  per-bucket GPU byte estimates, renderer-tracked total, drawable count, and
+  output-mode switch count; filled by `get_resource_status`.
+- **`ErikaSubtitleMemoryFontStatus`** — registered/selected count and total
+  bytes for in-memory subtitle fonts; free with
+  `erika_subtitle_memory_font_status_free`.
+- **`ErikaSubtitleMemoryFontFace`** / **`ErikaSubtitleMemoryFontInfo`** —
+  per-font face details and aggregate info; free with
+  `erika_subtitle_memory_font_info_free`.
 - **`ErikaDanmakuConfig`** — full danmaku layout/appearance config (font size,
   opacity, display area, scroll timing, collision/stacking flags, blocked modes,
   shadow style). `font_size` is a NipaPlay/Flutter *logical* size; Erika

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -449,7 +449,7 @@ char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
 
 ```json
 { "ok": true,  "status": 0, "value": <result> }
-{ "ok": false, "status": 1, "error": "<message>" }
+{ "ok": false, "status": 3, "error": "<message>" }
 ```
 
 `arguments_json` 必须是 JSON 对象。`method` 选择操作，与 C 入口一一对应：
@@ -460,7 +460,9 @@ char *erika_presenter_poll_event_json(ErikaPresenterHandle *);
 `loadDanmakuJson`、`addDanmakuTrackFile`、`addDanmakuTrackJson`、
 `removeDanmakuTrack`、`setDanmakuTrackEnabled`、`setDanmakuTrackOffset`、
 `setDanmakuGlobalOffset`、`danmakuTracks`、`clearDanmaku`、`setDanmakuEnabled`、
-`setDanmakuConfig`）。未知 method 返回 `ok: false`，不会中止。权威分发表见
+`setDanmakuConfig`），以及字幕字体与资源状态系列（`selectSubtitleMemoryFonts`、
+`clearSubtitleMemoryFonts`、`getSubtitleMemoryFontStatus`、`getResourceStatus`）。
+未知 method 返回 `ok: false`，不会中止。权威分发表见
 `crates/erika_capi/src/presenter_json.rs`。
 
 这层桥只是便利封装，不是第二套 API：它调用的就是上面这些函数，没有额外能力。
@@ -511,7 +513,7 @@ Fallback 数值是稳定 ABI；新增原因只能追加，不能重排 `0..8`：
 | 7 | `SurfaceConfigureFailed` | `surface_configure_failed` | 请求的输出 surface configure 失败。 |
 | 8 | `LegacyAppleEdrUnsupported` | `legacy_apple_edr_unsupported` | 在未实现 Apple EDR 的 backend 上请求了该模式。 |
 
-`capture_frame_rgba` 是**截图**：把当前合成帧（视频 + 字幕 + 弹幕）离屏渲染进调用方
+`capture_frame_rgba` 是**截图**：把当前合成帧（视频 + 字幕，不含弹幕）离屏渲染进调用方
 分配的 RGBA8 缓冲，按请求的 `width`×`height`（与显示 surface 尺寸无关）。
 `out_capacity` 至少为 `width*height*4`。尚无可用帧时返回 `PlayerError`。Metal 与
 wgpu（包括 Android）已实现截图；当前 D3D11 backend 尚未实现。截图始终使用 SDR RGBA8
@@ -532,12 +534,12 @@ free(rgba);
 | 枚举 | 取值 |
 |------|------|
 | `ErikaState` | `Idle` `Opening` `Ready` `Playing` `Paused` `Stopped` `Closed` `Error` |
-| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` |
+| `ErikaEventKind` | `None` `StateChanged` `DurationChanged` `PositionChanged` `TracksChanged` `BufferingChanged` `VideoParamsChanged` `VideoDecoderChanged` `AudioOutputChanged` `SurfaceAttached` `SurfaceDetached` `Error` `TrackSelectionChanged` |
 | `ErikaTrackKind` | `Video` `Audio` `Subtitle` |
 | `ErikaTrackSource` | `Embedded` `External` |
-| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` |
+| `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
-| `ErikaPresenterOutputMode` | `Sdr` `AppleEdr` `ExtendedLinear` |
+| `ErikaPresenterOutputMode` | `Auto` `Sdr` `AppleEdr` `ExtendedLinear` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
 | `ErikaOutputFallbackReason` | `None` `DisplayHdrUnsupported` `HybridCompositionRequired` `WgpuBackendNotVulkan` `Rgba16FloatSurfaceFormatUnavailable` `NativeWindowDataSpaceApiUnavailable` `ScrgbDataSpaceVerificationFailed` `SurfaceConfigureFailed` `LegacyAppleEdrUnsupported` |

--- a/docs/danmaku_architecture.ja.md
+++ b/docs/danmaku_architecture.ja.md
@@ -127,7 +127,7 @@ Flutter wrapper は `addDanmakuTrackFile`、`addDanmakuTrackJson`、`removeDanma
 
 `PlayerVideoFrame` は `pts`、`media_time`、`generation` を持ちます。presenter が `pump_video` で frame を upload した後、`frame.pts.unwrap_or(frame.media_time)` を現在の弾幕 query time として使います。その後 `update_overlay` が同じ PTS を使って subtitle overlay と danmaku render plan を生成します。最終的に renderer は `RenderFrameContext { media_time, generation, overlay, danmaku }` を受け取ります。
 
-renderer は不一致の danmaku plan を gate で落とします。Metal / WGPU ともに plan の `generation` が context generation と一致し、plan の `media_time` が context media time と一致し、viewport が現在の出力サイズに一致する必要があります。これにより seek、stop、close、track switch、config change の後に古い plan が描画され続けることを防ぎます。
+renderer は不一致の danmaku plan を gate で落とします。Metal / WGPU ともに plan の `generation` が context generation と一致し、viewport が現在の出力サイズに一致する必要があります。media_time の照合は presenter の windowed plan が担います——各 plan は `[window_start, window_end]` を持ち、再生時間が window を外れると古い plan は描画に回りません。これにより seek、stop、close、track switch、config change の後に古い generation / 古い window の plan が描画され続けることを防ぎます。
 
 つまり、弾幕位置は「pause 中に止まる」だけではありません。常に video media timeline によって決まります。再生中は media time に合わせて scrolling 弾幕が流れ、pause 中は media time が変わらないので位置も変わらず、seek 後は新しい media time を直接 query し、古い plan は generation 不一致で破棄されます。
 

--- a/docs/danmaku_architecture.md
+++ b/docs/danmaku_architecture.md
@@ -84,7 +84,7 @@ flowchart LR
 
 这一段的输入应保持 NipaPlay DFM+ 的抽象：规范化弹幕 item、viewport、字体测量结果、用户配置。Erika 可以用自己的 Rust 类型承载这些字段，但字段语义要对齐 NipaPlay：时间、文本、type_code、颜色、is_me、paint_width/paint_height、display_area、scroll_duration、allow_stacking、merge、max_quantity、max_lines、track_gap、outline、block_words 等都应进入 DFM+ prepare。
 
-在 DFM+ 之前，Erika 现在多了一层 `DanmakuSession`。它不参与布局算法，只负责把播放器/Flutter 传入的弹幕输入面整理成 DFM+ 能消费的一条 active timeline：多个弹幕轨可以同时启用，按轨 offset 和全局 offset 会在 active timeline 构建时应用，源 item id 会加上 track id 前缀以避免多轨合并后的 id 冲突。seek 不应该因为 generation 改变而重新 prepare；prepare 的失效条件应是 timeline/session 内容、viewport 或 config 变化，generation 只盖在当前帧输出上用于 renderer gate。
+在 DFM+ 之前，Erika 现在多了一层 `DanmakuSession`。它不参与布局算法，只负责把播放器/Flutter 传入的弹幕输入面整理成 DFM+ 能消费的一条 active timeline：多个弹幕轨可以同时启用，按轨 offset 和全局 offset 会在 active timeline 构建时应用，源 item id 会加上 track id 前缀以避免多轨合并后的 id 冲突。prepare 在独立 worker 上异步执行，plan 请求以 `{media_time, viewport, generation}` 为 key，其中任何一项变化都会触发重新 prepare；结果 plan 只覆盖一个时间窗口，播放时间离开窗口即作废，seek 后旧窗口的 plan 不会被继续使用。
 
 这一段的输出也应保持 NipaPlay DFM+ 的抽象：prepared layout 保存稳定布局结果；frame query 只根据 media time 输出当前 visible items 的 index 和位置。Erika 之后再把 item_index 对应的文本、颜色、字号、描边等样式转换成 `DanmakuFrameLayout` 和 `DanmakuRenderPlan`。
 
@@ -125,7 +125,7 @@ Flutter wrapper 已经对应暴露 `addDanmakuTrackFile`、`addDanmakuTrackJson`
 
 `PlayerVideoFrame` 带有 `pts`、`media_time` 和 `generation`。presenter 在 `pump_video` 上传视频帧后，用 `frame.pts.unwrap_or(frame.media_time)` 作为当前弹幕查询时间。之后 `update_overlay` 用同一个 pts 生成字幕 overlay 和 danmaku render plan。最终 renderer 收到 `RenderFrameContext { media_time, generation, overlay, danmaku }`。
 
-renderer 会 gate 掉不匹配的弹幕 plan。Metal 和 WGPU 都要求 plan 的 `generation` 等于 context generation，plan 的 `media_time` 等于 context media_time，并且 viewport 与当前输出尺寸一致。这样 seek、stop、close、弹幕轨切换或配置变化后，旧 generation 的弹幕 plan 不会继续进入渲染。
+renderer 会 gate 掉不匹配的弹幕 plan。Metal 和 WGPU 都要求 plan 的 `generation` 等于 context generation，并且 viewport 与当前输出尺寸一致；media_time 匹配由 presenter 的窗口化 plan 负责——每个 plan 带 `[window_start, window_end]`，播放时间离开窗口后旧 plan 不再进入渲染，renderer 不需要再核对时间。这样 seek、stop、close、弹幕轨切换或配置变化后，旧 generation 或旧窗口的弹幕 plan 不会继续进入渲染。
 
 这个契约的含义是：弹幕位置不是“暂停时不动”这么简单，而是任何时刻都由视频 media timeline 决定。播放位置连续推进时，滚动弹幕随 media time 流式变化；pause 时 media time 不变，所以弹幕位置不变；seek 后 media time 跳到新位置，prepared layout 根据新时间直接查询对应弹幕，旧 plan 因 generation 不匹配被丢弃。
 

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -69,15 +69,15 @@ compositor に届きます。字幕・danmaku・overlay は他 platform と同�
 必要な Vulkan extension が無い端末は FFmpeg software decode と CPU upload に
 fallback します。fallback は再生を失敗させず、`VideoDecoderChanged` event と
 presenter diagnostics から報告されます。HarmonyOS path は実機で検証済みですが、
-CI では未カバーです。
+CI は OpenHarmony C ABI をビルドしますが、デバイス側の実行検証はありません。
 
 ## iOS Build Path
 
-iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を app にリンクし、対象 iOS architecture 向けに Rust の `erika_capi` crate をビルドします。
+iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を app にリンクします。既定では一致する prebuilt アーカイブをダウンロードし、`ERIKA_FORCE_SOURCE_BUILD=1`（`ERIKA_REPO_ROOT` と併用）で初めて対象 iOS architecture 向けに Rust の `erika_capi` crate をビルドします。
 
 ## tvOS Build Path
 
-tvOS plugin は CocoaPod script phase 経由で Apple TV 実機と simulator 向けに Erika C ABI static library をビルド・リンクします。tvOS 13+、arm64 実機、arm64/x86_64 simulator に対応します。Rust nightly、prebuilt bundle、source build の詳細は [`packages/erika_flutter/README.ja.md`](../packages/erika_flutter/README.ja.md) を参照してください。
+tvOS plugin は CocoaPod script phase 経由で Erika C ABI static library をリンクします。iOS と同様に既定では prebuilt アーカイブをダウンロードし、`ERIKA_FORCE_SOURCE_BUILD=1` のときのみソースビルドします。tvOS 13+、arm64 実機、arm64/x86_64 simulator に対応します。Rust nightly、prebuilt bundle、source build の詳細は [`packages/erika_flutter/README.ja.md`](../packages/erika_flutter/README.ja.md) を参照してください。
 
 ## Minimal Presenter Flow
 
@@ -242,7 +242,7 @@ output negotiation、danmaku item count を表示します。FPS は隣接 sampl
 |-----------------|------|
 | `off` | どの mode も要求されていない。 |
 | `building` | kernel を compile 中（その mode の初回使用）。準備完了まで frame は未拡大で描画される。 |
-| `inactive` | mode は要求されたが、この frame では適用されていない。たとえば video の表示サイズが source resolution を超えていない、または source が HDR（upscaler は SDR luma のみ処理）など。 |
+| `inactive` | mode は要求されたが適用されていない——kernel が未準備（かつビルド中でもない）、または backend が fallback/failure を記録した。 |
 | `scalar` | Metal scalar または wgpu compute backend で動作中。 |
 | `simdgroupMatrix` | `simdgroup_matrix` backend で動作中（Apple Silicon の既定）。 |
 

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -92,19 +92,22 @@ the same wgpu pass as every other platform.
 Devices missing the required Vulkan extensions fall back to FFmpeg software
 decode with CPU upload. The fallback is reported through `VideoDecoderChanged`
 events and presenter diagnostics instead of failing playback. The HarmonyOS
-path is validated on device but is not yet covered by CI.
+path is validated on device; CI builds the OpenHarmony C ABI but has no
+device-side run verification.
 
 ## iOS Build Path
 
 The iOS plugin links the Erika C ABI static library into the app through a
-CocoaPod script phase that builds the Rust `erika_capi` crate for the target iOS
-architecture.
+CocoaPod script phase. By default it downloads the matching prebuilt archive;
+set `ERIKA_FORCE_SOURCE_BUILD=1` (with `ERIKA_REPO_ROOT`) to build the Rust
+`erika_capi` crate for the target iOS architecture instead.
 
 ## tvOS Build Path
 
 The tvOS plugin links the Erika C ABI static library through its CocoaPod script
-phase and builds it for tvOS devices and simulators. It supports tvOS 13+,
-arm64 devices, and arm64/x86_64 simulators. See
+phase. Like iOS it downloads the prebuilt archive by default, with
+`ERIKA_FORCE_SOURCE_BUILD=1` falling back to building from source. It supports
+tvOS 13+, arm64 devices, and arm64/x86_64 simulators. See
 [`packages/erika_flutter/README.md`](../packages/erika_flutter/README.md) for
 nightly, prebuilt-bundle, and source-build options.
 
@@ -246,8 +249,9 @@ provides `codec`, `width`, `height`, `pixelFormat`, `profile`, `level`, `bitRate
 `sampleRate`, `channels`, and `sampleFormat`.
 
 - `bitRate` is in bit/s. Erika prefers the video track's own codec parameters; only when there is
-  one video track with no bitrate and the container total plus every other audio-track bitrate are
-  known does it estimate video bitrate as container bitrate minus audio bitrates. It is `null` when
+  exactly one video track with no declared bitrate and the container bitrate plus every other
+  media track's bitrate (audio, subtitle, other video) are known does it estimate video bitrate as
+  container bitrate minus those. It is `null` when
   unavailable, is not an instantaneous runtime bitrate, and an estimate can include container
   overhead or non-audio streams.
 - `frameRateNumerator` / `frameRateDenominator` retain the rational value, preventing values
@@ -294,7 +298,7 @@ so the host should poll `getUpscalerStatus` to drive its UI:
 |-----------------|---------|
 | `off` | No mode requested. |
 | `building` | Kernels compiling (first use of a mode); frames render unscaled until ready. |
-| `inactive` | Mode requested but not applied this frame — e.g. the video is not displayed above its source resolution, or the source is HDR (upscaler runs on SDR luma only). |
+| `inactive` | Mode requested but not applied — kernels not ready (and not compiling), or the backend recorded a fallback/failure. |
 | `scalar` | Running on the Metal scalar or wgpu compute backend. |
 | `simdgroupMatrix` | Running on the `simdgroup_matrix` backend (Apple Silicon default). |
 

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -63,15 +63,15 @@ surface 取为 `OHNativeWindow` 并 attach 给 presenter；wgpu 随后通过 Vul
 
 缺少所需 Vulkan 扩展的设备回退到 FFmpeg 软解 + CPU 上传。回退通过
 `VideoDecoderChanged` 事件和 presenter 诊断上报，而不是让播放失败。HarmonyOS
-路径已在真机验证，但尚未纳入 CI。
+路径已在真机验证；CI 构建 OpenHarmony C ABI，但无设备侧运行验证。
 
 ## iOS Build Path
 
-iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进 app，并为目标 iOS architecture 构建 Rust `erika_capi` crate。
+iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进 app。默认下载匹配的预构建归档；设 `ERIKA_FORCE_SOURCE_BUILD=1`（配合 `ERIKA_REPO_ROOT`）才会为目标 iOS architecture 从源码构建 Rust `erika_capi` crate。
 
 ## tvOS Build Path
 
-tvOS plugin 通过 CocoaPod script phase 为 Apple TV 真机和模拟器构建并链接 Erika C ABI static library；支持 tvOS 13+、arm64 真机，以及 arm64/x86_64 模拟器。详细的 Rust nightly、预构建包和源码构建选项见 [`packages/erika_flutter/README.zh.md`](../packages/erika_flutter/README.zh.md)。
+tvOS plugin 通过 CocoaPod script phase 链接 Erika C ABI static library；与 iOS 一样默认下载预构建归档，`ERIKA_FORCE_SOURCE_BUILD=1` 时才从源码构建。支持 tvOS 13+、arm64 真机，以及 arm64/x86_64 模拟器。详细的 Rust nightly、预构建包和源码构建选项见 [`packages/erika_flutter/README.zh.md`](../packages/erika_flutter/README.zh.md)。
 
 ## Minimal Presenter Flow
 
@@ -246,7 +246,7 @@ HUD 的驱动机制，数据新鲜度取决于已挂载 surface 的显示循环�
 |-----------------|------|
 | `off` | 没有请求任何模式。 |
 | `building` | kernel 正在编译（首次使用该模式）；在准备好之前视频会保持未放大。 |
-| `inactive` | 请求了模式，但这一帧没有生效，例如视频显示尺寸没有超过源分辨率，或源视频是 HDR（upscaler 只处理 SDR luma）。 |
+| `inactive` | 请求了模式但未生效——内核未就绪（且不在编译中），或后端记录了回退/失败。 |
 | `scalar` | 运行在 Metal scalar 或 wgpu compute backend 上。 |
 | `simdgroupMatrix` | 运行在 `simdgroup_matrix` backend 上（Apple Silicon 默认）。 |
 

--- a/docs/integration.ja.md
+++ b/docs/integration.ja.md
@@ -55,8 +55,8 @@ if (!p) { /* erika_last_error_message() を読む */ }
 
 `erika_presenter_create()` は既定値（SDR、アップスケーラ無し）。神経輝度アップスケーラは
 Apple platform では Metal、Android を含む compute-capable Vulkan/wgpu adapter では
-wgpu が実行します。GLES 3.0 や D3D11 のような compute 非対応 backend は native luma
-sampling を維持し、`Inactive` status と fallback reason を明示します。
+wgpu、Windows では D3D11 compute が実行します。compute 非対応 backend（主に GLES 3.0）は
+native luma sampling を維持し、`Inactive` status と fallback reason を明示します。
 
 ## 4. surface を attach する
 
@@ -218,7 +218,7 @@ sleep で 60 Hz を近似できます。
 - **出力:** `erika_presenter_get_output_status` で active mode と fallback counter を確認。
   Android native host は `erika_presenter_set_output_headroom` で dynamic display ratio を
   publish します。`capture_frame_rgba` は display output が extended-linear の場合も、映像 +
-  字幕 + 弾幕を SDR RGBA8 screenshot として返します。
+  字幕（弾幕は含みません）を SDR RGBA8 screenshot として返します。
 
 ## 9. 解放
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -42,8 +42,8 @@ create ──▶ attach surface ──▶ open ──▶ play ──▶ (render_
 `open` and `play` are asynchronous. The handle moves through
 `Opening → Ready → Playing`; observe transitions and failures via events rather
 than blocking. You can attach the surface
-before or after `open`, but attaching first lets the idle test pattern / first
-frame appear immediately.
+before or after `open`; attaching first means the first decoded frame appears
+on the next tick instead of waiting for a late attach.
 
 ## 3. Create the presenter
 
@@ -58,10 +58,10 @@ if (!p) { /* read erika_last_error_message() */ }
 ```
 
 `erika_presenter_create()` uses defaults (SDR, no upscaler). The neural luma
-upscaler is implemented by Metal on Apple platforms and by wgpu compute on
-capable Vulkan-class adapters, including Android. Backends without compute
-(notably GLES 3.0 and D3D11) retain native luma sampling and report an explicit
-`Inactive` status and fallback reason.
+upscaler is implemented by Metal on Apple platforms, D3D11 compute on Windows,
+and wgpu compute on capable Vulkan-class adapters, including Android. Backends
+without compute (notably GLES 3.0) retain native luma sampling and report an
+explicit `Inactive` status and fallback reason.
 
 ## 4. Attach a surface
 
@@ -234,7 +234,7 @@ All of these are safe to call live, between ticks:
 - **Output:** inspect the actual mode and fallback counters with
   `erika_presenter_get_output_status`; Android native hosts publish dynamic
   display ratios with `erika_presenter_set_output_headroom`. `capture_frame_rgba`
-  always produces an SDR RGBA8 screenshot of video + subtitle + danmaku, even
+  always produces an SDR RGBA8 screenshot of video + subtitle (danmaku excluded), even
   when the display output is extended-linear.
 
 ## 9. Teardown

--- a/docs/integration.zh.md
+++ b/docs/integration.zh.md
@@ -52,8 +52,8 @@ if (!p) { /* 读取 erika_last_error_message() */ }
 
 `erika_presenter_create()` 用默认值（SDR、无超分）。神经亮度超分在 Apple 平台由
 Metal 实现，在包括 Android 在内、具备 compute 能力的 Vulkan/wgpu adapter 上由
-wgpu 实现。GLES 3.0 和 D3D11 等无 compute 后端会保留原生 luma sampling，并明确
-报告 `Inactive` 状态和回退原因。
+wgpu 实现，Windows 上由 D3D11 compute 实现。无 compute 的后端（主要是 GLES 3.0）会保留原生
+luma sampling，并明确报告 `Inactive` 状态和回退原因。
 
 ## 4. Attach 一个 surface
 
@@ -208,7 +208,7 @@ while (erika_presenter_poll_event(p, &ev) == ErikaStatus_Ok) {
 - **超分:** `set_upscaler(mode)`;用 `get_upscaler_status` 检视。
 - **输出:** 用 `erika_presenter_get_output_status` 检视实际模式和 fallback counters。
   Android 原生宿主用 `erika_presenter_set_output_headroom` 发布动态显示 ratio。
-  `capture_frame_rgba` 始终输出视频 + 字幕 + 弹幕的 SDR RGBA8 截图，即使显示输出是
+  `capture_frame_rgba` 始终输出视频 + 字幕（不含弹幕）的 SDR RGBA8 截图，即使显示输出是
   extended-linear。
 
 ## 9. 释放

--- a/docs/releasing.ja.md
+++ b/docs/releasing.ja.md
@@ -41,11 +41,12 @@ HarmonyOS/OpenHarmony に対応します。package archive には plugin source�
 `LICENSE`、README、example、version 固定の native artifact manifest が含まれ、platform
 build は対応する GitHub Release archive を download して SHA-256 を検証します。
 
-公開前に clean worktree の package directory で検証します：
+公開前に clean worktree の package directory で検証・公開します：
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
+dart pub publish
 ```
 
 merge 前に [flutter-package.yml](../.github/workflows/flutter-package.yml) が isolated package

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -42,11 +42,11 @@ Every archive also includes `include/erika.h`, `LICENSE` (Erika, MPL-2.0),
 under `licenses/`, and a `MANIFEST.txt` recording the tag/commit.
 Every GitHub Release also includes `SHA256SUMS` with the digest of each archive.
 
-The native dependencies (FFmpeg, libass, FreeType, HarfBuzz, FriBidi, zlib, and
-Android's dav1d AV1 software decoder) are **statically linked** via the `lgpl`
+The native dependencies (FFmpeg, libass, FreeType, HarfBuzz, FriBidi, zlib,
+dav1d, and SoundTouch) are **statically linked** via the `lgpl`
 profile, so each library is self-contained except for OS frameworks
 (VideoToolbox/Metal/CoreAudio on Apple; Direct3D 11 / WASAPI on Windows;
-MediaCodec/Camera2/AAudio/ANativeWindow on Android), which are always present on
+MediaCodec/AAudio/ANativeWindow on Android), which are always present on
 the target OS. The Android shared library additionally depends on the bundled
 NDK `libc++_shared.so` for the same ABI.
 
@@ -63,11 +63,12 @@ contains the plugin sources, package `LICENSE`, README files, examples, and the
 version-pinned native artifact manifest; platform builds fetch the matching
 GitHub Release archives and verify their SHA-256 values.
 
-From a clean worktree, validate the package from its directory:
+From a clean worktree, validate and publish the package from its directory:
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
+dart pub publish
 ```
 
 The isolated package and platform consumer checks run from
@@ -216,7 +217,7 @@ beside your binary).
 
 Erika is MPL-2.0. The bundled native libraries keep their own licenses
 (`THIRD_PARTY_NOTICES.md`). Because Erika is open source with a reproducible
-build, the LGPL components (FFmpeg, FriBidi) satisfy the LGPL relinking
+build, the LGPL components (FFmpeg, FriBidi, SoundTouch) satisfy the LGPL relinking
 requirement: the `MANIFEST.txt` records the exact source commit, and anyone can
 rebuild against a modified FFmpeg via `xtask deps build --all` + `cargo build`
 (see [building.md](building.md)). Keep `LICENSE` and `THIRD_PARTY_NOTICES.md` in

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -38,11 +38,12 @@ Flutter Android 构建按实际请求的 ABI 下载对应
 和 HarmonyOS/OpenHarmony。package archive 包含插件源码、package `LICENSE`、README、
 example 和固定 native artifact manifest；平台构建会下载匹配的 GitHub Release 归档并校验 SHA-256。
 
-发布前先在干净工作树中从 package 目录验证：
+发布前先在干净工作树中从 package 目录验证，然后手动发布：
 
 ```sh
 cd packages/erika_flutter
 dart pub publish --dry-run
+dart pub publish
 ```
 
 合并前由 [flutter-package.yml](../.github/workflows/flutter-package.yml) 执行 isolated


### PR DESCRIPTION
重新落地 8/16 的文档对齐提交(d3f9544)。该提交当时被 push 到已合并的 codex/pub-dev-auto-publish 分支,main 从未收到;本次基于当前 main 重新应用并解决了 releasing 文档与 #104(独立 pub 发布 tag 流程)的冲突:

- capi_reference: capture 不含弹幕、JSON error envelope status 为 3、补充缺失枚举(VideoDecoderChanged / AudioOutputChanged / OhosNativeWindow / Auto)、内存字体家族、audio_only_tick、resource status
- architecture: dav1d 是非 Windows 的 AV1 回退(不限 Android)、导出函数 88 个、平台最低版本(macOS 11+ / iOS 13+)、SoundTouch 变速
- building / flutter_embedding / integration / danmaku_architecture: 与 0.1.7 实现逐项核对(dav1d 构建、预编译 bundle 默认、idle test pattern 默认关闭、D3D11 有 compute ArtCNN、capture 不含弹幕、窗口化 danmaku plan 等)
- erika.h: capture 注释改为 video + subtitle, no danmaku
- releasing: 保留 main 上的自动化 pub 发布流程,补回手动 `dart pub publish` 回退说明

所有改动均经源码核对,与发布在 pub.dev 的 erika_flutter 0.1.7 一致。