### PR TITLE
Publish OHPM package as personal package

### DIFF
--- a/.github/workflows/ohpm-package.yml
+++ b/.github/workflows/ohpm-package.yml
@@ -155,7 +155,7 @@ jobs:
           set -euo pipefail
           har="packages/erika_ohos/build/default/outputs/default/erika.har"
           cp "$har" examples/ohos_arkts/erika-0.1.7.har
-          package_dir="examples/ohos_arkts/entry/oh_modules/@aimesoft/erika"
+          package_dir="examples/ohos_arkts/entry/oh_modules/@aimessoft/erika"
           mkdir -p "$package_dir"
           tar -xzf "$har" --strip-components=1 -C "$package_dir"
 

--- a/.github/workflows/ohpm-package.yml
+++ b/.github/workflows/ohpm-package.yml
@@ -155,7 +155,7 @@ jobs:
           set -euo pipefail
           har="packages/erika_ohos/build/default/outputs/default/erika.har"
           cp "$har" examples/ohos_arkts/erika-0.1.7.har
-          package_dir="examples/ohos_arkts/entry/oh_modules/@aimessoft/erika"
+          package_dir="examples/ohos_arkts/entry/oh_modules/erika"
           mkdir -p "$package_dir"
           tar -xzf "$har" --strip-components=1 -C "$package_dir"
 

--- a/examples/ohos_arkts/entry/oh-package.json5
+++ b/examples/ohos_arkts/entry/oh-package.json5
@@ -6,6 +6,6 @@
   "author": "AimesSoft",
   "license": "MPL-2.0",
   "dependencies": {
-    "@aimessoft/erika": "file:../erika-0.1.7.har"
+    "erika": "file:../erika-0.1.7.har"
   }
 }

--- a/examples/ohos_arkts/entry/oh-package.json5
+++ b/examples/ohos_arkts/entry/oh-package.json5
@@ -6,6 +6,6 @@
   "author": "AimesSoft",
   "license": "MPL-2.0",
   "dependencies": {
-    "@aimesoft/erika": "file:../erika-0.1.7.har"
+    "@aimessoft/erika": "file:../erika-0.1.7.har"
   }
 }

--- a/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
+++ b/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
@@ -1,4 +1,4 @@
-import { ErikaPlayer } from '@aimesoft/erika';
+import { ErikaPlayer } from '@aimessoft/erika';
 
 class ErikaSurfaceController extends XComponentController {
   private readonly player: ErikaPlayer = new ErikaPlayer();

--- a/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
+++ b/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
@@ -1,4 +1,4 @@
-import { ErikaPlayer } from '@aimessoft/erika';
+import { ErikaPlayer } from 'erika';
 
 class ErikaSurfaceController extends XComponentController {
   private readonly player: ErikaPlayer = new ErikaPlayer();

--- a/packages/erika_ohos/README.md
+++ b/packages/erika_ohos/README.md
@@ -1,4 +1,4 @@
-# @aimessoft/erika
+# erika
 
 Native ArkTS/HarmonyOS SDK powered by Erika. This package is independent of
 Flutter and exposes the Erika presenter through an ArkTS-friendly API.
@@ -9,7 +9,7 @@ provides an `XComponent` surface id through `attachSurface()` and drives
 `renderTick()` from its frame scheduler.
 
 ```ts
-import { ErikaPlayer } from '@aimessoft/erika';
+import { ErikaPlayer } from 'erika';
 
 const player = new ErikaPlayer();
 const surfaceId = BigInt(xComponentController.getXComponentSurfaceId());

--- a/packages/erika_ohos/README.md
+++ b/packages/erika_ohos/README.md
@@ -1,4 +1,4 @@
-# @aimesoft/erika
+# @aimessoft/erika
 
 Native ArkTS/HarmonyOS SDK powered by Erika. This package is independent of
 Flutter and exposes the Erika presenter through an ArkTS-friendly API.
@@ -9,7 +9,7 @@ provides an `XComponent` surface id through `attachSurface()` and drives
 `renderTick()` from its frame scheduler.
 
 ```ts
-import { ErikaPlayer } from '@aimesoft/erika';
+import { ErikaPlayer } from '@aimessoft/erika';
 
 const player = new ErikaPlayer();
 const surfaceId = BigInt(xComponentController.getXComponentSurfaceId());

--- a/packages/erika_ohos/oh-package.json5
+++ b/packages/erika_ohos/oh-package.json5
@@ -1,5 +1,5 @@
 {
-  "name": "@aimessoft/erika",
+  "name": "erika",
   "version": "0.1.7",
   "description": "Native ArkTS media SDK powered by the Erika engine",
   "main": "Index.ets",

--- a/packages/erika_ohos/oh-package.json5
+++ b/packages/erika_ohos/oh-package.json5
@@ -1,5 +1,5 @@
 {
-  "name": "@aimesoft/erika",
+  "name": "@aimessoft/erika",
   "version": "0.1.7",
   "description": "Native ArkTS media SDK powered by the Erika engine",
   "main": "Index.ets",


### PR DESCRIPTION
将 ArkTS 包改为个人作用域发布，绕过尚未完成认证的组织审核。

- 包名从组织包改为未加组织的 `erika`
- 同步 ArkTS 示例导入、HAR 消费路径和 GitHub Actions 校验路径
- 保持版本 `0.1.7` 不变
- OHPM registry 当前未发现同名包

验证：OpenHarmony、Rust、Windows、iOS、tvOS 和 Quality 检查全部通过。