### PR TITLE
Fix danmaku continuity across planner windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Danmaku
+
+- Kept both accepted and rejected placement decisions stable across sliding
+  planner windows, preventing dropped comments from reappearing mid-flight or
+  forcing visible comments onto another lane.
+- Decoupled host-provided danmaku IDs from internal layout identity and parse
+  optional JSON IDs as exact `u64` values without floating-point rounding.
+
 ## 0.1.7 - 2026-08-16
 
 ### Flutter package distribution

--- a/crates/erika/src/danmaku.rs
+++ b/crates/erika/src/danmaku.rs
@@ -41,8 +41,6 @@ const SCROLL_DURATION_REFERENCE_LOGICAL_WIDTH: f32 = 1280.0;
 const SCROLL_DURATION_MIN_WIDTH_SCALE: f32 = 0.9;
 const SCROLL_DURATION_MAX_WIDTH_SCALE: f32 = 1.3;
 const DEFAULT_DANMAKU_TRACK_ID: u64 = 1;
-const TRACK_ID_SHIFT: u64 = 48;
-const ITEM_ID_MASK: u64 = (1u64 << TRACK_ID_SHIFT) - 1;
 const MAX_CUSTOM_DANMAKU_FONT_BYTES: u64 = 64 * 1024 * 1024;
 pub const DANMAKU_DEBUG_BUCKETS: usize = 16;
 
@@ -725,6 +723,7 @@ impl DanmakuSession {
             return;
         }
         let mut items = Vec::new();
+        let mut layout_item_id = 1u64;
         for track in &self.tracks {
             if !track.enabled {
                 continue;
@@ -735,7 +734,12 @@ impl DanmakuSession {
                     continue;
                 };
                 let mut item = item.clone();
-                item.id = compose_track_item_id(track.id, item.id);
+                // Source IDs belong to the host's data model and may be large or
+                // duplicated across sources. Layout identity only has to be
+                // unique for this immutable session version, so allocate it here
+                // instead of packing two arbitrary u64 values into one.
+                item.id = layout_item_id;
+                layout_item_id += 1;
                 item.pts = pts;
                 items.push(item);
             }
@@ -1895,6 +1899,7 @@ pub struct DfmLayoutEngine {
     font_selection: DanmakuFontSelection,
     prepared: Option<DfmPreparedLayout>,
     stable_tracks: HashMap<u64, usize>,
+    rejected_items: BTreeSet<u64>,
     stable_viewport: Option<DanmakuViewport>,
 }
 
@@ -1909,6 +1914,7 @@ impl DfmLayoutEngine {
             font_selection: DanmakuFontSelection::default(),
             prepared: None,
             stable_tracks: HashMap::new(),
+            rejected_items: BTreeSet::new(),
             stable_viewport: None,
         }
     }
@@ -1916,7 +1922,7 @@ impl DfmLayoutEngine {
     pub fn set_timeline(&mut self, timeline: DanmakuTimeline) {
         self.timeline = timeline;
         self.prepared = None;
-        self.invalidate_stable_tracks();
+        self.invalidate_placement_history();
     }
 
     pub fn sync_timeline(&mut self, timeline: &DanmakuTimeline) {
@@ -1929,7 +1935,7 @@ impl DfmLayoutEngine {
     pub fn clear_timeline(&mut self) {
         self.timeline = DanmakuTimeline::default();
         self.prepared = None;
-        self.invalidate_stable_tracks();
+        self.invalidate_placement_history();
     }
 
     pub fn set_config(&mut self, config: DanmakuLayoutConfig) -> bool {
@@ -1956,6 +1962,7 @@ impl DfmLayoutEngine {
         }
         if layout_changed {
             self.prepared = None;
+            self.rejected_items.clear();
             // Track assignments are preferences, not hard constraints. Keeping
             // them across font-size and other layout changes lets overlapping
             // items stay in the same logical lane; the retainer will reject a
@@ -1976,7 +1983,7 @@ impl DfmLayoutEngine {
         self.rasterizer = DanmakuTextRasterizer::for_config_and_selection(&self.config, &selection);
         self.font_selection = selection;
         self.prepared = None;
-        self.invalidate_stable_tracks();
+        self.invalidate_placement_history();
         true
     }
 
@@ -2003,22 +2010,38 @@ impl DfmLayoutEngine {
 
     pub fn prepare(&mut self, viewport: DanmakuViewport, _generation: u64) -> DfmPreparedLayout {
         if self.stable_viewport != Some(viewport) {
-            self.invalidate_stable_tracks();
+            self.invalidate_placement_history();
             self.stable_viewport = Some(viewport);
         }
         let config = self.config.sanitized();
+        let planned_ids = self
+            .timeline
+            .items()
+            .iter()
+            .filter(|item| item.mode != DanmakuMode::Special)
+            .filter(|item| !self.rejected_items.contains(&item.id))
+            .map(|item| item.id)
+            .collect::<BTreeSet<_>>();
         let prepared = prepare_layout(
             &self.timeline,
             viewport,
             &config,
             &self.rasterizer,
             &self.stable_tracks,
+            &self.rejected_items,
         );
         let active_ids = prepared
             .items()
             .iter()
             .map(|item| item.id)
             .collect::<BTreeSet<_>>();
+        if config.enabled {
+            // A sliding window may forget older track occupancy, but it must not
+            // revise an item's original admission decision. Otherwise an item
+            // dropped at birth can reappear halfway across the screen.
+            self.rejected_items
+                .extend(planned_ids.difference(&active_ids).copied());
+        }
         self.stable_tracks
             .retain(|item_id, _| active_ids.contains(item_id));
         for item in prepared.items() {
@@ -2028,8 +2051,9 @@ impl DfmLayoutEngine {
         prepared
     }
 
-    pub fn invalidate_stable_tracks(&mut self) {
+    pub fn invalidate_placement_history(&mut self) {
         self.stable_tracks.clear();
+        self.rejected_items.clear();
         self.stable_viewport = None;
     }
 
@@ -2079,6 +2103,7 @@ fn prepare_layout(
     config: &DanmakuLayoutConfig,
     rasterizer: &DanmakuTextRasterizer,
     stable_tracks: &HashMap<u64, usize>,
+    rejected_items: &BTreeSet<u64>,
 ) -> DfmPreparedLayout {
     if timeline.is_empty() || !config.enabled {
         let dfm_layout = dfm::PreparedLayout {
@@ -2106,7 +2131,7 @@ fn prepare_layout(
     let source_count = timeline.items().len();
     let mut source_items = Vec::new();
     for source in timeline.items() {
-        if source.mode == DanmakuMode::Special {
+        if source.mode == DanmakuMode::Special || rejected_items.contains(&source.id) {
             continue;
         }
         let font_size =
@@ -2341,9 +2366,7 @@ fn item_from_json_value(value: &Value, fallback_id: u64) -> Result<DanmakuItem> 
         .and_then(parse_color_value)
         .unwrap_or(DanmakuColor::WHITE);
     Ok(DanmakuItem {
-        id: numeric_field(object, &["id"])
-            .map(|value| value as u64)
-            .unwrap_or(fallback_id),
+        id: u64_field(object, &["id"]).unwrap_or(fallback_id),
         pts: Duration::from_secs_f64(
             numeric_field(object, &["time", "t"])
                 .unwrap_or(0.0)
@@ -2374,6 +2397,16 @@ fn numeric_field(object: &serde_json::Map<String, Value>, keys: &[&str]) -> Opti
         .find_map(|key| object.get(*key))
         .and_then(|value| match value {
             Value::Number(value) => value.as_f64(),
+            Value::String(value) => value.parse().ok(),
+            _ => None,
+        })
+}
+
+fn u64_field(object: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(|value| match value {
+            Value::Number(value) => value.as_u64(),
             Value::String(value) => value.parse().ok(),
             _ => None,
         })
@@ -2468,11 +2501,6 @@ fn apply_track_offset(pts: Duration, offset_micros: i64) -> Option<Duration> {
         return Some(pts.saturating_add(Duration::from_micros(offset_micros as u64)));
     }
     pts.checked_sub(Duration::from_micros(offset_micros.unsigned_abs()))
-}
-
-fn compose_track_item_id(track_id: u64, item_id: u64) -> u64 {
-    let track_part = track_id.min((1u64 << (64 - TRACK_ID_SHIFT)) - 1) << TRACK_ID_SHIFT;
-    track_part | (item_id & ITEM_ID_MASK)
 }
 
 fn sanitize_f32(value: f32, fallback: f32) -> f32 {
@@ -2988,6 +3016,36 @@ mod tests {
     }
 
     #[test]
+    fn parses_json_ids_without_floating_point_rounding() {
+        let input = r#"[
+            {"id":9007199254740993,"time":1,"content":"first"},
+            {"id":"18446744073709551615","time":2,"content":"second"}
+        ]"#;
+        let timeline = DanmakuTimeline::from_json(input).unwrap();
+
+        assert_eq!(timeline.items()[0].id, 9_007_199_254_740_993);
+        assert_eq!(timeline.items()[1].id, u64::MAX);
+    }
+
+    #[test]
+    fn session_allocates_layout_ids_independently_of_source_ids() {
+        let mut first = item(1.0, "first", DanmakuMode::Scroll);
+        first.id = u64::MAX;
+        let mut second = item(2.0, "second", DanmakuMode::Scroll);
+        second.id = u64::MAX;
+        let timeline = DanmakuTimeline::new(vec![first, second]).unwrap();
+        let mut session = DanmakuSession::from_timeline(timeline);
+
+        let ids = session
+            .active_timeline()
+            .items()
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
     fn parses_json_lines_and_xml() {
         let jsonl = r#"{"t":1,"c":"a","y":"bottom","r":16777215}
 {"t":2,"c":"b","y":"scroll"}"#;
@@ -3170,6 +3228,56 @@ mod tests {
                 .stable_tracks
                 .keys()
                 .all(|item_id| second.items().iter().any(|item| item.id == *item_id))
+        );
+    }
+
+    #[test]
+    fn sliding_timeline_window_does_not_revive_rejected_items() {
+        let mut entries = vec![
+            item(0.0, "occupy", DanmakuMode::Scroll),
+            item(0.0, "occupy", DanmakuMode::Scroll),
+            item(
+                1.0,
+                "this rejected danmaku is deliberately very wide",
+                DanmakuMode::Scroll,
+            ),
+            item(4.0, "already visible", DanmakuMode::Scroll),
+        ];
+        for (index, entry) in entries.iter_mut().enumerate() {
+            entry.id = index as u64 + 1;
+        }
+        let timeline = DanmakuTimeline::new(entries).unwrap();
+        let config = DanmakuLayoutConfig {
+            track_gap_ratio: 0.0,
+            merge_duplicates: false,
+            ..DanmakuLayoutConfig::default()
+        };
+        let viewport = DanmakuViewport::new(320, 58);
+        let first_window = timeline.window(Duration::ZERO, Duration::from_secs(8));
+        let second_window = timeline.window(Duration::from_secs(1), Duration::from_secs(9));
+        let mut engine = DfmLayoutEngine::new(first_window, config);
+
+        let first = engine.prepare(viewport, 1);
+        assert!(!first.items().iter().any(|item| item.id == 3));
+        let original_track = first
+            .items()
+            .iter()
+            .find(|item| item.id == 4)
+            .expect("later item is placed after the first pair expires")
+            .track_index;
+
+        engine.sync_timeline(&second_window);
+        let second = engine.prepare(viewport, 1);
+
+        assert!(!second.items().iter().any(|item| item.id == 3));
+        assert_eq!(
+            second
+                .items()
+                .iter()
+                .find(|item| item.id == 4)
+                .expect("visible item remains prepared")
+                .track_index,
+            original_track
         );
     }
 

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -400,7 +400,7 @@ struct AsyncDanmakuPlannerState {
     config: DanmakuLayoutConfig,
     rasterizer: DanmakuTextRasterizer,
     latest_request: Option<AsyncDanmakuPlanRequest>,
-    invalidate_stable_tracks: bool,
+    invalidate_placement_history: bool,
     shutdown: bool,
 }
 
@@ -433,7 +433,7 @@ impl AsyncDanmakuPlanner {
             config,
             rasterizer,
             latest_request: None,
-            invalidate_stable_tracks: false,
+            invalidate_placement_history: false,
             shutdown: false,
         };
         let shared = Arc::new((Mutex::new(state), Condvar::new()));
@@ -526,7 +526,7 @@ impl AsyncDanmakuPlanner {
         if let Some(timeline) = timeline {
             if state.timeline != timeline {
                 state.timeline = timeline;
-                state.invalidate_stable_tracks = true;
+                state.invalidate_placement_history = true;
             }
         }
         if let Some(config) = config {
@@ -3060,14 +3060,14 @@ fn run_async_danmaku_planner(
             }
             seen_revision = state.revision;
             let config_update = (state.config_revision != applied_config_revision).then(|| {
-                let invalidate_stable_tracks = state.invalidate_stable_tracks;
-                state.invalidate_stable_tracks = false;
+                let invalidate_placement_history = state.invalidate_placement_history;
+                state.invalidate_placement_history = false;
                 (
                     state.config_revision,
                     state.timeline.clone(),
                     state.config.clone(),
                     state.rasterizer.clone(),
-                    invalidate_stable_tracks,
+                    invalidate_placement_history,
                 )
             });
             (state.latest_request, config_update)
@@ -3078,13 +3078,13 @@ fn run_async_danmaku_planner(
             next_timeline,
             next_config,
             next_rasterizer,
-            invalidate_stable_tracks,
+            invalidate_placement_history,
         )) = config_update
         {
             timeline = next_timeline;
             config = next_config;
-            if invalidate_stable_tracks {
-                engine.invalidate_stable_tracks();
+            if invalidate_placement_history {
+                engine.invalidate_placement_history();
             }
             engine.set_config_with_rasterizer(config.clone(), next_rasterizer);
             applied_config_revision = revision;
@@ -5090,30 +5090,41 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             presenter.add_danmaku_track(second, "second", DanmakuTrackSource::Json, -1_000_000);
 
         assert_eq!(presenter.danmaku_tracks().len(), 2);
-        let plan = presenter.danmaku.render_plan(
+        let layout = presenter.danmaku.frame_layout(
             Duration::from_millis(1500),
             DanmakuViewport::new(640, 360),
             1,
         );
-        assert!(plan.items.iter().any(|item| item.item_id >> 48 == first_id));
         assert!(
-            plan.items
+            layout
+                .items
                 .iter()
-                .any(|item| item.item_id >> 48 == second_id)
+                .any(|item| item.text.as_ref() == "first")
+        );
+        assert!(
+            layout
+                .items
+                .iter()
+                .any(|item| item.text.as_ref() == "second")
+        );
+        assert_eq!(
+            layout
+                .items
+                .iter()
+                .map(|item| item.item_id)
+                .collect::<HashSet<_>>()
+                .len(),
+            2
         );
 
         assert!(presenter.set_danmaku_track_enabled(first_id, false));
-        let plan = presenter.danmaku.render_plan(
+        let layout = presenter.danmaku.frame_layout(
             Duration::from_millis(1500),
             DanmakuViewport::new(640, 360),
             2,
         );
-        assert!(!plan.items.iter().any(|item| item.item_id >> 48 == first_id));
-        assert!(
-            plan.items
-                .iter()
-                .any(|item| item.item_id >> 48 == second_id)
-        );
+        assert_eq!(layout.items.len(), 1);
+        assert_eq!(layout.items[0].text.as_ref(), "second");
 
         assert!(presenter.remove_danmaku_track(second_id));
         assert_eq!(presenter.danmaku_tracks().len(), 1);

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -583,7 +583,8 @@ ErikaStatus erika_presenter_select_subtitle_track(
 /* Danmaku (bullet comments). load_* replaces danmaku with one anonymous track;
  * add_*_track builds a named multi-track list. Input is Bilibili XML (*_file,
  * by path/URL) or JSON (*_json, inline). offset_micros shifts one track's
- * timeline; the global offset shifts all. See docs/danmaku_architecture.md. */
+ * timeline; the global offset shifts all. The inline JSON schema is documented
+ * in docs/capi_reference.md; layout behavior is in docs/danmaku_architecture.md. */
 ErikaStatus erika_presenter_load_danmaku_file(
     ErikaPresenterHandle *handle,
     const char *uri);

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -403,6 +403,24 @@ XML（`*_file`、パス/URL）または JSON（`*_json`、インライン）。`
 [danmaku_architecture.md](danmaku_architecture.md) を参照。
 `set_danmaku_block_words_json` はフィルタ用の文字列 JSON 配列を取ります。
 
+inline JSON の root は item array、または `comments`、`danmaku`、`items` の
+いずれかの array を持つ object です。各 item は次の field を受け取ります
+（括弧内は alias）。
+
+- `content`（`text`、`c`）：本文。欠落または空白だけの item は skip されます。
+- `time`（`t`）：表示時刻（秒）。既定値は `0` です。
+- `type`（`mode`、`y`）：`scroll`/`1`、`bottom`/`4`、`top`/`5`、
+  `reverse`/`6`、`special`/`7`。数値の `type_code` / `mode_code` も使えます。
+- `color`（`r`）：decimal RGB、`#RRGGBB`、または `rgb(r,g,b)`。
+- `font_size`（`fontSize`、`size`、`s`）、`opacity`（`alpha`、`a`）、
+  `is_me`（`isMe`、`self`、`mine`）：任意の style / self-danmaku metadata。
+- `id`：任意の unsigned 64-bit integer または decimal string。省略時は入力全体での
+  item position が割り当てられます。session は別の内部 layout identity を生成するため、
+  planner window 間の track 安定性のために host が business ID を合成する必要はありません。
+
+未知の field は無視されるため、`cid` や `danmakuId` などの source field を含む
+standard map もそのまま渡せます。
+
 `set_debug_hud_enabled` は default で off です。on にすると Presenter は native video
 composition に diagnostic HUD を描画します。HUD は track technical metadata、
 playback state、decoded/rendered FPS、decode/zero-copy counters、render/audio state、HDR

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -444,6 +444,25 @@ tracks. `set_danmaku_config` / `_ptr` apply the full `ErikaDanmakuConfig` (the
 it back. See [danmaku_architecture.md](danmaku_architecture.md) for the layout
 engine. `set_danmaku_block_words_json` takes a JSON array of strings to filter.
 
+Inline JSON may be an item array or an object containing a `comments`,
+`danmaku`, or `items` array. Each item accepts these fields (aliases in
+parentheses):
+
+- `content` (`text`, `c`): text; an item with missing or blank text is skipped.
+- `time` (`t`): presentation time in seconds, defaulting to `0`.
+- `type` (`mode`, `y`): `scroll`/`1`, `bottom`/`4`, `top`/`5`, `reverse`/`6`,
+  or `special`/`7`. Numeric `type_code` / `mode_code` are also accepted.
+- `color` (`r`): decimal RGB, `#RRGGBB`, or `rgb(r,g,b)`.
+- `font_size` (`fontSize`, `size`, `s`), `opacity` (`alpha`, `a`), and `is_me`
+  (`isMe`, `self`, `mine`): optional style and self-danmaku metadata.
+- `id`: an optional unsigned 64-bit integer or decimal string. When omitted,
+  Erika assigns the item's position in the complete input. The session creates
+  a separate internal layout identity, so hosts do not need to synthesize a
+  business ID to keep tracks stable across planner windows.
+
+Unknown fields are ignored, so standard maps carrying source fields such as
+`cid` or `danmakuId` may be passed through unchanged.
+
 `set_debug_hud_enabled` is off by default. When enabled, the Presenter draws a
 native diagnostic HUD in the video composition. It shows track
 technical metadata, playback state, decoded/rendered FPS, decode and zero-copy

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -383,6 +383,21 @@ ErikaStatus erika_presenter_set_danmaku_block_words_json(ErikaPresenterHandle *,
 [danmaku_architecture.md](danmaku_architecture.md)。`set_danmaku_block_words_json`
 接受一个字符串 JSON 数组用于过滤。
 
+内联 JSON 的根可以是 item 数组，也可以是包含 `comments`、`danmaku` 或 `items`
+数组的对象。每个 item 使用以下字段；括号内是兼容别名：
+
+- `content`（`text`、`c`）：正文；缺失或空白的 item 会被跳过。
+- `time`（`t`）：出现时间，单位为秒，默认 `0`。
+- `type`（`mode`、`y`）：`scroll`/`1`、`bottom`/`4`、`top`/`5`、
+  `reverse`/`6` 或 `special`/`7`。也可使用数值 `type_code` / `mode_code`。
+- `color`（`r`）：十进制 RGB、`#RRGGBB` 或 `rgb(r,g,b)`。
+- `font_size`（`fontSize`、`size`、`s`）、`opacity`（`alpha`、`a`）、
+  `is_me`（`isMe`、`self`、`mine`）：可选样式和自发标记。
+- `id`：可选的无符号 64 位整数或十进制字符串。省略时按整份输入中的顺序分配；
+  session 会另外生成布局内部身份，因此调用方无需为了滑窗轨道稳定而合成业务 ID。
+
+未知字段会被忽略，因此包含 `cid`、`danmakuId` 等数据源字段的标准 map 可以直接传入。
+
 `set_debug_hud_enabled` 默认关闭。开启后 Presenter 在原生视频合成中绘制诊断 HUD，显示轨道
 技术信息、播放状态、实时解码/渲染 FPS、解码/零拷贝路径、渲染和音频状态、
 HDR 输出以及弹幕数量。HUD 只在已有视频帧时显示；其统计不要求调用方轮询，也不会写入

--- a/docs/danmaku_architecture.en.md
+++ b/docs/danmaku_architecture.en.md
@@ -84,7 +84,7 @@ The part that should be replaced “as close as possible to the original DFM+ co
 
 Its input should stay aligned with NipaPlay DFM+: normalized items, viewport, font metrics, and user config. Erika may use its own Rust types, but field semantics should match NipaPlay: time, text, type_code, color, is_me, paint_width/paint_height, display_area, scroll_duration, allow_stacking, merge, max_quantity, max_lines, track_gap, outline, block_words, and so on.
 
-Before DFM+, Erika adds `DanmakuSession`. It does not participate in layout; it only prepares an active timeline that DFM+ can consume. Multiple tracks may be enabled at once; per-track and global offsets are applied when building the active timeline; source item IDs are prefixed with the track ID to avoid collisions after multi-track merging. Seek should not force a re-prepare because generation changes; prepare should only be invalidated by timeline/session content, viewport, or config changes. Generation only gates current-frame output for the renderer.
+Before DFM+, Erika adds `DanmakuSession`. It does not participate in layout; it only prepares an active timeline that DFM+ can consume. Multiple tracks may be enabled at once, and per-track and global offsets are applied when building the active timeline. After merging, the session allocates unique layout item IDs for that content revision instead of packing host business IDs into layout identity. Consecutive planner windows carry both completed track assignments and rejection decisions forward; timeline/session content, viewport, or layout-config changes rebuild that planning history. Generation only gates current-frame output for the renderer.
 
 The output should also stay close to NipaPlay DFM+: prepared layout stores stable results, and frame query returns only the visible items and their positions for the current media time. Erika can then map `item_index` to text, colors, font size, outline, and so on to build `DanmakuFrameLayout` and `DanmakuRenderPlan`.
 
@@ -170,4 +170,3 @@ The API layer should expose the NipaPlay danmaku input surface to the player and
 The render layer should stay native to Erika. DFM+ outputs “where each danmaku item is at the current media time, and what style it has,” not GPU textures or Flutter resources. Erika's renderer turns that output into glyph atlases, quad instances, and Metal/WGPU composition together with video.
 
 The synchronization layer must keep the current generation + media_time contract. Seek, stop, close, track switch, and config change all invalidate the old plan; each frame query only looks at the video timeline; danmaku do not own a separate wall-clock timer. That contract is the real fix for “the video jumped but the danmaku didn't.”
-

--- a/docs/danmaku_architecture.ja.md
+++ b/docs/danmaku_architecture.ja.md
@@ -84,7 +84,7 @@ flowchart LR
 
 入力は NipaPlay DFM+ の抽象とそろえるべきです。つまり、正規化済み item、viewport、font metrics、user config です。Erika は独自の Rust 型を使っても構いませんが、field semantics は NipaPlay と一致していなければなりません。time、text、type_code、color、is_me、paint_width/paint_height、display_area、scroll_duration、allow_stacking、merge、max_quantity、max_lines、track_gap、outline、block_words などが DFM+ prepare に流れ込む必要があります。
 
-DFM+ の前段にある `DanmakuSession` は layout algorithm には参加しません。複数 track を同時に有効化でき、track ごとの offset と global offset は active timeline 構築時に適用され、source item id は track id で prefix されて multi-track merge 後の衝突を避けます。seek は generation が変わったという理由で prepare をやり直すべきではありません。prepare の失効条件は timeline/session の内容、viewport、config の変化です。generation は renderer の current-frame gate にだけ使います。
+DFM+ の前段にある `DanmakuSession` は layout algorithm には参加しません。複数 track を同時に有効化でき、track ごとの offset と global offset は active timeline 構築時に適用されます。merge 後は host の business id を layout identity に pack せず、session がその content revision 専用の一意な layout item id を割り当てます。連続する planner window は確定済みの track assignment と reject decision の両方を引き継ぎ、timeline/session content、viewport、layout config が変わったときだけ planning history を作り直します。generation は renderer の current-frame gate にだけ使います。
 
 出力側も NipaPlay DFM+ の抽象に近いままであるべきです。prepared layout は安定した結果を保持し、frame query は current media time に対する visible items と位置だけを返します。その後で Erika が `item_index` に対応する text、color、font size、outline などを `DanmakuFrameLayout` と `DanmakuRenderPlan` に変換します。
 
@@ -170,4 +170,3 @@ API layer は NipaPlay の弾幕 input surface を player と Flutter wrapper �
 render layer は Erika の native 実装として保つべきです。DFM+ が出力するのは「current media time で各弾幕がどこにあり、どんな style か」であって、GPU texture や Flutter resource ではありません。Erika renderer はその出力を glyph atlas、quad instances、Metal/WGPU 合成に変え、動画と一緒に描画します。
 
 synchronization layer は現在の generation + media_time 契約を維持しなければなりません。seek、stop、close、track switch、config change はすべて古い plan を無効化し、各 frame query は video timeline だけを見ます。弾幕は別の wall-clock timer を持ちません。この契約こそが「動画は跳んだのに弾幕が跳ばない」を解決する本体です。
-

--- a/docs/danmaku_architecture.md
+++ b/docs/danmaku_architecture.md
@@ -84,7 +84,7 @@ flowchart LR
 
 这一段的输入应保持 NipaPlay DFM+ 的抽象：规范化弹幕 item、viewport、字体测量结果、用户配置。Erika 可以用自己的 Rust 类型承载这些字段，但字段语义要对齐 NipaPlay：时间、文本、type_code、颜色、is_me、paint_width/paint_height、display_area、scroll_duration、allow_stacking、merge、max_quantity、max_lines、track_gap、outline、block_words 等都应进入 DFM+ prepare。
 
-在 DFM+ 之前，Erika 现在多了一层 `DanmakuSession`。它不参与布局算法，只负责把播放器/Flutter 传入的弹幕输入面整理成 DFM+ 能消费的一条 active timeline：多个弹幕轨可以同时启用，按轨 offset 和全局 offset 会在 active timeline 构建时应用，源 item id 会加上 track id 前缀以避免多轨合并后的 id 冲突。prepare 在独立 worker 上异步执行，plan 请求以 `{media_time, viewport, generation}` 为 key，其中任何一项变化都会触发重新 prepare；结果 plan 只覆盖一个时间窗口，播放时间离开窗口即作废，seek 后旧窗口的 plan 不会被继续使用。
+在 DFM+ 之前，Erika 现在多了一层 `DanmakuSession`。它不参与布局算法，只负责把播放器/Flutter 传入的弹幕输入面整理成 DFM+ 能消费的一条 active timeline：多个弹幕轨可以同时启用，按轨 offset 和全局 offset 会在 active timeline 构建时应用；合并完成后由 session 为当前内容版本分配唯一的布局 item id，不把宿主业务 id 打包进布局身份。prepare 在独立 worker 上异步执行，plan 请求以 `{media_time, viewport, generation}` 为 key，其中任何一项变化都会触发重新 prepare；结果 plan 只覆盖一个时间窗口。连续窗口会继承已经完成的轨道分配和拒绝决定，只有 timeline/session 内容、viewport 或布局配置变化才会重建这段规划历史。
 
 这一段的输出也应保持 NipaPlay DFM+ 的抽象：prepared layout 保存稳定布局结果；frame query 只根据 media time 输出当前 visible items 的 index 和位置。Erika 之后再把 item_index 对应的文本、颜色、字号、描边等样式转换成 `DanmakuFrameLayout` 和 `DanmakuRenderPlan`。
 

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -583,7 +583,8 @@ ErikaStatus erika_presenter_select_subtitle_track(
 /* Danmaku (bullet comments). load_* replaces danmaku with one anonymous track;
  * add_*_track builds a named multi-track list. Input is Bilibili XML (*_file,
  * by path/URL) or JSON (*_json, inline). offset_micros shifts one track's
- * timeline; the global offset shifts all. See docs/danmaku_architecture.md. */
+ * timeline; the global offset shifts all. The inline JSON schema is documented
+ * in docs/capi_reference.md; layout behavior is in docs/danmaku_architecture.md. */
 ErikaStatus erika_presenter_load_danmaku_file(
     ErikaPresenterHandle *handle,
     const char *uri);

--- a/packages/erika_ohos/src/main/cpp/include/erika.h
+++ b/packages/erika_ohos/src/main/cpp/include/erika.h
@@ -582,7 +582,8 @@ ErikaStatus erika_presenter_select_subtitle_track(
 /* Danmaku (bullet comments). load_* replaces danmaku with one anonymous track;
  * add_*_track builds a named multi-track list. Input is Bilibili XML (*_file,
  * by path/URL) or JSON (*_json, inline). offset_micros shifts one track's
- * timeline; the global offset shifts all. See docs/danmaku_architecture.md. */
+ * timeline; the global offset shifts all. The inline JSON schema is documented
+ * in docs/capi_reference.md; layout behavior is in docs/danmaku_architecture.md. */
 ErikaStatus erika_presenter_load_danmaku_file(
     ErikaPresenterHandle *handle,
     const char *uri);


### PR DESCRIPTION
## Summary

- preserve both accepted track assignments and rejected admission decisions across consecutive asynchronous planner windows
- prevent previously dropped scrolling comments from reappearing mid-flight and moving visible comments to another lane
- allocate session-local layout identities instead of packing host IDs into 48 bits
- parse optional JSON IDs as exact unsigned 64-bit values and document the inline JSON contract in Chinese, English, and Japanese

## Root cause

The planner retained tracks only for prepared items. A comment rejected in one window had no persistent decision, so after the lookback boundary moved it could be admitted by a later replay even though its start time had passed. Host IDs also passed through floating-point conversion and a lossy low-48-bit composition, allowing unrelated comments to share stable-track state.

## Validation

- cargo test -p erika -p erika_capi
- 519 Erika unit tests passed
- 6 ArtCNN reference tests passed, 2 benchmark tests ignored
- 5 WGPU tests passed
- 34 C API tests passed
- cargo fmt --all -- --check
- git diff --check

Closes #118