### PR TITLE
Add Swift SDK binary packaging

### DIFF
--- a/.github/workflows/swift-sdk-binary.yml
+++ b/.github/workflows/swift-sdk-binary.yml
@@ -1,0 +1,99 @@
+name: Swift SDK Binary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/swift-sdk-binary.yml"
+      - "packaging/build_swift_xcframework.sh"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing Erika native release version
+        required: true
+        default: "0.1.7"
+        type: string
+      upload:
+        description: Attach the Swift XCFramework to the existing release
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Assemble Apple XCFramework
+    runs-on: macos-26
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ inputs.version || '0.1.7' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download existing Apple release archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p downloads output
+          gh release download "v${VERSION}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir downloads \
+            --pattern SHA256SUMS \
+            --pattern erika-capi-macos-universal.zip \
+            --pattern erika-capi-ios.zip \
+            --pattern erika-capi-tvos.zip
+
+      - name: Verify release archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd downloads
+          for archive in \
+            erika-capi-macos-universal.zip \
+            erika-capi-ios.zip \
+            erika-capi-tvos.zip
+          do
+            expected="$(awk -v file="$archive" '$2 == file { print $1 }' SHA256SUMS)"
+            test -n "$expected"
+            printf '%s  %s\n' "$expected" "$archive" | shasum -a 256 --check
+          done
+
+      - name: Assemble SwiftPM binary target
+        id: binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="output/erika-swift-core-${VERSION}.xcframework.zip"
+          bash packaging/build_swift_xcframework.sh downloads "$archive"
+          checksum="$(swift package compute-checksum "$archive")"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Erika Swift core ${VERSION}"
+            echo
+            echo "SwiftPM checksum: \`$checksum\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: erika-swift-core-${{ env.VERSION }}
+          path: ${{ steps.binary.outputs.archive }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Attach binary target to the native release
+        if: github.event_name == 'workflow_dispatch' && inputs.upload
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="${{ steps.binary.outputs.archive }}"
+          name="$(basename "$archive")"
+          existing="$(gh release view "v${VERSION}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets \
+            --jq ".assets[] | select(.name == \"$name\") | .name")"
+          test -z "$existing"
+          gh release upload "v${VERSION}" "$archive" --repo "$GITHUB_REPOSITORY"

--- a/packaging/build_swift_xcframework.sh
+++ b/packaging/build_swift_xcframework.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: build_swift_xcframework.sh <release-download-dir> <output-zip>" >&2
+  exit 2
+fi
+
+SOURCE_DIR="$(cd "$1" && pwd)"
+OUTPUT_DIR="$(cd "$(dirname "$2")" && pwd)"
+OUTPUT_ZIP="$OUTPUT_DIR/$(basename "$2")"
+WORK_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/erika-swift.XXXXXX")"
+
+for archive in \
+  erika-capi-macos-universal.zip \
+  erika-capi-ios.zip \
+  erika-capi-tvos.zip
+do
+  test -s "$SOURCE_DIR/$archive"
+  platform="${archive#erika-capi-}"
+  platform="${platform%.zip}"
+  mkdir -p "$WORK_DIR/$platform"
+  unzip -q "$SOURCE_DIR/$archive" -d "$WORK_DIR/$platform"
+done
+
+MACOS_LIBRARY="$(find "$WORK_DIR/macos-universal" -type f -name 'liberika_capi.a' -print -quit)"
+IOS_FRAMEWORK="$(find "$WORK_DIR/ios" -type d -name 'erika_capi.xcframework' -print -quit)"
+TVOS_FRAMEWORK="$(find "$WORK_DIR/tvos" -type d -name 'erika_capi.xcframework' -print -quit)"
+IOS_DEVICE="$(find "$IOS_FRAMEWORK" -type f -name '*.a' -path '*ios-arm64/*' -print -quit)"
+IOS_SIMULATOR="$(find "$IOS_FRAMEWORK" -type f -name '*.a' -path '*ios-*simulator/*' -print -quit)"
+TVOS_DEVICE="$(find "$TVOS_FRAMEWORK" -type f -name '*.a' -path '*tvos-arm64/*' -print -quit)"
+TVOS_SIMULATOR="$(find "$TVOS_FRAMEWORK" -type f -name '*.a' -path '*tvos-*simulator/*' -print -quit)"
+HEADER="$(find "$WORK_DIR/macos-universal" -type f -path '*/include/erika.h' -print -quit)"
+
+for path in \
+  "$MACOS_LIBRARY" \
+  "$IOS_DEVICE" \
+  "$IOS_SIMULATOR" \
+  "$TVOS_DEVICE" \
+  "$TVOS_SIMULATOR" \
+  "$HEADER"
+do
+  test -n "$path"
+  test -s "$path"
+done
+
+HEADERS="$WORK_DIR/headers"
+mkdir -p "$HEADERS"
+cp "$HEADER" "$HEADERS/erika.h"
+cat > "$HEADERS/module.modulemap" <<'MODULEMAP'
+module CErika [system] {
+  header "erika.h"
+  export *
+}
+MODULEMAP
+
+XCFRAMEWORK="$WORK_DIR/CErika.xcframework"
+xcodebuild -create-xcframework \
+  -library "$MACOS_LIBRARY" -headers "$HEADERS" \
+  -library "$IOS_DEVICE" -headers "$HEADERS" \
+  -library "$IOS_SIMULATOR" -headers "$HEADERS" \
+  -library "$TVOS_DEVICE" -headers "$HEADERS" \
+  -library "$TVOS_SIMULATOR" -headers "$HEADERS" \
+  -output "$XCFRAMEWORK"
+
+test ! -e "$OUTPUT_ZIP"
+ditto -c -k --sequesterRsrc --keepParent "$XCFRAMEWORK" "$OUTPUT_ZIP"
+unzip -tq "$OUTPUT_ZIP"
+
+echo "SwiftPM checksum: $(swift package compute-checksum "$OUTPUT_ZIP")"
+ls -lh "$OUTPUT_ZIP"


### PR DESCRIPTION
## 变更

- 复用 `v0.1.7` 已发布的 macOS、iOS、tvOS 原生包
- 合成 SwiftPM 可消费的统一 `CErika.xcframework`
- 自动校验原始 SHA-256 并输出 SwiftPM checksum
- 可将增量资产挂到现有 `v0.1.7` Release

## 影响

不重编 Erika 核心，不修改其他平台版本或现有发布资产。