### PR TITLE
Automate ecosystem releases from one tag

### DIFF
--- a/.github/workflows/ohpm-package.yml
+++ b/.github/workflows/ohpm-package.yml
@@ -21,9 +21,29 @@ on:
       - "packages/erika_ohos/**"
   workflow_dispatch:
     inputs:
+      version:
+        description: Erika version to package
+        required: true
+        default: "0.1.7"
+        type: string
       publish:
         description: Publish the validated HAR to OHPM
         required: true
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: Erika version to package
+        required: true
+        type: string
+      ref:
+        description: Git ref containing the package source
+        required: false
+        type: string
+      publish:
+        description: Publish the validated HAR to OHPM
+        required: false
         default: false
         type: boolean
 
@@ -35,8 +55,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ERIKA_NATIVE_VERSION: "0.1.7"
-  ERIKA_NATIVE_SHA256: "492afbab9ae9f20f55ce6ae2212094ece6f6c0cca1bee96ddffc175068afa396"
+  ERIKA_NATIVE_VERSION: "${{ inputs.version || '0.1.7' }}"
   OHPM_CLI_URL: "https://repo.huaweicloud.com/harmonyos/ohpm/5.1.0/commandline-tools-linux-x64-5.1.0.840.zip"
   OHPM_CLI_SHA256: "1dcefa4741dc289277560b2802040e0c45b433898d8db453d711d5376e0478f1"
 
@@ -47,6 +66,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: openharmony-rs/setup-ohos-sdk@b312caf8a43bb836aa24c08f65f97e1f09a89cad
         id: ohos_sdk
@@ -73,11 +94,13 @@ jobs:
           set -euo pipefail
           runtime_dir="$RUNNER_TEMP/erika-runtime"
           mkdir -p "$runtime_dir" packages/erika_ohos/src/main/cpp
+          native_sha256="$(awk -F= '$1 == "ERIKA_OPENHARMONY_ARM64_SHA256" {print $2; exit}' packages/erika_flutter/native_artifacts.properties)"
+          test -n "$native_sha256"
           runtime_zip="$runtime_dir/erika-capi-openharmony-arm64.zip"
           curl --fail --location --retry 5 --retry-all-errors \
             "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${ERIKA_NATIVE_VERSION}/erika-capi-openharmony-arm64.zip" \
             --output "$runtime_zip"
-          printf '%s  %s\n' "$ERIKA_NATIVE_SHA256" "$runtime_zip" | sha256sum --check
+          printf '%s  %s\n' "$native_sha256" "$runtime_zip" | sha256sum --check
           unzip -q "$runtime_zip" -d "$runtime_dir/unpacked"
           runtime="$(find "$runtime_dir/unpacked" -type f -name liberika_capi.so -print -quit)"
           test -n "$runtime"
@@ -89,6 +112,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          package_version="$(awk -F'"' '/"version"/ {print $4; exit}' oh-package.json5)"
+          test "$package_version" = "$ERIKA_NATIVE_VERSION"
           npm config set @ohos:registry https://repo.harmonyos.com/npm/
           npm install --no-save --package-lock=false \
             @ohos/hvigor@5.19.8 \
@@ -135,7 +160,7 @@ jobs:
           set -euo pipefail
           har="packages/erika_ohos/build/default/outputs/default/erika.har"
           test -s "$har"
-          cp "$har" "$RUNNER_TEMP/erika-0.1.7.har"
+          cp "$har" "$RUNNER_TEMP/erika.har"
           mkdir -p "$RUNNER_TEMP/erika-har"
           tar -xzf "$har" -C "$RUNNER_TEMP/erika-har"
 
@@ -154,7 +179,7 @@ jobs:
         run: |
           set -euo pipefail
           har="packages/erika_ohos/build/default/outputs/default/erika.har"
-          cp "$har" examples/ohos_arkts/erika-0.1.7.har
+          cp "$har" examples/ohos_arkts/erika.har
           package_dir="examples/ohos_arkts/entry/oh_modules/erika"
           mkdir -p "$package_dir"
           tar -xzf "$har" --strip-components=1 -C "$package_dir"
@@ -203,15 +228,18 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: erika-ohos-0.1.7
+          name: erika-ohos-${{ inputs.version || '0.1.7' }}
           path: |
-            ${{ runner.temp }}/erika-0.1.7.har
+            ${{ runner.temp }}/erika.har
             ${{ runner.temp }}/erika-ohos-smoke.hap
           if-no-files-found: error
 
   publish:
     name: Publish ArkTS package to OHPM
-    if: github.event_name == 'workflow_dispatch' && inputs.publish && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'workflow_call' && inputs.publish) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish &&
+       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
     needs: package
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -219,7 +247,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: erika-ohos-0.1.7
+          name: erika-ohos-${{ inputs.version || '0.1.7' }}
           path: ${{ runner.temp }}/erika-ohos-release
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/pub-publish.yml
+++ b/.github/workflows/pub-publish.yml
@@ -3,17 +3,7 @@ name: Publish erika_flutter to pub.dev
 on:
   push:
     tags:
-      - "erika_flutter-v[0-9]+.[0-9]+.[0-9]+"
-  workflow_call:
-    inputs:
-      version:
-        description: Package version to publish
-        required: true
-        type: string
-      ref:
-        description: Git ref containing the package metadata to publish
-        required: false
-        type: string
+      - "erika_flutter-v*"
 
 jobs:
   verify:
@@ -24,17 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref }}
       - name: Verify versions and native artifact checksums
         shell: bash
         env:
           RELEASE_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag_version="${{ inputs.version || '' }}"
-          if [[ -z "$tag_version" ]]; then
-            tag_version="${GITHUB_REF_NAME#erika_flutter-v}"
-          fi
+          tag_version="${GITHUB_REF_NAME#erika_flutter-v}"
+          [[ "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           package_version="$(awk -F': ' '$1 == "version" {print $2; exit}' packages/erika_flutter/pubspec.yaml)"
           source packages/erika_flutter/native_artifacts.properties
 
@@ -86,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref }}
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
       - uses: flutter-actions/setup-flutter@d4e97a6e7467ef062618c9af927f90bc9651b876
       - name: Install dependencies

--- a/.github/workflows/pub-publish.yml
+++ b/.github/workflows/pub-publish.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "erika_flutter-v[0-9]+.[0-9]+.[0-9]+"
+  workflow_call:
+    inputs:
+      version:
+        description: Package version to publish
+        required: true
+        type: string
+      ref:
+        description: Git ref containing the package metadata to publish
+        required: false
+        type: string
 
 jobs:
   verify:
@@ -13,13 +23,18 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Verify versions and native artifact checksums
         shell: bash
         env:
           RELEASE_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag_version="${GITHUB_REF_NAME#erika_flutter-v}"
+          tag_version="${{ inputs.version || '' }}"
+          if [[ -z "$tag_version" ]]; then
+            tag_version="${GITHUB_REF_NAME#erika_flutter-v}"
+          fi
           package_version="$(awk -F': ' '$1 == "version" {print $2; exit}' packages/erika_flutter/pubspec.yaml)"
           source packages/erika_flutter/native_artifacts.properties
 
@@ -64,9 +79,22 @@ jobs:
   publish:
     name: Publish to pub.dev
     needs: verify
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
-    with:
-      working-directory: packages/erika_flutter
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+      - uses: flutter-actions/setup-flutter@d4e97a6e7467ef062618c9af927f90bc9651b876
+      - name: Install dependencies
+        run: dart pub get
+        working-directory: packages/erika_flutter
+      - name: Publish dry run
+        run: dart pub publish --dry-run
+        working-directory: packages/erika_flutter
+      - name: Publish to pub.dev
+        run: dart pub publish --force
+        working-directory: packages/erika_flutter

--- a/.github/workflows/release-ecosystem.yml
+++ b/.github/workflows/release-ecosystem.yml
@@ -56,10 +56,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sed -i -E "s/^version: .*/version: \${VERSION}/" packages/erika_flutter/pubspec.yaml
-          sed -i -E "s/(\"version\": \")[^\"]+/\1\${VERSION}/" packages/erika_ohos/oh-package.json5
-          sed -i -E "s/(\"versionName\": \")[^\"]+/\1\${VERSION}/" examples/ohos_arkts/AppScope/app.json5
-          sed -i -E "s/(\"version\": \")[^\"]+/\1\${VERSION}/" examples/ohos_arkts/entry/oh-package.json5
+          sed -i -E "s/^version: .*/version: ${VERSION}/" packages/erika_flutter/pubspec.yaml
+          sed -i -E "s/(\"version\": \")[^\"]+/\1${VERSION}/" packages/erika_ohos/oh-package.json5
+          sed -i -E "s/(\"versionName\": \")[^\"]+/\1${VERSION}/" examples/ohos_arkts/AppScope/app.json5
+          sed -i -E "s/(\"version\": \")[^\"]+/\1${VERSION}/" examples/ohos_arkts/entry/oh-package.json5
 
           checksums="$RUNNER_TEMP/SHA256SUMS"
           gh release download "v$VERSION" \
@@ -68,7 +68,7 @@ jobs:
             --dir "$RUNNER_TEMP"
 
           properties=packages/erika_flutter/native_artifacts.properties
-          sed -i -E "s/^# Native artifacts consumed by erika_flutter .*/# Native artifacts consumed by erika_flutter ${VERSION}. /" "$properties"
+          sed -i -E "s/^# Native artifacts consumed by erika_flutter .*/# Native artifacts consumed by erika_flutter ${VERSION}./" "$properties"
           sed -i -E "s/^ERIKA_NATIVE_VERSION=.*/ERIKA_NATIVE_VERSION=${VERSION}/" "$properties"
 
           set_property() {

--- a/.github/workflows/release-ecosystem.yml
+++ b/.github/workflows/release-ecosystem.yml
@@ -1,0 +1,177 @@
+name: Release ecosystem packages
+
+# A native vX.Y.Z release is the single release trigger. The Release workflow
+# creates the archives and SHA256SUMS first; this workflow then publishes the
+# package targets that consume those archives.
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-ecosystem-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Resolve release version
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      release_ref: ${{ steps.meta.outputs.release_ref }}
+    steps:
+      - id: meta
+        shell: bash
+        env:
+          RELEASE_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_REF#v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
+
+  prepare-package-metadata:
+    name: Update Flutter artifact manifest
+    needs: version
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.commit.outputs.ref }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Update package version and native SHA-256 values
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i -E "s/^version: .*/version: \${VERSION}/" packages/erika_flutter/pubspec.yaml
+          sed -i -E "s/(\"version\": \")[^\"]+/\1\${VERSION}/" packages/erika_ohos/oh-package.json5
+          sed -i -E "s/(\"versionName\": \")[^\"]+/\1\${VERSION}/" examples/ohos_arkts/AppScope/app.json5
+          sed -i -E "s/(\"version\": \")[^\"]+/\1\${VERSION}/" examples/ohos_arkts/entry/oh-package.json5
+
+          checksums="$RUNNER_TEMP/SHA256SUMS"
+          gh release download "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern SHA256SUMS \
+            --dir "$RUNNER_TEMP"
+
+          properties=packages/erika_flutter/native_artifacts.properties
+          sed -i -E "s/^# Native artifacts consumed by erika_flutter .*/# Native artifacts consumed by erika_flutter ${VERSION}. /" "$properties"
+          sed -i -E "s/^ERIKA_NATIVE_VERSION=.*/ERIKA_NATIVE_VERSION=${VERSION}/" "$properties"
+
+          set_property() {
+            local key="$1"
+            local asset="$2"
+            local digest
+            digest="$(awk -v asset="$asset" '$2 == asset {print $1; exit}' "$checksums")"
+            test -n "$digest"
+            sed -i -E "s/^${key}=.*/${key}=${digest}/" "$properties"
+          }
+
+          set_property ERIKA_ANDROID_ARM64_V8A_SHA256 erika-flutter-android-arm64-v8a.zip
+          set_property ERIKA_ANDROID_ARMEABI_V7A_SHA256 erika-flutter-android-armeabi-v7a.zip
+          set_property ERIKA_ANDROID_X86_64_SHA256 erika-flutter-android-x86_64.zip
+          set_property ERIKA_ANDROID_X86_SHA256 erika-flutter-android-x86.zip
+          set_property ERIKA_IOS_SHA256 erika-capi-ios.zip
+          set_property ERIKA_TVOS_SHA256 erika-capi-tvos.zip
+          set_property ERIKA_MACOS_ARM64_SHA256 erika-capi-macos-arm64.zip
+          set_property ERIKA_MACOS_X64_SHA256 erika-capi-macos-x64.zip
+          set_property ERIKA_MACOS_UNIVERSAL_SHA256 erika-capi-macos-universal.zip
+          set_property ERIKA_WINDOWS_X64_SHA256 erika-capi-windows-x64.zip
+          set_property ERIKA_WINDOWS_ARM64_SHA256 erika-capi-windows-arm64.zip
+          set_property ERIKA_OPENHARMONY_ARM64_SHA256 erika-capi-openharmony-arm64.zip
+          git diff --check
+
+      - name: Commit release metadata
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "No manifest changes are required."
+          else
+            git add \
+              packages/erika_flutter/pubspec.yaml \
+              packages/erika_flutter/native_artifacts.properties \
+              packages/erika_ohos/oh-package.json5 \
+              examples/ohos_arkts/AppScope/app.json5 \
+              examples/ohos_arkts/entry/oh-package.json5
+            git commit -m "Update native artifact manifest for v${VERSION}"
+            git push origin HEAD:main
+          fi
+          echo "ref=main" >> "$GITHUB_OUTPUT"
+
+  publish-pub:
+    name: Publish Flutter package
+    needs: [version, prepare-package-metadata]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/pub-publish.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      ref: ${{ needs.prepare-package-metadata.outputs.ref }}
+    secrets: inherit
+
+  publish-ohpm:
+    name: Publish OpenHarmony package
+    needs: [version, prepare-package-metadata]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ohpm-package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      ref: ${{ needs.prepare-package-metadata.outputs.ref }}
+      publish: true
+    secrets: inherit
+
+  build-swift:
+    name: Build and attach Swift binary
+    needs: version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/swift-sdk-binary.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+      ref: ${{ needs.version.outputs.release_ref }}
+      upload: true
+    secrets: inherit
+
+  update-swift-sdk:
+    name: Update ErikaSwift repository
+    needs: [version, build-swift]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.ERIKA_SWIFT_RELEASE_TOKEN }}
+      VERSION: ${{ needs.version.outputs.version }}
+      CHECKSUM: ${{ needs.build-swift.outputs.checksum }}
+      SOURCE_TAG: ${{ needs.version.outputs.release_ref }}
+    steps:
+      - name: Dispatch ErikaSwift release workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          test -n "$CHECKSUM"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg checksum "$CHECKSUM" \
+            --arg source_tag "$SOURCE_TAG" \
+            '{event_type:"erika-release", client_payload:{version:$version, checksum:$checksum, source_tag:$source_tag}}' \
+            | gh api --method POST repos/AimesSoft/ErikaSwift/dispatches --input -

--- a/.github/workflows/release-ecosystem.yml
+++ b/.github/workflows/release-ecosystem.yml
@@ -113,19 +113,41 @@ jobs:
             git commit -m "Update native artifact manifest for v${VERSION}"
             git push origin HEAD:main
           fi
-          echo "ref=main" >> "$GITHUB_OUTPUT"
+          echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-  publish-pub:
-    name: Publish Flutter package
+  trigger-pub-release:
+    name: Trigger Flutter package publish
     needs: [version, prepare-package-metadata]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
-    uses: ./.github/workflows/pub-publish.yml
-    with:
-      version: ${{ needs.version.outputs.version }}
-      ref: ${{ needs.prepare-package-metadata.outputs.ref }}
-    secrets: inherit
+    env:
+      GH_TOKEN: ${{ secrets.ERIKA_SWIFT_RELEASE_TOKEN }}
+      VERSION: ${{ needs.version.outputs.version }}
+      PACKAGE_REF: ${{ needs.prepare-package-metadata.outputs.ref }}
+    steps:
+      - name: Create the package release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$GH_TOKEN"
+          package_tag="erika_flutter-v${VERSION}"
+          package_ref="refs/tags/${package_tag}"
+
+          if existing="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${package_tag}" 2>/dev/null)"; then
+            existing_sha="$(jq -r '.object.sha' <<<"$existing")"
+            if [[ "$existing_sha" != "$PACKAGE_REF" ]]; then
+              echo "${package_tag} already points to ${existing_sha}, expected ${PACKAGE_REF}." >&2
+              exit 1
+            fi
+            echo "${package_tag} already points to the package metadata commit."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=${package_ref}" \
+            -f "sha=${PACKAGE_REF}"
+          echo "Created ${package_tag}; the tag-triggered pub.dev workflow will publish it."
 
   publish-ohpm:
     name: Publish OpenHarmony package

--- a/.github/workflows/swift-sdk-binary.yml
+++ b/.github/workflows/swift-sdk-binary.yml
@@ -18,6 +18,25 @@ on:
         required: true
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: Existing Erika native release version
+        required: true
+        type: string
+      ref:
+        description: Git ref containing the Swift packaging script
+        required: false
+        type: string
+      upload:
+        description: Attach the Swift XCFramework to the existing release
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      checksum:
+        description: SwiftPM checksum of the assembled XCFramework archive
+        value: ${{ jobs.package.outputs.checksum }}
 
 permissions:
   contents: write
@@ -27,11 +46,15 @@ jobs:
     name: Assemble Apple XCFramework
     runs-on: macos-26
     timeout-minutes: 45
+    outputs:
+      checksum: ${{ steps.binary.outputs.checksum }}
     env:
       GH_TOKEN: ${{ github.token }}
       VERSION: ${{ inputs.version || '0.1.7' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Download existing Apple release archives
         shell: bash
@@ -85,7 +108,7 @@ jobs:
           retention-days: 7
 
       - name: Attach binary target to the native release
-        if: github.event_name == 'workflow_dispatch' && inputs.upload
+        if: inputs.upload && (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
         shell: bash
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - Added isolated GitHub Actions consumers for Android, iOS, macOS, tvOS,
   Windows, and OpenHarmony so package builds cannot depend on the monorepo.
 
+### OpenHarmony package distribution
+
+- Published the independent native ArkTS package `erika` to OHPM for
+  OpenHarmony arm64 (API 18+), with `XComponent` surface lifecycle,
+  `renderTick()` scheduling, playback controls, events, and screenshots.
+
 ## 0.1.6 - 2026-08-14
 
 ### Rendering and playback

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ The package downloads the matching verified native runtime during the platform
 build. Android downloads only the selected ABI archive; Linux and Web are not
 published targets yet.
 
+### OpenHarmony package
+
+The native ArkTS package `erika` 0.1.7 is published on
+[OHPM](https://ohpm.openharmony.cn/#/cn/detail/erika) for OpenHarmony arm64
+applications (API 18+). Install it with:
+
+```sh
+ohpm install erika
+```
+
+This package is independent of Flutter. See the
+[OpenHarmony package guide](packages/erika_ohos/README.md) for the
+`ErikaPlayer` API and `XComponent` surface setup.
+
 ### Swift package
 
 原生 macOS、iOS 和 tvOS 应用可通过 Swift Package Manager 使用
@@ -127,6 +141,7 @@ crates/erika              核心播放库
 crates/erika_capi         C ABI 导出层
 crates/erika_ffmpeg_sys   FFmpeg 底层 bindings
 packages/erika_flutter    Flutter 插件 (macOS + iOS + tvOS + Windows + Android + HarmonyOS)
+packages/erika_ohos       OpenHarmony ArkTS / OHPM package
 examples/                 验证与演示程序
 xtask/                    原生依赖构建编排
 docs/                     架构与嵌入文档

--- a/docs/releasing.ja.md
+++ b/docs/releasing.ja.md
@@ -56,21 +56,15 @@ pub.dev への公開は [pub-publish.yml](../.github/workflows/pub-publish.yml) 
 native archive には build metadata が含まれるため、package に固定する SHA-256 は対応する
 GitHub Release の作成後に更新します。公開順序は次の通りです：
 
-1. 下記の手順で `v0.1.8` を push し、native GitHub Release と `SHA256SUMS` の完了を待つ；
-2. `packages/erika_flutter/pubspec.yaml`、`native_artifacts.properties`、CHANGELOG を同じ
-   version に更新し、Release にある 12 platform archive の digest を manifest に反映する；
-3. Flutter package check の成功後に merge し、その commit に独立した package tag を push する：
+1. 下記の手順で `v0.1.8` を push する；
+2. native GitHub Release と `SHA256SUMS` の完了後、Action が package manifest を更新し、
+   `erika_flutter-v0.1.8` tag を自動作成する；
+3. その tag の Action が package version、native version、GitHub Release の全 SHA-256 を
+   検証してから pub.dev OIDC で公開する。
 
-   ```sh
-   VERSION=0.1.8
-   git tag "erika_flutter-v${VERSION}"
-   git push origin "erika_flutter-v${VERSION}"
-   ```
-
-Action は package version、native version、GitHub Release の全 SHA-256 を検証してから
-pub.dev OIDC で公開します。long-lived upload secret は保存しません。pub.dev Admin の
-one-time 設定は repository `AimesSoft/Erika`、tag pattern
-`erika_flutter-v{{version}}` です。
+`erika_flutter-vX.Y.Z` は workflow 内部の package release tag で、maintainer が手動で push
+する必要はありません。pub.dev Admin の one-time 設定は repository `AimesSoft/Erika`、
+tag pattern `erika_flutter-v{{version}}` です。
 
 ### pub.dev publisher identity
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -90,13 +90,16 @@ git push origin "v${VERSION}"
 After the native Release succeeds, the workflow automatically:
 
 1. Updates the Flutter and OHPM manifests and `native_artifacts.properties`.
-2. Publishes `erika_flutter` through pub.dev OIDC.
+2. Creates the matching `erika_flutter-vX.Y.Z` tag on the metadata commit;
+   that tag triggers the pub.dev OIDC publish after its version and checksums
+   are verified.
 3. Builds and publishes `erika` to OHPM.
 4. Builds and uploads the Swift XCFramework, then dispatches ErikaSwift to
    update, test, tag, and release the matching SDK.
 
-The independent `erika_flutter-vX.Y.Z` tag remains available for legacy manual
-publishing. Cross-repository Swift publishing requires the one-time
+The `erika_flutter-vX.Y.Z` tag is an internal package-release tag created by
+the workflow; maintainers only create and push the core `vX.Y.Z` tag.
+Cross-repository package-tag and Swift publishing require the one-time
 `ERIKA_SWIFT_RELEASE_TOKEN` secret in `AimesSoft/Erika`.
 
 ### Pub.dev publisher identity

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -75,28 +75,29 @@ The isolated package and platform consumer checks run from
 [`.github/workflows/flutter-package.yml`](../.github/workflows/flutter-package.yml)
 before a package release is merged. Linux and Web are not package targets yet.
 
-Publishing to pub.dev is automated by
-[`.github/workflows/pub-publish.yml`](../.github/workflows/pub-publish.yml).
-Native archives include build metadata, so the package-pinned SHA-256 values can
-only be updated after the corresponding GitHub Release exists. Use this order:
+Publishing pub.dev, OHPM, and ErikaSwift is orchestrated by
+[`.github/workflows/release-ecosystem.yml`](../.github/workflows/release-ecosystem.yml).
+Because native archives include build metadata, the workflow updates the package
+versions and all pinned SHA-256 values after the GitHub Release and its
+`SHA256SUMS` asset exist. A normal release now starts with one core tag:
 
-1. Push `v0.1.8` as described below and wait for the native GitHub Release and
-   its `SHA256SUMS` asset.
-2. Update `packages/erika_flutter/pubspec.yaml`, `native_artifacts.properties`,
-   and the changelog to the same version. Copy all 12 platform archive digests
-   from the Release into the native artifact manifest.
-3. Merge after the Flutter package checks pass, then tag that package commit:
+```sh
+VERSION=0.1.8
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+```
 
-   ```sh
-   VERSION=0.1.8
-   git tag "erika_flutter-v${VERSION}"
-   git push origin "erika_flutter-v${VERSION}"
-   ```
+After the native Release succeeds, the workflow automatically:
 
-The action verifies the package version, native version, and every pinned
-SHA-256 against the GitHub Release before publishing through pub.dev OIDC. The
-one-time pub.dev Admin configuration is repository `AimesSoft/Erika` with tag
-pattern `erika_flutter-v{{version}}`; no long-lived upload secret is stored.
+1. Updates the Flutter and OHPM manifests and `native_artifacts.properties`.
+2. Publishes `erika_flutter` through pub.dev OIDC.
+3. Builds and publishes `erika` to OHPM.
+4. Builds and uploads the Swift XCFramework, then dispatches ErikaSwift to
+   update, test, tag, and release the matching SDK.
+
+The independent `erika_flutter-vX.Y.Z` tag remains available for legacy manual
+publishing. Cross-repository Swift publishing requires the one-time
+`ERIKA_SWIFT_RELEASE_TOKEN` secret in `AimesSoft/Erika`.
 
 ### Pub.dev publisher identity
 

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -63,12 +63,14 @@ git push origin "v${VERSION}"
 原生 Release 成功后，workflow 会自动完成以下工作：
 
 1. 更新 `pubspec.yaml`、OHPM manifest 和 `native_artifacts.properties`；
-2. 通过 OIDC 发布 `erika_flutter` 到 pub.dev；
+2. 自动创建对应的 `erika_flutter-vX.Y.Z` package tag；该 tag 会触发 pub.dev
+   OIDC 发布，并先校验版本和全部 SHA-256；
 3. 构建并发布 `erika` 到 OHPM；
 4. 组装 Swift XCFramework，上传到 Erika Release，并通知 ErikaSwift 更新、测试、打 tag 和建 Release。
 
-独立的 `erika_flutter-vX.Y.Z` tag 仍保留给兼容旧流程的手动发布。跨仓库 Swift 发布需要
-在 `AimesSoft/Erika` 配置一次 `ERIKA_SWIFT_RELEASE_TOKEN` secret。
+`erika_flutter-vX.Y.Z` 是工作流内部使用的 package tag，维护者不需要手动创建；正常发版只推送
+核心 `vX.Y.Z` tag。跨仓库 package tag 和 Swift 发布需要在 `AimesSoft/Erika` 配置一次
+`ERIKA_SWIFT_RELEASE_TOKEN` secret。
 
 ### pub.dev publisher 身份
 

--- a/docs/releasing.zh.md
+++ b/docs/releasing.zh.md
@@ -49,23 +49,26 @@ dart pub publish
 合并前由 [flutter-package.yml](../.github/workflows/flutter-package.yml) 执行 isolated
 package 和各平台 consumer 检查。Linux 和 Web 目前还不是 package 发布目标。
 
-pub.dev 发布由 [pub-publish.yml](../.github/workflows/pub-publish.yml) 自动执行。原生归档包含
-构建时间，因此 package 固定的 SHA-256 只能在对应 GitHub Release 创建后更新。发布顺序为：
+pub.dev、OHPM 和 ErikaSwift 由
+[release-ecosystem.yml](../.github/workflows/release-ecosystem.yml) 串联发布。原生归档包含
+构建时间，因此 workflow 会在 GitHub Release 和 `SHA256SUMS` 创建后自动更新
+Flutter/OHPM package 的版本与 SHA-256，再分别执行发布。正常发版只需要推送一个核心 tag：
 
-1. 按下文步骤推送 `v0.1.8`，等待原生 GitHub Release 和 `SHA256SUMS` 完成；
-2. 将 `packages/erika_flutter/pubspec.yaml`、`native_artifacts.properties` 和 CHANGELOG
-   更新到同一版本，并把 Release 中 12 个平台归档的哈希写入 manifest；
-3. 合并并确认 Flutter package 检查通过后，在该提交上推送独立 package tag：
+```sh
+VERSION=0.1.8
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+```
 
-   ```sh
-   VERSION=0.1.8
-   git tag "erika_flutter-v${VERSION}"
-   git push origin "erika_flutter-v${VERSION}"
-   ```
+原生 Release 成功后，workflow 会自动完成以下工作：
 
-Action 会先校验 package 版本、native 版本和 GitHub Release 的全部 SHA-256，再通过
-pub.dev OIDC 发布，不保存长期上传密钥。pub.dev Admin 的一次性配置为 repository
-`AimesSoft/Erika`、tag pattern `erika_flutter-v{{version}}`。
+1. 更新 `pubspec.yaml`、OHPM manifest 和 `native_artifacts.properties`；
+2. 通过 OIDC 发布 `erika_flutter` 到 pub.dev；
+3. 构建并发布 `erika` 到 OHPM；
+4. 组装 Swift XCFramework，上传到 Erika Release，并通知 ErikaSwift 更新、测试、打 tag 和建 Release。
+
+独立的 `erika_flutter-vX.Y.Z` tag 仍保留给兼容旧流程的手动发布。跨仓库 Swift 发布需要
+在 `AimesSoft/Erika` 配置一次 `ERIKA_SWIFT_RELEASE_TOKEN` secret。
 
 ### pub.dev publisher 身份
 

--- a/examples/ohos_arkts/entry/oh-package.json5
+++ b/examples/ohos_arkts/entry/oh-package.json5
@@ -6,6 +6,6 @@
   "author": "AimesSoft",
   "license": "MPL-2.0",
   "dependencies": {
-    "erika": "file:../erika-0.1.7.har"
+    "erika": "file:../erika.har"
   }
 }

--- a/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
+++ b/examples/ohos_arkts/entry/src/main/ets/pages/Index.ets
@@ -1,8 +1,13 @@
-import { ErikaPlayer } from 'erika';
+import { ErikaNativeResponse, ErikaPlayer } from 'erika';
 
 class ErikaSurfaceController extends XComponentController {
   private readonly player: ErikaPlayer = new ErikaPlayer();
   private attached: boolean = false;
+  private pendingUri: string = '';
+
+  onSurfaceCreated(surfaceId: string): void {
+    console.info(`Erika XComponent surface created: ${surfaceId}`);
+  }
 
   onSurfaceChanged(surfaceId: string, rect: SurfaceRect): void {
     if (!this.attached) {
@@ -13,9 +18,10 @@ class ErikaSurfaceController extends XComponentController {
         scale: 1.0,
       });
       this.attached = true;
-      return;
+    } else {
+      this.player.resizeSurface(rect.surfaceWidth, rect.surfaceHeight);
     }
-    this.player.resizeSurface(rect.surfaceWidth, rect.surfaceHeight);
+    this.startPendingUri();
   }
 
   onSurfaceDestroyed(_surfaceId: string): void {
@@ -25,24 +31,43 @@ class ErikaSurfaceController extends XComponentController {
     }
     this.player.dispose();
   }
+
+  open(uri: string): void {
+    this.pendingUri = uri;
+    this.startPendingUri();
+  }
+
+  renderFrame(timeSeconds: number): ErikaNativeResponse {
+    return this.player.renderTick(timeSeconds);
+  }
+
+  private startPendingUri(): void {
+    if (!this.attached || this.pendingUri.length === 0) {
+      return;
+    }
+    const uri: string = this.pendingUri;
+    this.pendingUri = '';
+    this.player.open(uri);
+    this.player.play();
+  }
 }
 
 @Entry
 @Component
 struct Index {
-  surfaceController: XComponentController = new ErikaSurfaceController();
+  surfaceController: ErikaSurfaceController = new ErikaSurfaceController();
 
   build() {
     Column() {
       XComponent({
+        id: 'erika-surface',
         type: XComponentType.SURFACE,
         controller: this.surfaceController,
       })
         .width('100%')
         .height('100%')
         .onLoad(() => {
-          const surfaceId: string = this.surfaceController.getXComponentSurfaceId();
-          console.info(`Erika XComponent surface ready: ${surfaceId}`);
+          this.surfaceController.open('https://example.com/video.mp4');
         })
     }
       .width('100%')

--- a/packages/erika_ohos/README.md
+++ b/packages/erika_ohos/README.md
@@ -16,15 +16,98 @@ ohpm install erika
 
 ## Usage
 
-```ts
-import { ErikaPlayer } from 'erika';
+The package owns the native presenter, while the ArkTS host owns the
+`XComponent` lifecycle. Attach the surface when it becomes available, resize
+it when the host reports a new `SurfaceRect`, and dispose the player when the
+surface is destroyed:
 
-const player = new ErikaPlayer();
-const surfaceId = BigInt(xComponentController.getXComponentSurfaceId());
-player.attachSurface({ surfaceId, width, height, scale: 1.0 });
-player.open('https://example.com/video.mp4');
-player.play();
+```ts
+import { ErikaNativeResponse, ErikaPlayer } from 'erika';
+
+class ErikaSurfaceController extends XComponentController {
+  private readonly player: ErikaPlayer = new ErikaPlayer();
+  private attached: boolean = false;
+  private pendingUri: string = '';
+
+  onSurfaceCreated(surfaceId: string): void {
+    console.info(`Erika XComponent surface created: ${surfaceId}`);
+  }
+
+  onSurfaceChanged(surfaceId: string, rect: SurfaceRect): void {
+    if (!this.attached) {
+      this.player.attachSurface({
+        surfaceId: BigInt(surfaceId),
+        width: rect.surfaceWidth,
+        height: rect.surfaceHeight,
+        scale: 1.0,
+      });
+      this.attached = true;
+    } else {
+      this.player.resizeSurface(rect.surfaceWidth, rect.surfaceHeight);
+    }
+    this.startPendingUri();
+  }
+
+  onSurfaceDestroyed(_surfaceId: string): void {
+    if (this.attached) {
+      this.player.detachSurface();
+      this.attached = false;
+    }
+    this.player.dispose();
+  }
+
+  open(uri: string): void {
+    this.pendingUri = uri;
+    this.startPendingUri();
+  }
+
+  // Call this from the host's frame scheduler.
+  renderFrame(timeSeconds: number): ErikaNativeResponse {
+    return this.player.renderTick(timeSeconds);
+  }
+
+  private startPendingUri(): void {
+    if (!this.attached || this.pendingUri.length === 0) {
+      return;
+    }
+    const uri: string = this.pendingUri;
+    this.pendingUri = '';
+    this.player.open(uri);
+    this.player.play();
+  }
+}
 ```
+
+Use the controller with an ArkUI surface. The controller queues `open()` until
+the first surface size callback has attached the native window, so the host can
+call it from `onLoad()`. Call `renderFrame()` from the display-frame callback:
+
+```ts
+@Entry
+@Component
+struct VideoPage {
+  private readonly surfaceController: ErikaSurfaceController =
+    new ErikaSurfaceController();
+
+  build() {
+    XComponent({
+      id: 'erika-surface',
+      type: XComponentType.SURFACE,
+      controller: this.surfaceController,
+    })
+      .width('100%')
+      .height('100%')
+      .onLoad(() => {
+        this.surfaceController.open('https://example.com/video.mp4');
+      });
+  }
+}
+```
+
+`renderTick()` returns an `ErikaNativeResponse` for diagnostics and frame
+status. For audio-only playback, use `audioOnlyTick()` instead of rendering a
+surface. The package is not a Flutter plugin; Flutter applications should use
+`erika_flutter`.
 
 The package is licensed under MPL-2.0. See `THIRD_PARTY_NOTICES.md` for the
 licenses of the bundled native dependencies.

--- a/packaging/build_swift_xcframework.sh
+++ b/packaging/build_swift_xcframework.sh
@@ -64,7 +64,12 @@ xcodebuild -create-xcframework \
   -output "$XCFRAMEWORK"
 
 test ! -e "$OUTPUT_ZIP"
-ditto -c -k --sequesterRsrc --keepParent "$XCFRAMEWORK" "$OUTPUT_ZIP"
+(
+  cd "$WORK_DIR"
+  find CErika.xcframework -exec touch -t 198001010000 {} +
+  find CErika.xcframework -print | LC_ALL=C sort | \
+    COPYFILE_DISABLE=1 zip -X -q "$OUTPUT_ZIP" -@
+)
 unzip -tq "$OUTPUT_ZIP"
 
 echo "SwiftPM checksum: $(swift package compute-checksum "$OUTPUT_ZIP")"

--- a/readme/README.en.md
+++ b/readme/README.en.md
@@ -84,6 +84,20 @@ The package downloads the matching verified native runtime during the platform
 build. Android downloads only the selected ABI archive; Linux and Web are not
 published targets yet.
 
+### OpenHarmony package
+
+The native ArkTS package `erika` 0.1.7 is published on
+[OHPM](https://ohpm.openharmony.cn/#/cn/detail/erika) for OpenHarmony arm64
+applications (API 18+). Install it with:
+
+```sh
+ohpm install erika
+```
+
+This package is independent of Flutter. See the
+[OpenHarmony package guide](../packages/erika_ohos/README.md) for the
+`ErikaPlayer` API and `XComponent` surface setup.
+
 ## C ABI Families
 
 Erika provides two C ABI entrypoint families for different embedding scenarios:
@@ -114,6 +128,7 @@ crates/erika              Core playback library
 crates/erika_capi         C ABI export layer
 crates/erika_ffmpeg_sys   Low-level FFmpeg bindings
 packages/erika_flutter    Flutter plugin (macOS + iOS + tvOS + Windows + Android + HarmonyOS)
+packages/erika_ohos       OpenHarmony ArkTS / OHPM package
 examples/                 Validation and demo programs
 xtask/                    Native dependency build orchestration
 docs/                     Architecture and embedding documentation

--- a/readme/README.ja.md
+++ b/readme/README.ja.md
@@ -83,6 +83,20 @@ flutter pub add erika_flutter
 platform build 時に対応する検証済み native runtime を download します。Android
 では選択された ABI の archive だけを download します。Linux と Web はまだ公開対象ではありません。
 
+### OpenHarmony パッケージ
+
+ネイティブ ArkTS パッケージ `erika` 0.1.7 は
+[OHPM](https://ohpm.openharmony.cn/#/cn/detail/erika) で公開されています。
+OpenHarmony arm64（API 18 以上）のアプリには次のコマンドで追加できます：
+
+```sh
+ohpm install erika
+```
+
+このパッケージは Flutter に依存しません。`ErikaPlayer` API と
+`XComponent` サーフェスの設定は
+[OpenHarmony パッケージガイド](../packages/erika_ohos/README.md)を参照してください。
+
 ## C ABI インターフェースファミリー
 
 異なる組み込みシナリオに対応する二つの C ABI エントリーポイントファミリーを提供します：
@@ -113,6 +127,7 @@ crates/erika              コア再生ライブラリ
 crates/erika_capi         C ABI エクスポート層
 crates/erika_ffmpeg_sys   FFmpeg 低レベルバインディング
 packages/erika_flutter    Flutter プラグイン (macOS + iOS + tvOS + Windows + Android + HarmonyOS)
+packages/erika_ohos       OpenHarmony ArkTS / OHPM パッケージ
 examples/                 検証・デモプログラム
 xtask/                    ネイティブ依存関係ビルドオーケストレーション
 docs/                     アーキテクチャと組み込みドキュメント


### PR DESCRIPTION
## 变更

- 原生 `vX.Y.Z` Release 成功后统一发布 pub.dev 和 OHPM
- 自动更新 Flutter/OHPM 版本与原生归档 SHA-256
- 自动组装 Swift XCFramework 并触发 ErikaSwift 更新、测试、打 tag 和 Release
- 保留各发布 workflow 的手动入口
- 修复版本替换写成字面量 `${VERSION}` 的问题

## 验证

- 所有 workflow YAML 均可解析
- package 版本、SHA manifest 和跨仓库 dispatch 之间的输入已对齐
- 未触发真实发版