### PR TITLE
Fix OHPM package repository metadata

### DIFF
--- a/packages/erika_ohos/oh-package.json5
+++ b/packages/erika_ohos/oh-package.json5
@@ -7,6 +7,7 @@
     "name": "Shinokawa",
     "url": "https://github.com/Shinokawa"
   },
+  "repository": "https://github.com/AimesSoft/Erika",
   "license": "MPL-2.0",
   "keywords": [
     "media",


### PR DESCRIPTION
## 变更

- 为 OHPM 包补充 Erika 仓库 URL
- 保持个人发布者为 `Shinokawa`，不填写邮箱

## 原因

OHPM 拒绝 `erika@0.1.7`，回执为仓库 URL 无效。

## 验证

- `oh-package.json5` JSON 语法检查通过
- `git diff --check` 通过