### PR TITLE
Windows D3D11: composition swap chains that keep COM identity

### DIFF
--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -671,8 +671,12 @@ impl WgpuSurfaceHandle {
 pub struct SurfaceOutputCapabilities {
     /// The display/window host is eligible for an extended-linear signal.
     pub extended_linear: bool,
-    /// The native surface bypasses Flutter texture-layer composition (for
-    /// Android this means a SurfaceView hosted with Hybrid Composition).
+    /// The native surface bypasses Flutter texture-layer composition.
+    ///
+    /// Android: a SurfaceView hosted with Hybrid Composition (extended-linear HDR).
+    /// Windows D3D11: create an `IDXGISwapChain1` with
+    /// `CreateSwapChainForComposition` instead of `CreateSwapChainForHwnd`.
+    /// Default `false` leaves the HWND swap-chain path unchanged.
     pub direct_composition: bool,
     /// Requested display headroom ratio relative to SDR reference white.
     pub desired_headroom: f32,
@@ -808,6 +812,25 @@ pub trait RendererBackend {
     /// this for queryable runtime status; renderers that do not expose dynamic
     /// display headroom may ignore the update.
     fn set_output_headroom(&mut self, _headroom: f32, _known: bool) {}
+
+    /// Borrowed COM identity of a DirectComposition swap chain. No `AddRef`.
+    ///
+    /// Compare this pointer across frames. Only call
+    /// [`Self::composition_swapchain_iunknown`] when transferring a reference
+    /// into `IDCompositionVisual::SetContent`. `None` unless this renderer
+    /// currently owns a composition swap chain.
+    fn composition_swapchain_ptr(&self) -> Option<*mut std::ffi::c_void> {
+        None
+    }
+
+    /// AddRef'd `IUnknown` for a DirectComposition `SetContent` swap chain.
+    ///
+    /// Null-free raw pointer; the caller owns the reference and must `Release`
+    /// it (for example by wrapping it in a host `DcompContent`). `None` unless
+    /// this renderer currently owns a composition swap chain.
+    fn composition_swapchain_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -748,6 +748,23 @@ impl PresenterRuntime {
         self.renderer.detach_surface()
     }
 
+    /// Borrowed COM identity of a DirectComposition swap chain. No `AddRef`.
+    ///
+    /// Compare this pointer across frames. Only call
+    /// [`Self::composition_swapchain_iunknown`] when transferring a reference
+    /// into `IDCompositionVisual::SetContent`.
+    pub fn composition_swapchain_ptr(&self) -> Option<*mut std::ffi::c_void> {
+        self.renderer.composition_swapchain_ptr()
+    }
+
+    /// AddRef'd `IUnknown` for a DirectComposition `SetContent` swap chain.
+    ///
+    /// The caller owns the reference and must `Release` it (for example by
+    /// wrapping it in a host `DcompContent`).
+    pub fn composition_swapchain_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        self.renderer.composition_swapchain_iunknown()
+    }
+
     pub fn resize_surface(&mut self, width: u32, height: u32, scale: f64) -> Result<()> {
         let metrics = SurfaceMetrics::new(width, height, scale);
         let previous_metrics = self.current_surface_metrics;

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -34,10 +34,10 @@ use ::windows::Win32::Graphics::Dxgi::{
     DXGI_ERROR_WAS_STILL_DRAWING, DXGI_HDR_METADATA_HDR10, DXGI_HDR_METADATA_TYPE_HDR10,
     DXGI_HDR_METADATA_TYPE_NONE, DXGI_PRESENT_DO_NOT_WAIT, DXGI_PRESENT_PARAMETERS,
     DXGI_SCALING_STRETCH, DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT, DXGI_SWAP_CHAIN_DESC1,
-    DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT, IDXGIAdapter, IDXGIDevice,
-    IDXGIFactory2, IDXGISwapChain1, IDXGISwapChain3, IDXGISwapChain4,
+    DXGI_SWAP_CHAIN_FLAG, DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
+    IDXGIAdapter, IDXGIDevice, IDXGIFactory2, IDXGISwapChain1, IDXGISwapChain3, IDXGISwapChain4,
 };
-use ::windows::core::{Interface, PCSTR};
+use ::windows::core::{IUnknown, Interface, PCSTR};
 
 use crate::core::{
     ColorPrimaries, LumaUpscalerBackendStatus, PlatformSurface, PlayerError, PlayerVideoFrame,
@@ -577,6 +577,7 @@ struct D3d11DeviceState {
 
 struct AttachedSurface {
     hwnd: HWND,
+    composition: bool,
     metrics: SurfaceMetrics,
     output_mode: D3d11OutputMode,
     swapchain: Option<IDXGISwapChain1>,
@@ -795,6 +796,15 @@ impl D3d11Renderer {
         {
             report_upscaler_failure("pipeline_build", self.upscaler_mode, &error);
         }
+        // The existing swap chain belongs to the previous device; ResizeBuffers
+        // cannot migrate it. Drop it so recreate_surface_targets creates a new
+        // one — COM identity changes, which the host must rebind.
+        if let Some(old) = self.state.as_ref() {
+            if let Some(surface) = self.surface.as_mut() {
+                release_backbuffer_views(&old.context, surface);
+                surface.swapchain = None;
+            }
+        }
         self.state = Some(state);
         self.recreate_surface_targets()?;
         Ok(())
@@ -807,39 +817,55 @@ impl D3d11Renderer {
         let Some(state) = self.state.as_ref() else {
             return Ok(());
         };
-        trace("recreate_surface_targets: reset");
-        surface.render_target = None;
-        surface.linear_render_target = None;
-        surface.linear_shader_resource = None;
-        surface.swapchain = None;
+        trace("recreate_surface_targets: reset views");
+        release_backbuffer_views(&state.context, surface);
         let output_mode = surface.output_mode;
-        trace("recreate_surface_targets: create_swapchain");
-        surface.swapchain = Some(create_swapchain(
-            &state.device,
-            surface.hwnd,
-            surface.metrics.physical_extent.width,
-            surface.metrics.physical_extent.height,
-            output_mode.swapchain_format(),
-        )?);
-        configure_swapchain_color_space(
-            surface.swapchain.as_ref().expect("swapchain just created"),
-            output_mode,
-        )?;
+        let width = surface.metrics.physical_extent.width.max(1);
+        let height = surface.metrics.physical_extent.height.max(1);
+        let format = output_mode.swapchain_format();
+        let hwnd = surface.hwnd;
+        let composition = surface.composition;
+
+        // Size and SDR↔HDR format changes keep the same IDXGISwapChain1 so a
+        // DirectComposition visual's SetContent stays valid. Device changes
+        // drop the chain in set_device before reaching here.
+        let reused = if let Some(swapchain) = surface.swapchain.as_ref() {
+            trace("recreate_surface_targets: ResizeBuffers");
+            unsafe {
+                swapchain
+                    .ResizeBuffers(0, width, height, format, DXGI_SWAP_CHAIN_FLAG(0))
+                    .is_ok()
+            }
+        } else {
+            false
+        };
+        if !reused {
+            if surface.swapchain.is_some() {
+                trace("recreate_surface_targets: ResizeBuffers failed, creating new swapchain");
+            } else {
+                trace("recreate_surface_targets: create_swapchain");
+            }
+            surface.swapchain = None;
+            surface.swapchain = Some(create_swapchain(
+                &state.device,
+                hwnd,
+                width,
+                height,
+                format,
+                composition,
+            )?);
+        }
+        let swapchain = surface.swapchain.as_ref().expect("swapchain ensured");
+        configure_swapchain_color_space(swapchain, output_mode)?;
         if matches!(output_mode, D3d11OutputMode::Sdr) {
-            let _ = clear_hdr_metadata(surface.swapchain.as_ref().expect("swapchain just created"));
+            let _ = clear_hdr_metadata(swapchain);
         }
         trace("recreate_surface_targets: create_render_target");
-        surface.render_target = Some(create_render_target(
-            &state.device,
-            surface.swapchain.as_ref().expect("swapchain just created"),
-        )?);
+        surface.render_target = Some(create_render_target(&state.device, swapchain)?);
         if matches!(output_mode, D3d11OutputMode::Hdr10) {
             trace("recreate_surface_targets: create_linear_render_target");
-            let (render_target, shader_resource) = create_linear_render_target(
-                &state.device,
-                surface.metrics.physical_extent.width,
-                surface.metrics.physical_extent.height,
-            )?;
+            let (render_target, shader_resource) =
+                create_linear_render_target(&state.device, width, height)?;
             surface.linear_render_target = Some(render_target);
             surface.linear_shader_resource = Some(shader_resource);
         }
@@ -847,6 +873,14 @@ impl D3d11Renderer {
         self.stats.surface_height = surface.metrics.physical_extent.height;
         self.stats.hdr10_output_active = matches!(output_mode, D3d11OutputMode::Hdr10);
         Ok(())
+    }
+
+    fn composition_swapchain(&self) -> Option<&IDXGISwapChain1> {
+        let surface = self.surface.as_ref()?;
+        if !surface.composition {
+            return None;
+        }
+        surface.swapchain.as_ref()
     }
 
     fn set_output_mode(&mut self, output_mode: D3d11OutputMode) -> Result<()> {
@@ -1524,13 +1558,15 @@ impl RendererBackend for D3d11Renderer {
                 handle.kind
             )));
         }
-        if handle.raw_window == 0 {
+        let composition = handle.output_capabilities.direct_composition;
+        if !composition && handle.raw_window == 0 {
             return Err(PlayerError::Renderer(
                 "d3d11: Windows HWND surface handle is null".to_string(),
             ));
         }
         self.surface = Some(AttachedSurface {
             hwnd: HWND(handle.raw_window as *mut c_void),
+            composition,
             metrics: handle.metrics,
             output_mode: D3d11OutputMode::Sdr,
             swapchain: None,
@@ -1680,6 +1716,15 @@ impl RendererBackend for D3d11Renderer {
                 report_upscaler_failure("mode_switch", mode, &error);
             }
         }
+    }
+
+    fn composition_swapchain_ptr(&self) -> Option<*mut std::ffi::c_void> {
+        Some(Interface::as_raw(self.composition_swapchain()?))
+    }
+
+    fn composition_swapchain_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        let unknown: IUnknown = self.composition_swapchain()?.cast().ok()?;
+        Some(unknown.into_raw())
     }
 }
 
@@ -2099,6 +2144,7 @@ fn create_swapchain(
     width: u32,
     height: u32,
     format: DXGI_FORMAT,
+    composition: bool,
 ) -> Result<IDXGISwapChain1> {
     trace("create_swapchain: cast IDXGIDevice");
     let dxgi_device: IDXGIDevice = device
@@ -2126,9 +2172,16 @@ fn create_swapchain(
         AlphaMode: DXGI_ALPHA_MODE_IGNORE,
         Flags: 0,
     };
-    trace("create_swapchain: CreateSwapChainForHwnd");
-    let swapchain = unsafe { factory.CreateSwapChainForHwnd(device, hwnd, &desc, None, None) }
-        .map_err(|error| d3d_error("IDXGIFactory2::CreateSwapChainForHwnd", error))?;
+    let swapchain = if composition {
+        trace("create_swapchain: CreateSwapChainForComposition");
+        unsafe { factory.CreateSwapChainForComposition(device, &desc, None) }.map_err(|error| {
+            d3d_error("IDXGIFactory2::CreateSwapChainForComposition", error)
+        })?
+    } else {
+        trace("create_swapchain: CreateSwapChainForHwnd");
+        unsafe { factory.CreateSwapChainForHwnd(device, hwnd, &desc, None, None) }
+            .map_err(|error| d3d_error("IDXGIFactory2::CreateSwapChainForHwnd", error))?
+    };
     trace("create_swapchain: done");
     Ok(swapchain)
 }
@@ -2177,6 +2230,19 @@ fn clear_hdr_metadata(swapchain: &IDXGISwapChain1) -> Result<()> {
         .map_err(|error| d3d_error("IDXGISwapChain1::cast<IDXGISwapChain4>", error))?;
     unsafe { swapchain4.SetHDRMetaData(DXGI_HDR_METADATA_TYPE_NONE, None) }
         .map_err(|error| d3d_error("IDXGISwapChain4::SetHDRMetaData(None)", error))
+}
+
+fn release_backbuffer_views(context: &ID3D11DeviceContext, surface: &mut AttachedSurface) {
+    // ResizeBuffers / creating a new chain requires every RTV and SRV of the
+    // current back buffer to be gone, including those bound on the immediate
+    // context.
+    unsafe {
+        context.OMSetRenderTargets(None, None);
+        context.PSSetShaderResources(0, Some(&[None, None]));
+    }
+    surface.render_target = None;
+    surface.linear_render_target = None;
+    surface.linear_shader_resource = None;
 }
 
 fn create_render_target(

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -2174,9 +2174,8 @@ fn create_swapchain(
     };
     let swapchain = if composition {
         trace("create_swapchain: CreateSwapChainForComposition");
-        unsafe { factory.CreateSwapChainForComposition(device, &desc, None) }.map_err(|error| {
-            d3d_error("IDXGIFactory2::CreateSwapChainForComposition", error)
-        })?
+        unsafe { factory.CreateSwapChainForComposition(device, &desc, None) }
+            .map_err(|error| d3d_error("IDXGIFactory2::CreateSwapChainForComposition", error))?
     } else {
         trace("create_swapchain: CreateSwapChainForHwnd");
         unsafe { factory.CreateSwapChainForHwnd(device, hwnd, &desc, None, None) }


### PR DESCRIPTION
## Summary

The Windows D3D11 renderer can now create a **composition swap chain** (`CreateSwapChainForComposition`) from surface capabilities and hand that chain to the caller as a COM pointer for `IDCompositionVisual::SetContent`. The HWND path (`CreateSwapChainForHwnd`) remains the default and is unchanged.

This PR also removes two reasons the caller would have to `SetContent` again and again:

1. **Identity checks do not `AddRef`.** Compare a borrowed pointer every frame; take an `IUnknown` reference only when actually binding.
2. **Size and SDR↔HDR use `ResizeBuffers`.** The swap-chain COM object stays the same, so the last `SetContent` on the visual stays valid.

A new chain is still created on first attach and on device loss. COM identity changes then, and the caller must rebind.

## Motivation

DirectComposition remembers a **COM pointer**, not “whichever chain Erika is presenting right now.” The D3D11 renderer used to set `swapchain = None` and call `CreateSwapChainFor*` on every resize and output-mode change. New object, old visual: the picture went black until the caller happened to bind again.

`QueryInterface` + `AddRef` + immediate `Release` every frame, just to compare addresses, is also unnecessary. The raw `IDXGISwapChain1` pointer is enough for identity.

## HWND vs composition

| | HWND path (default) | Composition path |
| --- | --- | --- |
| Flag | `SurfaceOutputCapabilities.direct_composition == false` | `true` |
| Create | `CreateSwapChainForHwnd` | `CreateSwapChainForComposition` |
| HWND | Must be non-null | May be null (the caller owns the window) |
| Present | DXGI presents to that HWND | Caller `IDCompositionVisual::SetContent` |
| Pointer getters | Both return `None` | See below |
| Who should use it | Standalone windows, popups, existing demos | Callers that hang the video layer in the same DWM tree |

`direct_composition` originally meant Android Hybrid Composition / extended-linear HDR. Windows D3D11 **reuses the same field** to mean “create a composition swap chain.” Default `false` leaves existing HWND callers unchanged.

Erika does **not** create a DComp device, build a visual tree, or `Commit`. That is the caller’s job.

## API

### Surface capabilities

```rust
handle.with_output_capabilities(SurfaceOutputCapabilities {
    direct_composition: true,
    ..Default::default()
});
```

The flag is read at attach. Changing it later cannot turn an HWND chain into a composition chain (DXGI cannot do that). Detach and attach again to switch paths.

### Pointer ownership (two getters)

| Method | Refcount | Use |
| --- | --- | --- |
| `composition_swapchain_ptr()` | **No** `AddRef` | Compare COM identity across frames |
| `composition_swapchain_iunknown()` | `AddRef`s one `IUnknown` | Pass to `SetContent`; the caller must `Release` |

Both return `None` when there is no composition swap chain (HWND path, not yet attached, already detached).

`ptr()` is the raw `IDXGISwapChain1` pointer, **not** the result of `QueryInterface(IUnknown)`. Those are usually the same object, but the caller must **always compare `ptr()`**, never an `iunknown()` address against `ptr()`.

Suggested caller loop:

```rust
let identity = presenter.composition_swapchain_ptr()?;
if bound == identity {
    return; // identity unchanged; do not AddRef
}
let raw = presenter.composition_swapchain_iunknown()?;
unsafe {
    let content = IUnknown::from_raw(raw);
    visual.SetContent(&content)?;
    // `content` Releases on drop; SetContent holds its own reference
}
bound = identity;
```

Someone must `Release` the reference `iunknown()` hands over. Dropping the raw pointer leaks; wrapping it in `IUnknown::from_raw` is the safe pattern.

## `ResizeBuffers` vs recreate

`recreate_surface_targets` now:

1. Unbinds RTVs / SRVs from the pipeline and drops every back-buffer view (`ResizeBuffers` requires this).
2. **If a swap chain already exists:** `ResizeBuffers(0, w, h, format, 0)`. `0` keeps the buffer count. Format follows the current output mode (SDR `B8G8R8A8_UNORM` / HDR10 `R10G10B10A2_UNORM`).
3. On failure, or if there is no chain: drop the old object and `CreateSwapChainFor*`.
4. `SetColorSpace1` again, rebuild RTVs; HDR10 also rebuilds the scene-linear intermediate target.

| Event | Swap-chain COM identity | Caller `SetContent`? |
| --- | --- | --- |
| First attach | New | Yes |
| Width / height / DPI only | Unchanged | No |
| SDR ↔ HDR10 | Unchanged (`ResizeBuffers` changes format) | No |
| Recreate after `ResizeBuffers` failure | New | Yes |
| Device change (D3D11VA device ≠ current device) | New (the old chain belongs to the old device; it cannot `ResizeBuffers` onto a new one) | Yes |
| Detach | None | Unbind |

The HWND path also uses `ResizeBuffers`, so it skips a destroy/create and a possible flash. There is no DComp bind on that path; it is just the usual DXGI resize.

`set_device` drops the old chain before switching devices so the new device never `ResizeBuffers` a chain it does not own.

## How the caller binds

Erika does not bind the visual. Any code that hangs this chain on a DComp visual must re-`SetContent` when identity changes.

During a live resize the caller may skip `resize_surface` and let DComp scale the visual, then `ResizeBuffers` once the size settles. Identity is unchanged, so the bind is a no-op.

## Files

| File | Change |
| --- | --- |
| `crates/erika/src/core.rs` | Windows meaning of `direct_composition`; `composition_swapchain_ptr` / `composition_swapchain_iunknown` |
| `crates/erika/src/presenter.rs` | Forwards both getters |
| `crates/erika/src/renderer/d3d11.rs` | Composition create, `ResizeBuffers`, unbind RTVs, getters return only when `composition` |

## Out of scope

- DirectComposition device, visual tree, `Commit`
- How the caller’s UI reveals the video layer behind it
- Changing `AlphaMode`. The create desc still uses `DXGI_ALPHA_MODE_IGNORE`. The composition docs list UNSPECIFIED / PREMULTIPLIED / STRAIGHT; opaque video works in practice. Transparent video is a separate change.
- QIing an HWND chain into composition content (impossible)
- Non-Windows backends
- Android meaning of `direct_composition` (still Hybrid Composition)