### PR TITLE
fix(ios): defer foreground resume and recover interruptions

### DIFF
--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -293,6 +293,7 @@ pub struct PresenterRuntime {
     playback_rate: f64,
     pending_playback_rate: Option<PendingPlaybackRate>,
     audio_only_tick_active: bool,
+    resume_pending: bool,
     latest_video_decoder: Option<VideoDecoderEvent>,
     current_overlay: Option<OverlayFrame>,
     debug_hud: DebugHud,
@@ -689,6 +690,7 @@ impl PresenterRuntime {
             playback_rate: 1.0,
             pending_playback_rate: None,
             audio_only_tick_active: false,
+            resume_pending: false,
             latest_video_decoder: None,
             current_overlay: None,
             debug_hud: DebugHud::new(),
@@ -815,6 +817,7 @@ impl PresenterRuntime {
 
     pub fn open(&mut self, media: MediaRequest) -> Result<()> {
         self.quiesce_frame_output("open")?;
+        self.reset_video_decode_resume_state();
         self.reset_audio_output_with_committed_rate();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
         self.drain_pending_player_frames();
@@ -835,6 +838,7 @@ impl PresenterRuntime {
 
     pub fn play(&mut self) -> Result<()> {
         if self.player.is_stopped_at_end() {
+            self.reset_video_decode_resume_state();
             self.reset_audio_output_with_committed_rate();
             self.drain_pending_player_frames();
             self.bump_danmaku_generation();
@@ -879,6 +883,7 @@ impl PresenterRuntime {
     pub fn stop(&mut self) -> Result<()> {
         let quiesced = self.quiesce_frame_output("stop")?;
         let result = self.player.stop();
+        self.reset_video_decode_resume_state();
         self.reset_audio_output_with_committed_rate();
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
@@ -888,6 +893,7 @@ impl PresenterRuntime {
 
     pub fn close(&mut self) -> Result<()> {
         self.quiesce_frame_output("close")?;
+        self.reset_video_decode_resume_state();
         self.reset_audio_output_with_committed_rate();
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
@@ -1342,9 +1348,25 @@ impl PresenterRuntime {
 
     pub fn render_tick(&mut self, time_seconds: f64) -> Result<PresenterStats> {
         if self.audio_only_tick_active {
-            self.discard_pending_video_frames();
-            self.player.set_video_decode_suspended(false)?;
-            self.audio_only_tick_active = false;
+            if self.resume_pending {
+                self.try_resume_video_decode();
+            } else {
+                // Returning to the foreground can race the layer's first
+                // drawable. Arm the resume on this tick and let a later tick
+                // perform the decoder seek/flush after the surface is ready.
+                self.discard_pending_video_frames();
+                self.resume_pending = true;
+                trace::diagnostic(
+                    serde_json::json!({
+                        "event": "player_video_decode",
+                        "stage": "resume_pending",
+                        "reason": "foreground_render_tick",
+                    })
+                    .to_string(),
+                );
+            }
+        } else {
+            self.resume_pending = false;
         }
         let tick_started = Instant::now();
         self.commit_pending_playback_rate()?;
@@ -1445,6 +1467,13 @@ impl PresenterRuntime {
                 self.current_surface_metrics
                     .map_or(0, |metrics| metrics.physical_extent.height),
             );
+        if self.resume_pending && !self.surface_is_ready() {
+            self.last_render_duration = Duration::ZERO;
+            self.last_render_current_duration = Duration::ZERO;
+            self.last_render_test_duration = Duration::ZERO;
+            self.last_tick_duration = tick_started.elapsed();
+            return Ok(self.stats);
+        }
         let render_started = Instant::now();
         let render_result = self.renderer.render_current_frame(context);
         self.last_render_current_duration = render_started.elapsed();
@@ -1521,6 +1550,10 @@ impl PresenterRuntime {
     pub fn audio_only_tick(&mut self) -> Result<PresenterStats> {
         let tick_started = Instant::now();
         self.commit_pending_playback_rate()?;
+        // A background tick starts a new foreground-resume window. If a
+        // previous foreground attempt failed, do not carry its pending flag
+        // into the next foreground frame.
+        self.resume_pending = false;
         if !self.audio_only_tick_active {
             self.player.set_video_decode_suspended(true)?;
             self.discard_pending_video_frames();
@@ -1548,6 +1581,57 @@ impl PresenterRuntime {
 
     fn discard_pending_video_frames(&self) {
         while self.video_frames.try_recv().is_ok() {}
+    }
+
+    fn reset_video_decode_resume_state(&mut self) {
+        self.audio_only_tick_active = false;
+        self.resume_pending = false;
+    }
+
+    fn surface_is_ready(&self) -> bool {
+        let Some(metrics) = self.current_surface_metrics else {
+            return false;
+        };
+        let renderer = self.renderer.runtime_stats();
+        metrics.physical_extent.width > 0
+            && metrics.physical_extent.height > 0
+            && renderer.attached
+            && renderer.surface_width > 0
+            && renderer.surface_height > 0
+    }
+
+    fn try_resume_video_decode(&mut self) {
+        if !self.surface_is_ready() {
+            return;
+        }
+
+        self.discard_pending_video_frames();
+        match self.player.set_video_decode_suspended(false) {
+            Ok(_) => {
+                self.audio_only_tick_active = false;
+                self.resume_pending = false;
+                trace::diagnostic(
+                    serde_json::json!({
+                        "event": "player_video_decode",
+                        "stage": "resumed_at_keyframe",
+                    })
+                    .to_string(),
+                );
+            }
+            Err(error) => {
+                // A worker timeout or transient lifecycle race must not turn
+                // the render loop into a terminal C ABI error. Keep both
+                // flags set so the next display tick retries the transition.
+                trace::diagnostic(
+                    serde_json::json!({
+                        "event": "player_video_decode",
+                        "stage": "resume_retry_pending",
+                        "reason": error.to_string(),
+                    })
+                    .to_string(),
+                );
+            }
+        }
     }
 
     fn debug_hud_snapshot(&self) -> DebugHudSnapshot {
@@ -4656,6 +4740,25 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             presenter.runtime_snapshot().last_render_test_duration,
             Duration::ZERO
         );
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn foreground_tick_keeps_video_resume_pending_until_surface_is_ready() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+        presenter.audio_only_tick_active = true;
+
+        presenter.render_tick(0.0).unwrap();
+        assert!(presenter.audio_only_tick_active);
+        assert!(presenter.resume_pending);
+
+        presenter.render_tick(0.016).unwrap();
+        assert!(presenter.audio_only_tick_active);
+        assert!(presenter.resume_pending);
+
+        presenter.audio_only_tick().unwrap();
+        assert!(presenter.audio_only_tick_active);
+        assert!(!presenter.resume_pending);
     }
 
     #[test]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -77,6 +77,10 @@ const AUDIO_FAST_RATE_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
 const PLAYBACK_RATE_EPSILON: f64 = 0.001;
 const VIDEO_PUMP_FRAME_LIMIT: usize = 8;
 const VIDEO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+// A foreground resume that keeps failing must not retry once per display
+// frame: every attempt crosses the playback worker channel and can block the
+// render queue on the frame-output barrier timeout.
+const MAX_VIDEO_DECODE_RESUME_ATTEMPTS: u32 = 5;
 const DANMAKU_PLAN_REQUEST_QUANTUM: Duration = Duration::from_millis(250);
 const DANMAKU_PREPARE_REFRESH_MARGIN: Duration = Duration::from_secs(4);
 const DANMAKU_PLAN_LOOKAHEAD: Duration = Duration::from_secs(8);
@@ -294,6 +298,7 @@ pub struct PresenterRuntime {
     pending_playback_rate: Option<PendingPlaybackRate>,
     audio_only_tick_active: bool,
     resume_pending: bool,
+    video_decode_resume_attempts: u32,
     latest_video_decoder: Option<VideoDecoderEvent>,
     current_overlay: Option<OverlayFrame>,
     debug_hud: DebugHud,
@@ -691,6 +696,7 @@ impl PresenterRuntime {
             pending_playback_rate: None,
             audio_only_tick_active: false,
             resume_pending: false,
+            video_decode_resume_attempts: 0,
             latest_video_decoder: None,
             current_overlay: None,
             debug_hud: DebugHud::new(),
@@ -1350,7 +1356,7 @@ impl PresenterRuntime {
         if self.audio_only_tick_active {
             if self.resume_pending {
                 self.try_resume_video_decode();
-            } else {
+            } else if self.video_decode_resume_attempts < MAX_VIDEO_DECODE_RESUME_ATTEMPTS {
                 // Returning to the foreground can race the layer's first
                 // drawable. Arm the resume on this tick and let a later tick
                 // perform the decoder seek/flush after the surface is ready.
@@ -1365,8 +1371,12 @@ impl PresenterRuntime {
                     .to_string(),
                 );
             }
+            // Once the attempt budget is spent the resume stays disarmed until
+            // the next background tick opens a new foreground window, so a
+            // wedged worker cannot be re-probed on every display frame.
         } else {
             self.resume_pending = false;
+            self.video_decode_resume_attempts = 0;
         }
         let tick_started = Instant::now();
         self.commit_pending_playback_rate()?;
@@ -1551,9 +1561,10 @@ impl PresenterRuntime {
         let tick_started = Instant::now();
         self.commit_pending_playback_rate()?;
         // A background tick starts a new foreground-resume window. If a
-        // previous foreground attempt failed, do not carry its pending flag
-        // into the next foreground frame.
+        // previous foreground attempt failed, do not carry its pending flag or
+        // its spent attempt budget into the next foreground frame.
         self.resume_pending = false;
+        self.video_decode_resume_attempts = 0;
         if !self.audio_only_tick_active {
             self.player.set_video_decode_suspended(true)?;
             self.discard_pending_video_frames();
@@ -1586,6 +1597,7 @@ impl PresenterRuntime {
     fn reset_video_decode_resume_state(&mut self) {
         self.audio_only_tick_active = false;
         self.resume_pending = false;
+        self.video_decode_resume_attempts = 0;
     }
 
     fn surface_is_ready(&self) -> bool {
@@ -1610,6 +1622,7 @@ impl PresenterRuntime {
             Ok(_) => {
                 self.audio_only_tick_active = false;
                 self.resume_pending = false;
+                self.video_decode_resume_attempts = 0;
                 trace::diagnostic(
                     serde_json::json!({
                         "event": "player_video_decode",
@@ -1618,20 +1631,43 @@ impl PresenterRuntime {
                     .to_string(),
                 );
             }
-            Err(error) => {
-                // A worker timeout or transient lifecycle race must not turn
-                // the render loop into a terminal C ABI error. Keep both
-                // flags set so the next display tick retries the transition.
-                trace::diagnostic(
-                    serde_json::json!({
-                        "event": "player_video_decode",
-                        "stage": "resume_retry_pending",
-                        "reason": error.to_string(),
-                    })
-                    .to_string(),
-                );
-            }
+            Err(error) => self.note_video_decode_resume_failure(&error.to_string()),
         }
+    }
+
+    /// Accounts for one failed foreground resume and decides whether the next
+    /// display tick may try again.
+    ///
+    /// A worker timeout or transient lifecycle race must not turn the render
+    /// loop into a terminal C ABI error, so the attempt is retried instead of
+    /// propagated. The budget bounds that retry: a disconnected or hung
+    /// playback worker never recovers, and probing it on every display frame
+    /// would send one IPC command and one seek/flush per frame while each
+    /// attempt can stall the render queue for the frame-output barrier
+    /// timeout.
+    fn note_video_decode_resume_failure(&mut self, reason: &str) {
+        self.video_decode_resume_attempts = self.video_decode_resume_attempts.saturating_add(1);
+        let exhausted = self.video_decode_resume_attempts >= MAX_VIDEO_DECODE_RESUME_ATTEMPTS;
+        if exhausted {
+            // Leave the decoder suspended and keep rendering the last frame
+            // with audio; a later background/foreground cycle reopens the
+            // window with a fresh budget.
+            self.resume_pending = false;
+        }
+        trace::diagnostic(
+            serde_json::json!({
+                "event": "player_video_decode",
+                "stage": if exhausted {
+                    "resume_abandoned"
+                } else {
+                    "resume_retry_pending"
+                },
+                "reason": reason,
+                "attempt": self.video_decode_resume_attempts,
+                "maxAttempts": MAX_VIDEO_DECODE_RESUME_ATTEMPTS,
+            })
+            .to_string(),
+        );
     }
 
     fn debug_hud_snapshot(&self) -> DebugHudSnapshot {
@@ -4759,6 +4795,43 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         presenter.audio_only_tick().unwrap();
         assert!(presenter.audio_only_tick_active);
         assert!(!presenter.resume_pending);
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn foreground_video_resume_stops_retrying_after_the_attempt_budget() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+        presenter.audio_only_tick_active = true;
+        presenter.resume_pending = true;
+
+        for attempt in 1..MAX_VIDEO_DECODE_RESUME_ATTEMPTS {
+            presenter.note_video_decode_resume_failure("playback worker is not running");
+            assert_eq!(presenter.video_decode_resume_attempts, attempt);
+            assert!(presenter.resume_pending);
+        }
+
+        presenter.note_video_decode_resume_failure("playback worker is not running");
+        assert_eq!(
+            presenter.video_decode_resume_attempts,
+            MAX_VIDEO_DECODE_RESUME_ATTEMPTS
+        );
+        assert!(!presenter.resume_pending);
+
+        // A spent budget must not be re-armed by the next display frame, or the
+        // wedged worker would be probed once per tick again.
+        presenter.render_tick(0.016).unwrap();
+        assert!(presenter.audio_only_tick_active);
+        assert!(!presenter.resume_pending);
+        assert_eq!(
+            presenter.video_decode_resume_attempts,
+            MAX_VIDEO_DECODE_RESUME_ATTEMPTS
+        );
+
+        // A new background/foreground cycle opens a fresh window.
+        presenter.audio_only_tick().unwrap();
+        assert_eq!(presenter.video_decode_resume_attempts, 0);
+        presenter.render_tick(0.032).unwrap();
+        assert!(presenter.resume_pending);
     }
 
     #[test]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -844,7 +844,7 @@ impl PresenterRuntime {
 
     pub fn play(&mut self) -> Result<()> {
         if self.player.is_stopped_at_end() {
-            self.reset_video_decode_resume_state();
+            self.cancel_pending_video_decode_resume();
             self.reset_audio_output_with_committed_rate();
             self.drain_pending_player_frames();
             self.bump_danmaku_generation();
@@ -889,7 +889,7 @@ impl PresenterRuntime {
     pub fn stop(&mut self) -> Result<()> {
         let quiesced = self.quiesce_frame_output("stop")?;
         let result = self.player.stop();
-        self.reset_video_decode_resume_state();
+        self.cancel_pending_video_decode_resume();
         self.reset_audio_output_with_committed_rate();
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
@@ -1594,8 +1594,29 @@ impl PresenterRuntime {
         while self.video_frames.try_recv().is_ok() {}
     }
 
+    /// Clears the resume bookkeeping across a boundary that replaces or
+    /// retires the playback engine.
+    ///
+    /// `open` builds a fresh engine and `close` retires the worker, and a new
+    /// engine starts with video decode running, so the presenter owes it no
+    /// resume.
     fn reset_video_decode_resume_state(&mut self) {
         self.audio_only_tick_active = false;
+        self.resume_pending = false;
+        self.video_decode_resume_attempts = 0;
+    }
+
+    /// Drops an in-flight resume attempt without forgetting that the worker
+    /// still has video decode suspended.
+    ///
+    /// `stop` and a stopped-at-end replay reuse the current engine, and
+    /// neither clears its `video_decode_suspended` flag. Clearing
+    /// `audio_only_tick_active` here would desynchronize the presenter from
+    /// the worker: no later foreground tick would owe a resume, so playback
+    /// would stay audio-only with a frozen frame until the app is backgrounded
+    /// again. Resetting the budget lets the next foreground window retry from
+    /// scratch.
+    fn cancel_pending_video_decode_resume(&mut self) {
         self.resume_pending = false;
         self.video_decode_resume_attempts = 0;
     }
@@ -4832,6 +4853,54 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         assert_eq!(presenter.video_decode_resume_attempts, 0);
         presenter.render_tick(0.032).unwrap();
         assert!(presenter.resume_pending);
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn stop_keeps_the_video_decode_resume_owed_to_the_reused_worker() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+        presenter.audio_only_tick_active = true;
+        presenter.resume_pending = true;
+        presenter.video_decode_resume_attempts = MAX_VIDEO_DECODE_RESUME_ATTEMPTS;
+
+        // `stop` reuses the current engine and never clears its
+        // `video_decode_suspended` flag, so the presenter must keep owing it a
+        // resume; only the in-flight attempt and its budget are dropped.
+        let _ = presenter.stop();
+        assert!(presenter.audio_only_tick_active);
+        assert!(!presenter.resume_pending);
+        assert_eq!(presenter.video_decode_resume_attempts, 0);
+
+        // Returning to the foreground still arms the resume, so playback does
+        // not stay audio-only with a frozen frame.
+        presenter.render_tick(0.0).unwrap();
+        assert!(presenter.resume_pending);
+    }
+
+    #[test]
+    #[cfg(feature = "wgpu")]
+    fn only_engine_replacing_boundaries_forget_the_video_decode_resume() {
+        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
+
+        // `open` builds a fresh engine and `close` retires the worker, and a
+        // new engine decodes video, so the presenter owes it no resume.
+        presenter.audio_only_tick_active = true;
+        presenter.resume_pending = true;
+        presenter.video_decode_resume_attempts = 2;
+        presenter.reset_video_decode_resume_state();
+        assert!(!presenter.audio_only_tick_active);
+        assert!(!presenter.resume_pending);
+        assert_eq!(presenter.video_decode_resume_attempts, 0);
+
+        // `stop` and a stopped-at-end replay reuse the engine, which keeps its
+        // `video_decode_suspended` flag set, so the obligation must survive.
+        presenter.audio_only_tick_active = true;
+        presenter.resume_pending = true;
+        presenter.video_decode_resume_attempts = 2;
+        presenter.cancel_pending_video_decode_resume();
+        assert!(presenter.audio_only_tick_active);
+        assert!(!presenter.resume_pending);
+        assert_eq!(presenter.video_decode_resume_attempts, 0);
     }
 
     #[test]

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -432,7 +432,10 @@ impl MetalRendererImpl {
             let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
                 layer.nextDrawable()
             else {
-                return Err(PlayerError::Renderer(
+                // A drained drawable pool is temporary backpressure, not a
+                // renderer fault: every acquisition path reports it the same
+                // way so callers can skip the frame instead of failing.
+                return Err(PlayerError::RendererBackpressure(
                     "CAMetalLayer nextDrawable returned nil".to_string(),
                 ));
             };
@@ -517,7 +520,10 @@ impl MetalRendererImpl {
             let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
                 layer.nextDrawable()
             else {
-                return Err(PlayerError::Renderer(
+                // A drained drawable pool is temporary backpressure, not a
+                // renderer fault: every acquisition path reports it the same
+                // way so callers can skip the frame instead of failing.
+                return Err(PlayerError::RendererBackpressure(
                     "CAMetalLayer nextDrawable returned nil".to_string(),
                 ));
             };

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -703,7 +703,7 @@ impl MetalRendererImpl {
             let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
                 layer.nextDrawable()
             else {
-                return Err(PlayerError::Renderer(
+                return Err(PlayerError::RendererBackpressure(
                     "CAMetalLayer nextDrawable returned nil".to_string(),
                 ));
             };

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -803,6 +803,18 @@ impl RendererBackend for MetalRenderer {
             danmaku.map(DanmakuRenderFrame::new),
         );
         self.current_frame = Some(frame);
+        let rendered = match result {
+            Ok(()) => Ok(true),
+            Err(PlayerError::RendererBackpressure(reason)) => {
+                if trace::enabled() {
+                    trace::log(format!(
+                        "[erika-render-trace] stage=render_current_frame skipped reason={reason}"
+                    ));
+                }
+                Ok(false)
+            }
+            Err(error) => Err(error),
+        };
         if trace::enabled() {
             trace::log(format!(
                 "[erika-render-trace] stage=render_current_frame gen={} media={} output={}x{} danmaku={} elapsed_ms={:.3} result={}",
@@ -812,10 +824,10 @@ impl RendererBackend for MetalRenderer {
                 context.output_height,
                 danmaku.as_ref().map_or(0, |plan| plan.items.len()),
                 started.elapsed().as_secs_f64() * 1000.0,
-                result.is_ok(),
+                rendered.as_ref().is_ok_and(|rendered| *rendered),
             ));
         }
-        result.map(|()| true)
+        rendered
     }
 
     fn capture_current_frame(

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -647,6 +647,27 @@ fn inspect_overlay_frame(frame: &OverlayFrame) -> Result<PreparedOverlayFrameInf
     })
 }
 
+/// Turns a drained-drawable-pool failure into a skipped frame.
+///
+/// Every `CAMetalLayer.nextDrawable()` path reports a nil drawable as
+/// [`PlayerError::RendererBackpressure`]. Clear and test-pattern frames carry
+/// no decoded content, so dropping one is always cheaper than pushing a
+/// transient lifecycle race across the C ABI as a terminal renderer error.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+fn skip_on_backpressure(stage: &str, result: Result<()>) -> Result<()> {
+    match result {
+        Err(PlayerError::RendererBackpressure(reason)) => {
+            if trace::enabled() {
+                trace::log(format!(
+                    "[erika-render-trace] stage={stage} skipped reason={reason}"
+                ));
+            }
+            Ok(())
+        }
+        other => other,
+    }
+}
+
 pub fn fourcc_string(value: u32) -> String {
     let bytes = value.to_be_bytes();
     if bytes
@@ -702,7 +723,10 @@ impl RendererBackend for MetalRenderer {
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         {
             if self.inner.has_surface() {
-                self.inner.render_clear(ClearColor::black())?;
+                skip_on_backpressure(
+                    "clear_current_frame",
+                    self.inner.render_clear(ClearColor::black()),
+                )?;
             }
         }
         Ok(())
@@ -716,17 +740,20 @@ impl RendererBackend for MetalRenderer {
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         {
             let started = std::time::Instant::now();
-            self.inner.render_clear(ClearColor::animated(time_seconds))
-                .map(|result| {
-                    if trace::enabled() {
-                        trace::log(format!(
-                            "[erika-render-trace] stage=test_frame time_seconds={:.3} elapsed_ms={:.3}",
-                            time_seconds,
-                            started.elapsed().as_secs_f64() * 1000.0,
-                        ));
-                    }
-                    result
-                })
+            skip_on_backpressure(
+                "test_frame",
+                self.inner.render_clear(ClearColor::animated(time_seconds)),
+            )
+            .map(|result| {
+                if trace::enabled() {
+                    trace::log(format!(
+                        "[erika-render-trace] stage=test_frame time_seconds={:.3} elapsed_ms={:.3}",
+                        time_seconds,
+                        started.elapsed().as_secs_f64() * 1000.0,
+                    ));
+                }
+                result
+            })
         }
         #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
         {

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -1986,11 +1986,13 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   private var pollTimer: Timer?
   private var activePlayerId: Int64?
   private var interruptedPlayerId: Int64?
+  private var interruptionResumeWorkItem: DispatchWorkItem?
   private var notificationObservers: [NSObjectProtocol] = []
   private var remoteCommandTargets: [(MPRemoteCommand, Any)] = []
   private var systemMediaNavigation: [Int64: (previousEnabled: Bool, nextEnabled: Bool)] = [:]
 
   deinit {
+    interruptionResumeWorkItem?.cancel()
     notificationObservers.forEach(NotificationCenter.default.removeObserver)
     remoteCommandTargets.forEach { command, target in
       command.removeTarget(target)
@@ -2017,6 +2019,11 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let playerId = try requiredInt64(args["playerId"], name: "playerId")
         players.removeValue(forKey: playerId)
         systemMediaNavigation.removeValue(forKey: playerId)
+        if interruptedPlayerId == playerId {
+          interruptionResumeWorkItem?.cancel()
+          interruptionResumeWorkItem = nil
+          interruptedPlayerId = nil
+        }
         if activePlayerId == playerId {
           activePlayerId = nil
           clearNowPlayingInfo()
@@ -2744,20 +2751,57 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           let type = AVAudioSession.InterruptionType(rawValue: rawType),
           let host = activePlayerId.flatMap({ players[$0] }) else { return }
     if type == .began {
+      interruptionResumeWorkItem?.cancel()
+      interruptionResumeWorkItem = nil
       interruptedPlayerId = host.isPlaying ? host.id : nil
       if host.isPlaying {
-        try? host.pause()
+        do {
+          try host.pause()
+        } catch {
+          NSLog("ErikaFlutterPlugin: audio interruption pause failed: \(error)")
+        }
       }
       return
     }
     guard let rawOptions = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt,
           AVAudioSession.InterruptionOptions(rawValue: rawOptions).contains(.shouldResume),
           interruptedPlayerId == host.id else {
+      interruptionResumeWorkItem?.cancel()
+      interruptionResumeWorkItem = nil
       interruptedPlayerId = nil
       return
     }
-    interruptedPlayerId = nil
-    try? host.play()
+    resumeInterruptedPlayback(host, attempt: 0)
+  }
+
+  private func resumeInterruptedPlayback(_ host: ErikaPlayerHost, attempt: Int) {
+    guard interruptedPlayerId == host.id, activePlayerId == host.id else { return }
+    do {
+      // ErikaPlayerHost.play() configures the playback category and calls
+      // setActive(true) before sending the native play command.
+      try host.play()
+      interruptionResumeWorkItem = nil
+      interruptedPlayerId = nil
+    } catch {
+      let maxAttempts = 3
+      guard attempt < maxAttempts else {
+        interruptionResumeWorkItem = nil
+        interruptedPlayerId = nil
+        NSLog("ErikaFlutterPlugin: audio interruption resume failed after \(maxAttempts + 1) attempts: \(error)")
+        return
+      }
+      NSLog("ErikaFlutterPlugin: audio interruption resume attempt \(attempt + 1) failed: \(error)")
+      let workItem = DispatchWorkItem { [weak self, weak host] in
+        guard let self, let host else { return }
+        self.interruptionResumeWorkItem = nil
+        self.resumeInterruptedPlayback(host, attempt: attempt + 1)
+      }
+      interruptionResumeWorkItem = workItem
+      DispatchQueue.main.asyncAfter(
+        deadline: .now() + .milliseconds(100),
+        execute: workItem
+      )
+    }
   }
 
   private func presenterConfigForNewPlayer(arguments: Any?, hdrDebug: Bool) -> ErikaPresenterConfigC {

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -2019,11 +2019,7 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let playerId = try requiredInt64(args["playerId"], name: "playerId")
         players.removeValue(forKey: playerId)
         systemMediaNavigation.removeValue(forKey: playerId)
-        if interruptedPlayerId == playerId {
-          interruptionResumeWorkItem?.cancel()
-          interruptionResumeWorkItem = nil
-          interruptedPlayerId = nil
-        }
+        cancelPendingInterruptionResume(ifPlayer: playerId)
         if activePlayerId == playerId {
           activePlayerId = nil
           clearNowPlayingInfo()
@@ -2052,13 +2048,21 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         updateNowPlayingInfo(for: host)
         result(nil)
       case "pause":
-        try playerHost(from: try dictionaryArgs(call.arguments)).pause()
+        let host = try playerHost(from: try dictionaryArgs(call.arguments))
+        // Drop a pending interruption resume first: it is scheduled on the main
+        // queue and would otherwise fire after this pause and play again.
+        cancelPendingInterruptionResume(ifPlayer: host.id)
+        try host.pause()
         result(nil)
       case "stop":
-        try playerHost(from: try dictionaryArgs(call.arguments)).stop()
+        let host = try playerHost(from: try dictionaryArgs(call.arguments))
+        cancelPendingInterruptionResume(ifPlayer: host.id)
+        try host.stop()
         result(nil)
       case "close":
-        try playerHost(from: try dictionaryArgs(call.arguments)).close()
+        let host = try playerHost(from: try dictionaryArgs(call.arguments))
+        cancelPendingInterruptionResume(ifPlayer: host.id)
+        try host.close()
         result(nil)
       case "seek":
         let args = try dictionaryArgs(call.arguments)
@@ -2685,6 +2689,7 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
 
   private func performRemotePause() -> MPRemoteCommandHandlerStatus {
     guard let host = activePlayerId.flatMap({ players[$0] }) else { return .noSuchContent }
+    cancelPendingInterruptionResume(ifPlayer: host.id)
     do {
       try host.pause()
       return .success
@@ -2751,10 +2756,10 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
           let type = AVAudioSession.InterruptionType(rawValue: rawType),
           let host = activePlayerId.flatMap({ players[$0] }) else { return }
     if type == .began {
-      interruptionResumeWorkItem?.cancel()
-      interruptionResumeWorkItem = nil
-      interruptedPlayerId = host.isPlaying ? host.id : nil
-      if host.isPlaying {
+      let wasPlaying = host.isPlaying
+      cancelPendingInterruptionResume()
+      interruptedPlayerId = wasPlaying ? host.id : nil
+      if wasPlaying {
         do {
           try host.pause()
         } catch {
@@ -2766,12 +2771,25 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
     guard let rawOptions = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt,
           AVAudioSession.InterruptionOptions(rawValue: rawOptions).contains(.shouldResume),
           interruptedPlayerId == host.id else {
-      interruptionResumeWorkItem?.cancel()
-      interruptionResumeWorkItem = nil
-      interruptedPlayerId = nil
+      cancelPendingInterruptionResume()
       return
     }
     resumeInterruptedPlayback(host, attempt: 0)
+  }
+
+  /// Drops a scheduled interruption resume, whichever player it targets.
+  private func cancelPendingInterruptionResume() {
+    interruptionResumeWorkItem?.cancel()
+    interruptionResumeWorkItem = nil
+    interruptedPlayerId = nil
+  }
+
+  /// Drops a scheduled interruption resume only when it targets `playerId`, so
+  /// an explicit pause/stop/close on one player leaves another player's
+  /// pending resume alone.
+  private func cancelPendingInterruptionResume(ifPlayer playerId: Int64) {
+    guard interruptedPlayerId == playerId else { return }
+    cancelPendingInterruptionResume()
   }
 
   private func resumeInterruptedPlayback(_ host: ErikaPlayerHost, attempt: Int) {
@@ -2780,13 +2798,11 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       // ErikaPlayerHost.play() configures the playback category and calls
       // setActive(true) before sending the native play command.
       try host.play()
-      interruptionResumeWorkItem = nil
-      interruptedPlayerId = nil
+      cancelPendingInterruptionResume()
     } catch {
       let maxAttempts = 3
       guard attempt < maxAttempts else {
-        interruptionResumeWorkItem = nil
-        interruptedPlayerId = nil
+        cancelPendingInterruptionResume()
         NSLog("ErikaFlutterPlugin: audio interruption resume failed after \(maxAttempts + 1) attempts: \(error)")
         return
       }

--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -2793,7 +2793,13 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   }
 
   private func resumeInterruptedPlayback(_ host: ErikaPlayerHost, attempt: Int) {
-    guard interruptedPlayerId == host.id, activePlayerId == host.id else { return }
+    // A retry can fire after the active player changed. Drop the recovery
+    // instead of returning with `interruptedPlayerId` still set, which would
+    // leave a resume owed to a player that will never be resumed.
+    guard interruptedPlayerId == host.id, activePlayerId == host.id else {
+      cancelPendingInterruptionResume(ifPlayer: host.id)
+      return
+    }
     do {
       // ErikaPlayerHost.play() configures the playback category and calls
       // setActive(true) before sending the native play command.

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -70,6 +70,18 @@ void main() {
     });
   }
 
+  test('iOS retries audio-session activation after an allowed interruption', () {
+    final plugin = File(
+      'ios/Classes/ErikaFlutterPlugin.swift',
+    ).readAsStringSync();
+
+    expect(plugin, contains('AVAudioSession.interruptionNotification'));
+    expect(plugin, contains('try session.setActive(true)'));
+    expect(plugin, contains('private func resumeInterruptedPlayback'));
+    expect(plugin, contains('interruptionResumeWorkItem'));
+    expect(plugin, contains('guard attempt < maxAttempts else'));
+  });
+
   test('Android polls events on the presenter thread with adaptive scheduling', () {
     final plugin = File(
       'android/src/main/kotlin/dev/aimesoft/erika_flutter/'

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -82,6 +82,47 @@ void main() {
     expect(plugin, contains('guard attempt < maxAttempts else'));
   });
 
+  test('iOS drops a pending interruption resume on an explicit command', () {
+    final plugin = File(
+      'ios/Classes/ErikaFlutterPlugin.swift',
+    ).readAsStringSync();
+
+    expect(
+      plugin,
+      contains(
+          'private func cancelPendingInterruptionResume(ifPlayer playerId: Int64)'),
+    );
+
+    // Every explicit pause/stop/close path must disarm the retry before it
+    // fires, or the deferred resume would play against the user's intent.
+    for (final entry in <(String, String)>[
+      ('      case "pause":', 'try host.pause()'),
+      ('      case "stop":', 'try host.stop()'),
+      ('      case "close":', 'try host.close()'),
+    ]) {
+      final caseStart = plugin.indexOf(entry.$1);
+      expect(caseStart, greaterThanOrEqualTo(0), reason: entry.$1);
+      final body = plugin.substring(
+        caseStart,
+        plugin.indexOf(entry.$2, caseStart) + entry.$2.length,
+      );
+      expect(
+          body, contains('cancelPendingInterruptionResume(ifPlayer: host.id)'));
+    }
+
+    final remoteStart = plugin.indexOf(
+      'private func performRemotePause()',
+    );
+    final remoteEnd =
+        plugin.indexOf('private func performRemoteToggle()', remoteStart);
+    expect(remoteStart, greaterThanOrEqualTo(0));
+    expect(remoteEnd, greaterThan(remoteStart));
+    expect(
+      plugin.substring(remoteStart, remoteEnd),
+      contains('cancelPendingInterruptionResume(ifPlayer: host.id)'),
+    );
+  });
+
   test('Android polls events on the presenter thread with adaptive scheduling', () {
     final plugin = File(
       'android/src/main/kotlin/dev/aimesoft/erika_flutter/'


### PR DESCRIPTION
  ## Summary

  - Defer foreground video decoder seek/flush until the rendering surface is ready.
  - Treat `CAMetalLayer.nextDrawable() == nil` as temporary backpressure.
  - Retry foreground video resume without propagating transient failures through the C ABI.
  - Reactivate `AVAudioSession` and resume playback after allowed audio interruptions.
  - Add presenter and Flutter contract coverage.

  ## Testing

  - `cargo fmt --all -- --check`
  - Foreground resume test passed
  - Metal tests: 34 passed
  - Flutter contract tests: 7 passed
  - `swiftc -parse` passed