### PR TITLE
feat: 支持透明视频与跨平台原生 GPU 合成

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - When the first audio stream cannot be decoded, try the remaining audio
   streams in container order and report all decoder failures if none can be
   opened.
+- Added packed-alpha video presentation with premultiplied GPU output on
+  Windows and macOS, including native backdrop-aware overlay composition.
 
 ## 0.1.7 - 2026-08-16
 

--- a/crates/erika/src/android.rs
+++ b/crates/erika/src/android.rs
@@ -1190,7 +1190,7 @@ pub mod aaudio {
 
     fn normalize_playback_rate(rate: f64) -> f64 {
         if rate.is_finite() && rate > 0.0 {
-            rate.clamp(0.25, 4.0)
+            rate.clamp(0.25, 16.0)
         } else {
             1.0
         }

--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -971,7 +971,7 @@ fn offset_pts_scaled(
 
 fn normalize_playback_rate(rate: f64) -> f64 {
     if rate.is_finite() && rate > 0.0 {
-        rate.clamp(0.25, 4.0)
+        rate.clamp(0.25, 16.0)
     } else {
         1.0
     }
@@ -981,6 +981,12 @@ fn normalize_playback_rate(rate: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::ffmpeg::PcmSampleFormat;
+
+    #[test]
+    fn playback_rate_supports_short_form_video_acceleration() {
+        assert_eq!(normalize_playback_rate(4.8), 4.8);
+        assert_eq!(normalize_playback_rate(32.0), 16.0);
+    }
 
     fn stereo_format() -> PcmFormat {
         PcmFormat {

--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -770,6 +770,20 @@ pub trait RendererBackend {
     /// caller fall back to a test frame.
     fn render_current_frame(&mut self, context: RenderFrameContext<'_>) -> Result<bool>;
 
+    /// Selects the native GPU texture that receives the next Flutter texture
+    /// frame. Apple embedders pass an `id<MTLTexture>` pointer as `raw_texture`.
+    /// Backends without an external Flutter texture path reject the request.
+    fn set_flutter_texture_buffer(
+        &mut self,
+        _raw_texture: u64,
+        _width: u32,
+        _height: u32,
+    ) -> Result<()> {
+        Err(PlayerError::Renderer(
+            "external Flutter texture buffers are not supported by this renderer".to_string(),
+        ))
+    }
+
     /// Render the retained current frame into an offscreen RGBA buffer.
     fn capture_current_frame(
         &mut self,

--- a/crates/erika/src/ohos.rs
+++ b/crates/erika/src/ohos.rs
@@ -1134,7 +1134,7 @@ pub mod ohaudio {
 
     fn normalize_playback_rate(rate: f64) -> f64 {
         if rate.is_finite() && rate > 0.0 {
-            rate.clamp(0.25, 4.0)
+            rate.clamp(0.25, 16.0)
         } else {
             1.0
         }

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -1808,6 +1808,26 @@ impl PresenterRuntime {
             .map(|capture| capture.map(|capture| capture.rgba))
     }
 
+    /// Selects the external Flutter texture written by the next render tick.
+    ///
+    /// The platform plugin owns the texture and keeps it alive for the entire
+    /// call. The renderer retains the native object until another buffer is
+    /// selected or the surface is detached.
+    pub fn set_flutter_texture_buffer(
+        &mut self,
+        raw_texture: u64,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        if raw_texture == 0 || width == 0 || height == 0 {
+            return Err(PlayerError::Renderer(
+                "Flutter texture buffer and dimensions must be non-zero".to_string(),
+            ));
+        }
+        self.renderer
+            .set_flutter_texture_buffer(raw_texture, width, height)
+    }
+
     fn capture_overlay(&mut self, width: u32, height: u32) -> OverlayFrame {
         let capture_overlay_viewport = OverlayViewport::new(width, height);
         let mut capture_overlay = self
@@ -3570,11 +3590,10 @@ fn build_audio_output(config: PresenterAudioConfig) -> Box<dyn AudioOutputBacken
 #[cfg(feature = "wgpu")]
 fn build_wgpu_renderer(config: MetalRendererConfig) -> Result<Box<dyn RendererBackend>> {
     #[cfg(target_os = "android")]
-    let mut renderer = crate::renderer::wgpu::AndroidRecoveringWgpuRenderer::new_with_output_mode(
-        config.output_mode,
-    )?;
+    let mut renderer =
+        crate::renderer::wgpu::AndroidRecoveringWgpuRenderer::new_with_config(config)?;
     #[cfg(not(target_os = "android"))]
-    let mut renderer = crate::renderer::wgpu::WgpuRenderer::new()?;
+    let mut renderer = crate::renderer::wgpu::WgpuRenderer::new_with_config(config)?;
     renderer.set_luma_upscaler(config.luma_upscaler);
     #[cfg(not(target_os = "android"))]
     if config.output_mode.is_edr() {

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -23,7 +23,7 @@ use ::windows::Win32::Graphics::Direct3D11::{
     ID3D11Texture2D, ID3D11VertexShader,
 };
 use ::windows::Win32::Graphics::Dxgi::Common::{
-    DXGI_ALPHA_MODE_IGNORE, DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
+    DXGI_ALPHA_MODE_IGNORE, DXGI_ALPHA_MODE_PREMULTIPLIED, DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
     DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020, DXGI_COLOR_SPACE_TYPE, DXGI_FORMAT,
     DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_FORMAT_NV12, DXGI_FORMAT_P010, DXGI_FORMAT_R8_UNORM,
     DXGI_FORMAT_R8G8_UNORM, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R10G10B10A2_UNORM,
@@ -877,6 +877,7 @@ impl D3d11Renderer {
                 height,
                 format,
                 composition,
+                composition && self.video_alpha_mode.has_alpha(),
             )?);
         }
         let swapchain = surface.swapchain.as_ref().expect("swapchain ensured");
@@ -928,6 +929,17 @@ impl D3d11Renderer {
         let source_is_hdr = source.is_hdr();
         if source_is_hdr {
             self.stats.hdr_source_frames += 1;
+        }
+        // DirectComposition transparency is defined on the SDR premultiplied
+        // swap-chain path. Packed-alpha assets are effects/UI content rather
+        // than an HDR presentation plane, so keep their color and alpha in one
+        // stable BGRA8 composition space.
+        if self.video_alpha_mode.has_alpha() {
+            self.set_output_mode(D3d11OutputMode::Sdr)?;
+            if source_is_hdr {
+                self.stats.sdr_tonemap_frames += 1;
+            }
+            return Ok(D3d11OutputMode::Sdr);
         }
         if matches!(source.transfer, TransferFunction::Pq)
             && self.try_enable_hdr10_output(source)?
@@ -1570,7 +1582,16 @@ impl D3d11Renderer {
             .as_ref()
             .ok_or_else(|| PlayerError::Renderer("d3d11: no render target attached".to_string()))?;
         let _ = time_seconds;
-        let color = [0.0, 0.0, 0.0, 1.0];
+        let color = [
+            0.0,
+            0.0,
+            0.0,
+            if self.video_alpha_mode.has_alpha() {
+                0.0
+            } else {
+                1.0
+            },
+        ];
         unsafe {
             trace("render_clear: clear");
             state.context.ClearRenderTargetView(rtv, &color);
@@ -2186,6 +2207,7 @@ fn create_swapchain(
     height: u32,
     format: DXGI_FORMAT,
     composition: bool,
+    premultiplied_alpha: bool,
 ) -> Result<IDXGISwapChain1> {
     trace("create_swapchain: cast IDXGIDevice");
     let dxgi_device: IDXGIDevice = device
@@ -2210,7 +2232,11 @@ fn create_swapchain(
         BufferCount: 2,
         Scaling: DXGI_SCALING_STRETCH,
         SwapEffect: DXGI_SWAP_EFFECT_FLIP_DISCARD,
-        AlphaMode: DXGI_ALPHA_MODE_IGNORE,
+        AlphaMode: if premultiplied_alpha {
+            DXGI_ALPHA_MODE_PREMULTIPLIED
+        } else {
+            DXGI_ALPHA_MODE_IGNORE
+        },
         Flags: 0,
     };
     let swapchain = if composition {

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -50,7 +50,7 @@ use crate::danmaku::{
 use crate::ffmpeg::Frame;
 use crate::overlay::OverlayFrame;
 use crate::renderer::d3d11_artcnn::D3d11ArtCnn;
-use crate::renderer::metal::MetalRendererConfig;
+use crate::renderer::metal::{MetalRendererConfig, VideoAlphaMode};
 use crate::renderer::output::{
     ActiveOutputEncoding, OutputFallbackReason, OutputRuntimeStatus, OutputSurfaceFormat,
 };
@@ -239,18 +239,23 @@ float3 target_reference_linear_to_output(float3 rgb) {
     return rgb;
 }
 
-float4 final_output(float3 rgb) {
+float4 final_output(float3 rgb, float alpha) {
+    float3 output_rgb;
     if (scene_linear != 0u) {
-        return float4(max(rgb, float3(0.0, 0.0, 0.0)), 1.0);
+        output_rgb = max(rgb, float3(0.0, 0.0, 0.0)) * alpha;
+        return float4(output_rgb, alpha);
     }
     if (target_transfer == 3u) {
-        return float4(clamp(rgb, float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)), 1.0);
+        output_rgb = clamp(rgb, float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)) * alpha;
+        return float4(output_rgb, alpha);
     }
     if (edr_output != 0u) {
         float headroom = max(target_peak_nits() / target_reference_white_nits(), 1.0);
-        return float4(clamp(rgb, float3(0.0, 0.0, 0.0), float3(headroom, headroom, headroom)), 1.0);
+        output_rgb = clamp(rgb, float3(0.0, 0.0, 0.0), float3(headroom, headroom, headroom)) * alpha;
+        return float4(output_rgb, alpha);
     }
-    return float4(clamp(rgb, float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)), 1.0);
+    output_rgb = clamp(rgb, float3(0.0, 0.0, 0.0), float3(1.0, 1.0, 1.0)) * alpha;
+    return float4(output_rgb, alpha);
 }
 
 void expand_ycbcr_range(float y_in, float2 cbcr_in, out float y, out float2 cbcr) {
@@ -316,9 +321,15 @@ float sample_packed_luma(float2 texcoord) {
 }
 
 float4 ps_main(VsOut input) : SV_Target {
-    float2 luma_coord = input.texcoord * texture_scales.xy;
-    float2 chroma_coord = input.texcoord * texture_scales.zw;
-    float y_sample = input_mode == 2u
+    uint base_input_mode = input_mode & 255u;
+    bool packed_alpha = (input_mode & 256u) != 0u;
+    float2 color_coord = packed_alpha
+        ? float2(input.texcoord.x * 0.5, input.texcoord.y)
+        : input.texcoord;
+    float2 alpha_coord = float2(0.5 + input.texcoord.x * 0.5, input.texcoord.y);
+    float2 luma_coord = color_coord * texture_scales.xy;
+    float2 chroma_coord = color_coord * texture_scales.zw;
+    float y_sample = base_input_mode == 2u
         ? sample_packed_luma(luma_coord)
         : lumaTex.Sample(videoSampler, luma_coord).r;
     float2 cbcr_sample = chromaTex.Sample(videoSampler, chroma_coord).rg;
@@ -339,13 +350,24 @@ float4 ps_main(VsOut input) : SV_Target {
     rgb = tone_map_nits(rgb);
     rgb = target_nits_to_reference_linear(rgb);
     rgb = target_reference_linear_to_output(rgb);
-    return final_output(rgb);
+    float alpha = 1.0;
+    if (packed_alpha) {
+        float alpha_sample = lumaTex.Sample(
+            videoSampler,
+            alpha_coord * texture_scales.xy
+        ).r;
+        float unused_y;
+        float2 unused_cbcr;
+        expand_ycbcr_range(alpha_sample, float2(0.5, 0.5), unused_y, unused_cbcr);
+        alpha = saturate(unused_y);
+    }
+    return final_output(rgb, alpha);
 }
 
 float4 encode_ps_main(VsOut input) : SV_Target {
     float3 rgb = lumaTex.Sample(videoSampler, input.texcoord).rgb;
     rgb = target_reference_linear_to_output(rgb);
-    return final_output(rgb);
+    return final_output(rgb, 1.0);
 }
 "#;
 
@@ -727,6 +749,7 @@ pub struct D3d11Renderer {
     current_video: Option<ImportedVideoFrame>,
     danmaku_atlas_cache: Option<D3d11DanmakuAtlasCache>,
     requested_output_mode: crate::renderer::output::OutputMode,
+    video_alpha_mode: VideoAlphaMode,
     upscaler_mode: LumaUpscalerMode,
     upscaler: D3d11ArtCnn,
     next_frame_token: u64,
@@ -746,6 +769,7 @@ impl D3d11Renderer {
             current_video: None,
             danmaku_atlas_cache: None,
             requested_output_mode: config.output_mode,
+            video_alpha_mode: config.video_alpha_mode,
             upscaler_mode: config.luma_upscaler,
             upscaler: D3d11ArtCnn::default(),
             next_frame_token: 0,
@@ -1024,7 +1048,8 @@ impl D3d11Renderer {
             ),
             _array_index: array_index,
             frame_token,
-            constants: constants_for_frame(source_color, texture_format, target_color),
+            constants: constants_for_frame(source_color, texture_format, target_color)
+                .packed_alpha_right(self.video_alpha_mode.has_alpha()),
         });
         Ok(())
     }
@@ -1407,9 +1432,15 @@ impl D3d11Renderer {
             .expect("surface ensured")
             .metrics
             .physical_extent;
-        let target_rect =
-            aspect_fit_rect(video_width, video_height, physical.width, physical.height);
-        let upscale_requested = self.upscaler_mode.is_enabled()
+        let logical_video_width = self.video_alpha_mode.logical_width(video_width);
+        let target_rect = aspect_fit_rect(
+            logical_video_width,
+            video_height,
+            physical.width,
+            physical.height,
+        );
+        let upscale_requested = !self.video_alpha_mode.has_alpha()
+            && self.upscaler_mode.is_enabled()
             && self.upscaler.status() == LumaUpscalerBackendStatus::Scalar
             && target_rect.width > video_width as f32;
         let upscaled_luma = if upscale_requested {
@@ -1460,9 +1491,19 @@ impl D3d11Renderer {
             .as_ref()
             .ok_or_else(|| PlayerError::Renderer("d3d11: no swapchain attached".to_string()))?;
         unsafe {
-            state
-                .context
-                .ClearRenderTargetView(scene_rtv, &[0.0, 0.0, 0.0, 1.0]);
+            state.context.ClearRenderTargetView(
+                scene_rtv,
+                &[
+                    0.0,
+                    0.0,
+                    0.0,
+                    if self.video_alpha_mode.has_alpha() {
+                        0.0
+                    } else {
+                        1.0
+                    },
+                ],
+            );
         }
         state.draw_video(video, upscaled_luma.as_ref(), scene_rtv, target_rect)?;
         if !overlay_draws.is_empty() {

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -53,8 +53,9 @@ use crate::renderer::metal::upscaler::LumaUpscaler;
 use crate::renderer::metal::{
     ClearColor, DanmakuRenderFrame, ImportedVideoFormat, ImportedVideoFrameInfo,
     ImportedVideoPlaneInfo, MetalDrawablePixelFormat, MetalOutputMode, MetalRendererConfig,
-    MetalRendererStats, OverlayRenderFrame, PreparedOverlayFrameInfo, VideoFrameTextureSource,
-    VideoRenderFrame, fourcc_string, metal_drawable_pixel_format, metal_target_color,
+    MetalRendererStats, OverlayRenderFrame, PreparedOverlayFrameInfo, VideoAlphaMode,
+    VideoFrameTextureSource, VideoRenderFrame, fourcc_string, metal_drawable_pixel_format,
+    metal_target_color,
 };
 use crate::renderer::pipeline::{ColorRange, LumaUpscalerMode, ToneMapOperator};
 use crate::renderer::pipeline::{SourceColorState, TargetColorState};
@@ -118,8 +119,11 @@ pub struct MetalRendererImpl {
     queue: Retained<ProtocolObject<dyn MTLCommandQueue>>,
     requested_output_mode: MetalOutputMode,
     output_mode: MetalOutputMode,
+    video_alpha_mode: VideoAlphaMode,
     drawable_pixel_format: MetalDrawablePixelFormat,
     layer: Option<Retained<CAMetalLayer>>,
+    flutter_texture_attached: bool,
+    flutter_texture: Option<Retained<ProtocolObject<dyn MTLTexture>>>,
     texture_cache: Option<CFRetained<CVMetalTextureCache>>,
     video_pipeline: Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>,
     overlay_pipeline: Option<Retained<ProtocolObject<dyn MTLRenderPipelineState>>>,
@@ -164,8 +168,11 @@ impl MetalRendererImpl {
             queue,
             requested_output_mode: config.output_mode,
             output_mode: initial_output_mode,
+            video_alpha_mode: config.video_alpha_mode,
             drawable_pixel_format: metal_drawable_pixel_format(initial_output_mode),
             layer: None,
+            flutter_texture_attached: false,
+            flutter_texture: None,
             texture_cache: None,
             video_pipeline: None,
             overlay_pipeline: None,
@@ -204,25 +211,82 @@ impl MetalRendererImpl {
         layer.setDevice(Some(&*self.device));
         self.configure_layer_output(&layer);
         self.layer = Some(layer);
+        self.flutter_texture_attached = false;
+        self.flutter_texture = None;
         self.resize_surface(metrics);
+        Ok(())
+    }
+
+    pub fn attach_flutter_texture(&mut self, metrics: SurfaceMetrics) {
+        self.layer = None;
+        self.flutter_texture_attached = true;
+        self.flutter_texture = None;
+        self.output_mode = MetalOutputMode::Sdr;
+        self.drawable_pixel_format = MetalDrawablePixelFormat::Bgra8Unorm;
+        self.video_pipeline = None;
+        self.overlay_pipeline = None;
+        self.danmaku_batch_pipeline = None;
+        self.resize_surface(metrics);
+    }
+
+    pub unsafe fn set_flutter_texture_buffer(
+        &mut self,
+        raw_texture: *mut c_void,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        if !self.flutter_texture_attached {
+            return Err(PlayerError::Renderer(
+                "no Flutter texture surface attached".to_string(),
+            ));
+        }
+        if raw_texture.is_null() || width == 0 || height == 0 {
+            return Err(PlayerError::Renderer(
+                "Flutter Metal texture and dimensions must be non-zero".to_string(),
+            ));
+        }
+        let texture: Retained<ProtocolObject<dyn MTLTexture>> = unsafe {
+            Retained::retain(raw_texture.cast())
+        }
+        .ok_or_else(|| PlayerError::Renderer("failed to retain Flutter MTLTexture".to_string()))?;
+        if texture.pixelFormat() != MTLPixelFormat::BGRA8Unorm {
+            return Err(PlayerError::Renderer(format!(
+                "Flutter MTLTexture must use BGRA8Unorm, got {:?}",
+                texture.pixelFormat()
+            )));
+        }
+        if texture.width() != width as usize || texture.height() != height as usize {
+            return Err(PlayerError::Renderer(format!(
+                "Flutter MTLTexture size {}x{} does not match {width}x{height}",
+                texture.width(),
+                texture.height()
+            )));
+        }
+        self.stats.drawable_width = width;
+        self.stats.drawable_height = height;
+        self.flutter_texture = Some(texture);
         Ok(())
     }
 
     pub fn detach_surface(&mut self) {
         self.layer = None;
+        self.flutter_texture_attached = false;
+        self.flutter_texture = None;
     }
 
     pub fn resize_surface(&mut self, metrics: SurfaceMetrics) {
-        let Some(layer) = &self.layer else {
-            return;
-        };
         let (width, height) = metrics.physical_size();
         let drawable_width = width as f64;
         let drawable_height = height as f64;
-        let size = CGSize::new(drawable_width, drawable_height);
-        layer.setDrawableSize(size);
         self.stats.drawable_width = drawable_width.round() as u32;
         self.stats.drawable_height = drawable_height.round() as u32;
+        if let Some(layer) = &self.layer {
+            let size = CGSize::new(drawable_width, drawable_height);
+            layer.setDrawableSize(size);
+        }
+        if self.flutter_texture_attached {
+            self.flutter_texture = None;
+        }
     }
 
     pub fn stats(&self) -> MetalRendererStats {
@@ -303,7 +367,14 @@ impl MetalRendererImpl {
         if source_is_hdr {
             self.stats.hdr_source_frames = self.stats.hdr_source_frames.saturating_add(1);
         }
-        let selected = self.requested_output_mode.resolve_for_source(source_is_hdr);
+        // Flutter's macOS texture registrar currently consumes BGRA8
+        // CVPixelBuffers, so this compositor path is explicitly SDR. HDR input
+        // is tone-mapped rather than changing the external texture format.
+        let selected = if self.flutter_texture_attached {
+            MetalOutputMode::Sdr
+        } else {
+            self.requested_output_mode.resolve_for_source(source_is_hdr)
+        };
         if selected != self.output_mode {
             self.set_output_mode(selected);
         }
@@ -417,33 +488,44 @@ impl MetalRendererImpl {
     }
 
     pub fn has_surface(&self) -> bool {
-        self.layer.is_some()
+        self.layer.is_some() || self.flutter_texture_attached
     }
 
     pub fn render_clear(&mut self, color: ClearColor) -> Result<()> {
-        let Some(layer) = &self.layer else {
-            return Err(PlayerError::Renderer(
-                "no CAMetalLayer attached".to_string(),
-            ));
-        };
         let started = Instant::now();
+        let color = if self.video_alpha_mode.has_alpha() {
+            ClearColor {
+                red: 0.0,
+                green: 0.0,
+                blue: 0.0,
+                alpha: 0.0,
+            }
+        } else {
+            color
+        };
 
         unsafe {
-            let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
-                layer.nextDrawable()
-            else {
-                // A drained drawable pool is temporary backpressure, not a
-                // renderer fault: every acquisition path reports it the same
-                // way so callers can skip the frame instead of failing.
+            let (drawable, texture) = if let Some(layer) = &self.layer {
+                let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
+                    layer.nextDrawable()
+                else {
+                    return Err(PlayerError::RendererBackpressure(
+                        "CAMetalLayer nextDrawable returned nil".to_string(),
+                    ));
+                };
+                let texture = drawable.texture();
+                (Some(drawable), texture)
+            } else if let Some(texture) = self.flutter_texture.as_ref().cloned() {
+                (None, texture)
+            } else {
                 return Err(PlayerError::RendererBackpressure(
-                    "CAMetalLayer nextDrawable returned nil".to_string(),
+                    "Flutter texture buffer is not ready".to_string(),
                 ));
             };
 
             let descriptor = MTLRenderPassDescriptor::new();
             let attachments = descriptor.colorAttachments();
             let attachment = attachments.objectAtIndexedSubscript(0);
-            let texture = drawable.texture();
             attachment.setTexture(Some(&*texture));
             attachment.setLoadAction(MTLLoadAction::Clear);
             attachment.setStoreAction(MTLStoreAction::Store);
@@ -466,10 +548,21 @@ impl MetalRendererImpl {
                 ));
             };
             encoder.endEncoding();
-            let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
-                ProtocolObject::from_ref(&*drawable);
-            command_buffer.presentDrawable(drawable_ref);
+            if let Some(drawable) = &drawable {
+                let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
+                    ProtocolObject::from_ref(&**drawable);
+                command_buffer.presentDrawable(drawable_ref);
+            }
             command_buffer.commit();
+            if drawable.is_none() {
+                command_buffer.waitUntilCompleted();
+                if command_buffer.status() != MTLCommandBufferStatus::Completed {
+                    return Err(PlayerError::Renderer(format!(
+                        "Flutter texture clear failed with status {:?}",
+                        command_buffer.status()
+                    )));
+                }
+            }
             self.last_submitted_command_buffer = Some(command_buffer);
         }
 
@@ -510,28 +603,28 @@ impl MetalRendererImpl {
     }
 
     pub fn render_overlay_frame(&mut self, overlay: OverlayRenderFrame<'_>) -> Result<()> {
-        let Some(layer) = &self.layer else {
-            return Err(PlayerError::Renderer(
-                "no CAMetalLayer attached".to_string(),
-            ));
-        };
-
         unsafe {
-            let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
-                layer.nextDrawable()
-            else {
-                // A drained drawable pool is temporary backpressure, not a
-                // renderer fault: every acquisition path reports it the same
-                // way so callers can skip the frame instead of failing.
+            let (drawable, texture) = if let Some(layer) = &self.layer {
+                let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
+                    layer.nextDrawable()
+                else {
+                    return Err(PlayerError::RendererBackpressure(
+                        "CAMetalLayer nextDrawable returned nil".to_string(),
+                    ));
+                };
+                let texture = drawable.texture();
+                (Some(drawable), texture)
+            } else if let Some(texture) = self.flutter_texture.as_ref().cloned() {
+                (None, texture)
+            } else {
                 return Err(PlayerError::RendererBackpressure(
-                    "CAMetalLayer nextDrawable returned nil".to_string(),
+                    "Flutter texture buffer is not ready".to_string(),
                 ));
             };
 
             let descriptor = MTLRenderPassDescriptor::new();
             let attachments = descriptor.colorAttachments();
             let attachment = attachments.objectAtIndexedSubscript(0);
-            let texture = drawable.texture();
             attachment.setTexture(Some(&*texture));
             attachment.setLoadAction(MTLLoadAction::Clear);
             attachment.setStoreAction(MTLStoreAction::Store);
@@ -569,10 +662,21 @@ impl MetalRendererImpl {
                 ),
             )?;
             encoder.endEncoding();
-            let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
-                ProtocolObject::from_ref(&*drawable);
-            command_buffer.presentDrawable(drawable_ref);
+            if let Some(drawable) = &drawable {
+                let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
+                    ProtocolObject::from_ref(&**drawable);
+                command_buffer.presentDrawable(drawable_ref);
+            }
             command_buffer.commit();
+            if drawable.is_none() {
+                command_buffer.waitUntilCompleted();
+                if command_buffer.status() != MTLCommandBufferStatus::Completed {
+                    return Err(PlayerError::Renderer(format!(
+                        "Flutter texture overlay failed with status {:?}",
+                        command_buffer.status()
+                    )));
+                }
+            }
             self.last_submitted_command_buffer = Some(command_buffer);
         }
 
@@ -598,12 +702,6 @@ impl MetalRendererImpl {
         self.stats.last_danmaku_encode_duration = Duration::ZERO;
         self.stats.last_danmaku_vertex_bytes = 0;
         self.stats.last_danmaku_vertex_count = 0;
-        let Some(layer) = self.layer.as_ref().cloned() else {
-            return Err(PlayerError::Renderer(
-                "no CAMetalLayer attached".to_string(),
-            ));
-        };
-
         let Some(textures) = frame.frame.inner.as_ref() else {
             return Err(PlayerError::Renderer(
                 "imported video frame has no Metal textures".to_string(),
@@ -622,7 +720,9 @@ impl MetalRendererImpl {
 
         let source_color = frame.pipeline.source;
         self.select_output_mode_for_source(source_color);
-        self.configure_layer_source_color(&layer, source_color);
+        if let Some(layer) = self.layer.as_ref().cloned() {
+            self.configure_layer_source_color(&layer, source_color);
+        }
         frame.pipeline = frame
             .pipeline
             .with_target(metal_target_color(self.output_mode, source_color));
@@ -655,8 +755,11 @@ impl MetalRendererImpl {
         self.collect_gpu_timing();
         self.stats.last_upscaler_encode_duration = Duration::ZERO;
 
+        let logical_width = self
+            .video_alpha_mode
+            .logical_width(frame.frame.info.width as u32);
         let layout = VideoPresentationLayout::aspect_fit(
-            frame.frame.info.width as u32,
+            logical_width,
             frame.frame.info.height as u32,
             self.stats.drawable_width,
             self.stats.drawable_height,
@@ -706,18 +809,27 @@ impl MetalRendererImpl {
             }
             let luma: &ProtocolObject<dyn MTLTexture> = upscaled_luma.as_deref().unwrap_or(luma);
 
-            let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
-                layer.nextDrawable()
-            else {
+            let (drawable, texture) = if let Some(layer) = &self.layer {
+                let Some(drawable): Option<Retained<ProtocolObject<dyn CAMetalDrawable>>> =
+                    layer.nextDrawable()
+                else {
+                    return Err(PlayerError::RendererBackpressure(
+                        "CAMetalLayer nextDrawable returned nil".to_string(),
+                    ));
+                };
+                let texture = drawable.texture();
+                (Some(drawable), texture)
+            } else if let Some(texture) = self.flutter_texture.as_ref().cloned() {
+                (None, texture)
+            } else {
                 return Err(PlayerError::RendererBackpressure(
-                    "CAMetalLayer nextDrawable returned nil".to_string(),
+                    "Flutter texture buffer is not ready".to_string(),
                 ));
             };
 
             let descriptor = MTLRenderPassDescriptor::new();
             let attachments = descriptor.colorAttachments();
             let attachment = attachments.objectAtIndexedSubscript(0);
-            let texture = drawable.texture();
             attachment.setTexture(Some(&*texture));
             attachment.setLoadAction(MTLLoadAction::Clear);
             attachment.setStoreAction(MTLStoreAction::Store);
@@ -725,7 +837,11 @@ impl MetalRendererImpl {
                 red: 0.0,
                 green: 0.0,
                 blue: 0.0,
-                alpha: 1.0,
+                alpha: if self.video_alpha_mode.has_alpha() {
+                    0.0
+                } else {
+                    1.0
+                },
             });
 
             let Some(encoder) = command_buffer.renderCommandEncoderWithDescriptor(&descriptor)
@@ -741,7 +857,7 @@ impl MetalRendererImpl {
                 target_transfer: transfer_code(frame.pipeline.target.transfer),
                 tone_map: tone_map_code(frame.pipeline.tone_map.operator),
                 edr_output: self.output_mode.is_edr() as u32,
-                _reserved0: 0,
+                _reserved0: self.video_alpha_mode as u32,
                 _reserved1: 0,
                 rect: layout.target_rect,
                 viewport: layout.video_viewport(),
@@ -795,10 +911,21 @@ impl MetalRendererImpl {
             }
 
             encoder.endEncoding();
-            let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
-                ProtocolObject::from_ref(&*drawable);
-            command_buffer.presentDrawable(drawable_ref);
+            if let Some(drawable) = &drawable {
+                let drawable_ref: &ProtocolObject<dyn MTLDrawable> =
+                    ProtocolObject::from_ref(&**drawable);
+                command_buffer.presentDrawable(drawable_ref);
+            }
             command_buffer.commit();
+            if drawable.is_none() {
+                command_buffer.waitUntilCompleted();
+                if command_buffer.status() != MTLCommandBufferStatus::Completed {
+                    return Err(PlayerError::Renderer(format!(
+                        "Flutter texture frame failed with status {:?}",
+                        command_buffer.status()
+                    )));
+                }
+            }
             self.last_submitted_command_buffer = Some(command_buffer.clone());
             self.pending_gpu_timing = Some(command_buffer);
         }
@@ -2653,7 +2780,7 @@ struct VideoUniforms {
     uint target_transfer;
     uint tone_map;
     uint edr_output;
-    uint reserved0;
+    uint video_alpha_mode;
     uint reserved1;
     float4 rect;
     float4 viewport;
@@ -2802,15 +2929,19 @@ float3 target_reference_linear_to_output(float3 rgb, constant VideoUniforms& uni
     return rgb;
 }
 
-float4 final_output(float3 rgb, constant VideoUniforms& uniforms) {
+float4 final_output(float3 rgb, float alpha, constant VideoUniforms& uniforms) {
+    float3 premultiplied;
     if (uniforms.target_transfer == 3) {
-        return float4(clamp(rgb, 0.0, 1.0), 1.0);
+        premultiplied = clamp(rgb, 0.0, 1.0) * alpha;
+        return float4(premultiplied, alpha);
     }
     if (uniforms.edr_output != 0) {
         float headroom = max(target_peak_nits(uniforms) / target_reference_white_nits(uniforms), 1.0);
-        return float4(clamp(rgb, 0.0, headroom), 1.0);
+        premultiplied = clamp(rgb, 0.0, headroom) * alpha;
+        return float4(premultiplied, alpha);
     }
-    return float4(clamp(rgb, 0.0, 1.0), 1.0);
+    premultiplied = clamp(rgb, 0.0, 1.0) * alpha;
+    return float4(premultiplied, alpha);
 }
 
 float3 sdr_ui_color_to_target_output(float3 rgb, uint target_transfer, float reference_white_nits) {
@@ -2880,8 +3011,13 @@ fragment float4 erika_video_fragment(
     texture2d<float, access::sample> chroma_texture [[texture(1)]],
     sampler video_sampler [[sampler(0)]],
     constant VideoUniforms& uniforms [[buffer(0)]]) {
-    float y = luma_texture.sample(video_sampler, in.tex_coord).r;
-    float2 cbcr = chroma_texture.sample(video_sampler, in.tex_coord).rg;
+    bool packed_alpha = uniforms.video_alpha_mode == 1;
+    float2 color_coord = packed_alpha
+        ? float2(in.tex_coord.x * 0.5, in.tex_coord.y)
+        : in.tex_coord;
+    float2 alpha_coord = float2(0.5 + in.tex_coord.x * 0.5, in.tex_coord.y);
+    float y = luma_texture.sample(video_sampler, color_coord).r;
+    float2 cbcr = chroma_texture.sample(video_sampler, color_coord).rg;
     RangeExpandedYCbCr expanded = expand_ycbcr_range(y, cbcr, uniforms);
     y = expanded.y;
     cbcr = expanded.cbcr;
@@ -2899,7 +3035,12 @@ fragment float4 erika_video_fragment(
     rgb = tone_map_nits(rgb, uniforms);
     rgb = target_nits_to_reference_linear(rgb, uniforms);
     rgb = target_reference_linear_to_output(rgb, uniforms);
-    return final_output(rgb, uniforms);
+    float alpha = 1.0;
+    if (packed_alpha) {
+        float alpha_sample = luma_texture.sample(video_sampler, alpha_coord).r;
+        alpha = clamp(expand_ycbcr_range(alpha_sample, float2(0.5), uniforms).y, 0.0, 1.0);
+    }
+    return final_output(rgb, alpha, uniforms);
 }
 
 struct OverlayUniforms {
@@ -3199,7 +3340,16 @@ mod tests {
             VIDEO_SHADER_SOURCE
                 .contains("target_peak_nits(uniforms) / target_reference_white_nits(uniforms)")
         );
-        assert!(VIDEO_SHADER_SOURCE.contains("return final_output(rgb, uniforms)"));
+        assert!(VIDEO_SHADER_SOURCE.contains("return final_output(rgb, alpha, uniforms)"));
+    }
+
+    #[test]
+    fn video_shader_reconstructs_packed_alpha_as_premultiplied_output() {
+        assert!(VIDEO_SHADER_SOURCE.contains("uniforms.video_alpha_mode == 1"));
+        assert!(VIDEO_SHADER_SOURCE.contains("in.tex_coord.x * 0.5"));
+        assert!(VIDEO_SHADER_SOURCE.contains("0.5 + in.tex_coord.x * 0.5"));
+        assert!(VIDEO_SHADER_SOURCE.contains("premultiplied = clamp(rgb"));
+        assert!(VIDEO_SHADER_SOURCE.contains("float4(premultiplied, alpha)"));
     }
 
     #[test]

--- a/crates/erika/src/renderer/metal/mod.rs
+++ b/crates/erika/src/renderer/metal/mod.rs
@@ -2,9 +2,9 @@ use std::ffi::c_void;
 use std::time::Duration;
 
 use crate::core::{
-    ColorPrimaries, LumaUpscalerBackendStatus, PlatformSurface, PlayerError, PlayerVideoFrame,
-    RenderFrameContext, RendererBackend, RendererFrameCapture, RendererResourceStats,
-    RendererRuntimeStats, Result, SurfaceMetrics, TransferFunction,
+    ColorPrimaries, FlutterTextureKind, LumaUpscalerBackendStatus, PlatformSurface, PlayerError,
+    PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererFrameCapture,
+    RendererResourceStats, RendererRuntimeStats, Result, SurfaceMetrics, TransferFunction,
 };
 use crate::danmaku::DanmakuRenderPlan;
 use crate::ffmpeg::{Frame, PlanarFrame};
@@ -74,6 +74,41 @@ pub struct MetalRenderer {
 pub struct MetalRendererConfig {
     pub output_mode: MetalOutputMode,
     pub luma_upscaler: LumaUpscalerMode,
+    pub video_alpha_mode: VideoAlphaMode,
+}
+
+/// Describes how a decoded video frame carries transparency.
+///
+/// `PackedAlphaRight` expects a side-by-side frame: the left half contains
+/// colour and the right half contains a grayscale alpha mask. Renderers expose
+/// the left half as the logical video size and reconstruct premultiplied alpha
+/// in the presentation shader.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum VideoAlphaMode {
+    #[default]
+    Opaque = 0,
+    PackedAlphaRight = 1,
+}
+
+impl VideoAlphaMode {
+    pub fn from_raw(value: i32) -> Self {
+        match value {
+            1 => Self::PackedAlphaRight,
+            _ => Self::Opaque,
+        }
+    }
+
+    pub fn has_alpha(self) -> bool {
+        matches!(self, Self::PackedAlphaRight)
+    }
+
+    pub fn logical_width(self, encoded_width: u32) -> u32 {
+        match self {
+            Self::Opaque => encoded_width,
+            Self::PackedAlphaRight => (encoded_width / 2).max(1),
+        }
+    }
 }
 
 impl Default for MetalRendererConfig {
@@ -81,6 +116,7 @@ impl Default for MetalRendererConfig {
         Self {
             output_mode: MetalOutputMode::default(),
             luma_upscaler: LumaUpscalerMode::default(),
+            video_alpha_mode: VideoAlphaMode::default(),
         }
     }
 }
@@ -689,9 +725,30 @@ impl RendererBackend for MetalRenderer {
             PlatformSurface::Wgpu(_) => Err(crate::core::PlayerError::Renderer(
                 "wgpu surface cannot be attached to MetalRenderer".to_string(),
             )),
-            PlatformSurface::FlutterTexture(_) => Err(crate::core::PlayerError::Renderer(
-                "Flutter texture cannot be attached to MetalRenderer".to_string(),
-            )),
+            PlatformSurface::FlutterTexture(handle)
+                if matches!(
+                    handle.kind,
+                    FlutterTextureKind::MacOsTextureRegistrar
+                        | FlutterTextureKind::IosTextureRegistrar
+                ) =>
+            {
+                #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+                {
+                    self.inner.attach_flutter_texture(handle.metrics);
+                    Ok(())
+                }
+                #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+                {
+                    let _ = handle;
+                    Err(PlayerError::Renderer(
+                        "Apple Flutter textures require an Apple Metal renderer".to_string(),
+                    ))
+                }
+            }
+            PlatformSurface::FlutterTexture(handle) => Err(PlayerError::Renderer(format!(
+                "Flutter texture kind {:?} cannot be attached to MetalRenderer",
+                handle.kind
+            ))),
         }
     }
 
@@ -855,6 +912,28 @@ impl RendererBackend for MetalRenderer {
             ));
         }
         rendered
+    }
+
+    fn set_flutter_texture_buffer(
+        &mut self,
+        raw_texture: u64,
+        width: u32,
+        height: u32,
+    ) -> Result<()> {
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        {
+            unsafe {
+                self.inner
+                    .set_flutter_texture_buffer(raw_texture as *mut c_void, width, height)
+            }
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+        {
+            let _ = (raw_texture, width, height);
+            Err(PlayerError::Renderer(
+                "Metal Flutter textures are only available on Apple platforms".to_string(),
+            ))
+        }
     }
 
     fn capture_current_frame(

--- a/crates/erika/src/renderer/pipeline.rs
+++ b/crates/erika/src/renderer/pipeline.rs
@@ -1,5 +1,8 @@
 use crate::core::{ColorPrimaries, TransferFunction};
 
+pub const VIDEO_INPUT_MODE_MASK: u32 = 0xff;
+pub const VIDEO_INPUT_PACKED_ALPHA_RIGHT: u32 = 1 << 8;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct HdrMetadata {
     pub mastering_display: Option<MasteringDisplayMetadata>,
@@ -676,18 +679,31 @@ impl VideoUniforms {
     }
 
     pub fn rgb_texture_input(mut self) -> Self {
-        self.input_mode = 1;
+        self.input_mode = (self.input_mode & !VIDEO_INPUT_MODE_MASK) | 1;
         self
     }
 
     pub fn packed_d2s_luma_input(mut self) -> Self {
-        self.input_mode = 2;
+        self.input_mode = (self.input_mode & !VIDEO_INPUT_MODE_MASK) | 2;
         self
     }
 
     pub fn packed_d2s_rgb_detail_input(mut self) -> Self {
-        self.input_mode = 3;
+        self.input_mode = (self.input_mode & !VIDEO_INPUT_MODE_MASK) | 3;
         self
+    }
+
+    pub fn packed_alpha_right(mut self, enabled: bool) -> Self {
+        if enabled {
+            self.input_mode |= VIDEO_INPUT_PACKED_ALPHA_RIGHT;
+        } else {
+            self.input_mode &= !VIDEO_INPUT_PACKED_ALPHA_RIGHT;
+        }
+        self
+    }
+
+    pub fn has_packed_alpha_right(self) -> bool {
+        self.input_mode & VIDEO_INPUT_PACKED_ALPHA_RIGHT != 0
     }
 
     pub fn scene_linear_output(mut self) -> Self {
@@ -1141,6 +1157,22 @@ mod tests {
 
         assert!(pipeline.requires_gamut_mapping());
         assert!(pipeline.graph.contains(RenderPassKind::GamutMap));
+    }
+
+    #[test]
+    fn packed_alpha_flag_survives_source_texture_mode_changes() {
+        let pipeline = VideoRenderPipeline::sdr_default();
+        let uniforms = VideoUniforms::from_pipeline(&pipeline, false, false)
+            .packed_alpha_right(true)
+            .rgb_texture_input();
+
+        assert!(uniforms.has_packed_alpha_right());
+        assert_eq!(uniforms.input_mode & VIDEO_INPUT_MODE_MASK, 1);
+        assert_eq!(
+            uniforms.input_mode & VIDEO_INPUT_PACKED_ALPHA_RIGHT,
+            VIDEO_INPUT_PACKED_ALPHA_RIGHT,
+        );
+        assert!(!uniforms.packed_alpha_right(false).has_packed_alpha_right());
     }
 
     fn assert_matrix_close(actual: [[f32; 3]; 3], expected: [[f32; 3]; 3], epsilon: f32) {

--- a/crates/erika/src/renderer/wgpu.rs
+++ b/crates/erika/src/renderer/wgpu.rs
@@ -43,6 +43,7 @@ use crate::renderer::android_vulkan::{
     AndroidAhbConversionError, AndroidAhbCrop, AndroidAhbFrameDescription,
     AndroidAhbIntermediateFormat, AndroidVulkanInterop, retire_ahb_conversion_after_submission,
 };
+use crate::renderer::metal::{MetalRendererConfig, VideoAlphaMode};
 #[cfg(target_env = "ohos")]
 use crate::renderer::ohos_vulkan::{
     OhosNativeBufferConversionError, OhosNativeBufferCrop, OhosNativeBufferFrameDescription,
@@ -427,7 +428,8 @@ impl UploadedVideoFrame {
             &pipeline,
             self.uniforms.is_p010 != 0,
             output.extended_linear,
-        );
+        )
+        .packed_alpha_right(self.uniforms.has_packed_alpha_right());
         match &self.textures {
             UploadedVideoTextures::Planar { .. } => uniforms,
             UploadedVideoTextures::Rgb { .. } => uniforms.rgb_texture_input(),
@@ -503,6 +505,7 @@ pub struct WgpuRenderer {
     danmaku_atlas_cache: Option<WgpuDanmakuAtlasCache>,
     supports_16bit_norm: bool,
     output_mode: OutputMode,
+    video_alpha_mode: VideoAlphaMode,
     output_status: OutputRuntimeStatus,
     output_headroom: OutputHeadroomState,
     upscaler_mode: LumaUpscalerMode,
@@ -1219,14 +1222,22 @@ fn request_wgpu_device(
 
 impl WgpuRenderer {
     pub fn new() -> Result<Self> {
-        Self::new_with_output_mode(OutputMode::Sdr)
+        Self::new_with_config(MetalRendererConfig::default())
     }
 
     pub fn new_with_output_mode(output_mode: OutputMode) -> Result<Self> {
+        Self::new_with_config(MetalRendererConfig {
+            output_mode,
+            ..MetalRendererConfig::default()
+        })
+    }
+
+    pub fn new_with_config(config: MetalRendererConfig) -> Result<Self> {
         let candidate_count = wgpu_backend_candidates().len();
         Self::new_with_candidate_order(
             backend_candidate_order(candidate_count, 0, &[]),
-            output_mode,
+            config.output_mode,
+            config.video_alpha_mode,
         )
     }
 
@@ -1235,6 +1246,7 @@ impl WgpuRenderer {
         current_candidate: usize,
         excluded: &[usize],
         output_mode: OutputMode,
+        video_alpha_mode: VideoAlphaMode,
     ) -> (Result<Self>, Vec<usize>) {
         let candidate_count = wgpu_backend_candidates().len();
         let candidate_order = backend_candidate_order(
@@ -1242,7 +1254,8 @@ impl WgpuRenderer {
             current_candidate.saturating_add(1),
             excluded,
         );
-        let result = Self::new_with_candidate_order(candidate_order.clone(), output_mode);
+        let result =
+            Self::new_with_candidate_order(candidate_order.clone(), output_mode, video_alpha_mode);
         let selected_candidate = result
             .as_ref()
             .ok()
@@ -1256,6 +1269,7 @@ impl WgpuRenderer {
     fn new_with_candidate_order(
         candidate_order: Vec<usize>,
         output_mode: OutputMode,
+        video_alpha_mode: VideoAlphaMode,
     ) -> Result<Self> {
         let candidates = wgpu_backend_candidates();
         if candidate_order.is_empty() {
@@ -1407,6 +1421,7 @@ impl WgpuRenderer {
             danmaku_atlas_cache: None,
             supports_16bit_norm: context.supports_16bit_norm,
             output_mode,
+            video_alpha_mode,
             output_status: OutputRuntimeStatus::requested(output_mode),
             output_headroom: OutputHeadroomState::default(),
             upscaler_mode: LumaUpscalerMode::Off,
@@ -1901,6 +1916,7 @@ impl WgpuRenderer {
             }
         }
         VideoUniforms::from_pipeline(&pipeline, is_p010, output.extended_linear)
+            .packed_alpha_right(self.video_alpha_mode.has_alpha())
     }
 
     #[cfg(target_os = "android")]
@@ -2386,8 +2402,15 @@ impl WgpuRenderer {
                 video.uniforms_for_output(output),
             )
         };
-        let viewport = aspect_fit_viewport(video_width, video_height, target_width, target_height);
-        let upscale_requested = self.upscaler_mode.is_enabled()
+        let logical_video_width = self.video_alpha_mode.logical_width(video_width);
+        let viewport = aspect_fit_viewport(
+            logical_video_width,
+            video_height,
+            target_width,
+            target_height,
+        );
+        let upscale_requested = !self.video_alpha_mode.has_alpha()
+            && self.upscaler_mode.is_enabled()
             && self.upscaler.status() == WgpuArtCnnStatus::Scalar
             && viewport.width > video_width as f32
             && self.upscaler_failed_frame_token != Some(frame_token);
@@ -2549,7 +2572,11 @@ impl WgpuRenderer {
                     depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        load: wgpu::LoadOp::Clear(if self.video_alpha_mode.has_alpha() {
+                            wgpu::Color::TRANSPARENT
+                        } else {
+                            wgpu::Color::BLACK
+                        }),
                         store: wgpu::StoreOp::Store,
                     },
                 })],
@@ -3482,11 +3509,16 @@ impl WgpuRenderer {
                 .ok_or_else(|| {
                     PlayerError::Renderer("wgpu surface exposes no present modes".to_string())
                 })?;
+            let preferred_alpha_mode = if self.video_alpha_mode.has_alpha() {
+                wgpu::CompositeAlphaMode::PreMultiplied
+            } else {
+                wgpu::CompositeAlphaMode::Opaque
+            };
             let alpha_mode = caps
                 .alpha_modes
                 .iter()
                 .copied()
-                .find(|mode| *mode == wgpu::CompositeAlphaMode::Opaque)
+                .find(|mode| *mode == preferred_alpha_mode)
                 .or_else(|| caps.alpha_modes.first().copied())
                 .ok_or_else(|| {
                     PlayerError::Renderer("wgpu surface exposes no alpha modes".to_string())
@@ -4251,6 +4283,7 @@ pub struct AndroidRecoveringWgpuRenderer {
     surface: Option<WgpuSurfaceHandle>,
     current_frame: Option<PlayerVideoFrame>,
     output_mode: OutputMode,
+    video_alpha_mode: VideoAlphaMode,
     output_headroom: OutputHeadroomState,
     upscaler_mode: LumaUpscalerMode,
     retired_stats: RendererRuntimeStats,
@@ -4262,20 +4295,28 @@ pub struct AndroidRecoveringWgpuRenderer {
 #[cfg(target_os = "android")]
 impl AndroidRecoveringWgpuRenderer {
     pub fn new() -> Result<Self> {
-        Self::new_with_output_mode(OutputMode::Sdr)
+        Self::new_with_config(MetalRendererConfig::default())
     }
 
     pub fn new_with_output_mode(output_mode: OutputMode) -> Result<Self> {
+        Self::new_with_config(MetalRendererConfig {
+            output_mode,
+            ..MetalRendererConfig::default()
+        })
+    }
+
+    pub fn new_with_config(config: MetalRendererConfig) -> Result<Self> {
         Ok(Self {
-            active: WgpuRenderer::new_with_output_mode(output_mode)?,
+            active: WgpuRenderer::new_with_config(config)?,
             recovery_window: None,
             surface: None,
             current_frame: None,
-            output_mode,
+            output_mode: config.output_mode,
+            video_alpha_mode: config.video_alpha_mode,
             output_headroom: OutputHeadroomState::default(),
             upscaler_mode: LumaUpscalerMode::Off,
             retired_stats: RendererRuntimeStats::default(),
-            retired_output_status: OutputRuntimeStatus::requested(output_mode),
+            retired_output_status: OutputRuntimeStatus::requested(config.output_mode),
             terminal_failure: None,
             recovery_sequence: 0,
         })
@@ -4444,6 +4485,7 @@ impl AndroidRecoveringWgpuRenderer {
                 previous_candidate,
                 attempted_candidates,
                 self.output_mode,
+                self.video_alpha_mode,
             )
         }))
         .map_err(|payload| AndroidWgpuRebuildFailure {

--- a/crates/erika/src/renderer/wgpu_video.wgsl
+++ b/crates/erika/src/renderer/wgpu_video.wgsl
@@ -169,18 +169,23 @@ fn target_reference_linear_to_output(rgb: vec3<f32>) -> vec3<f32> {
     return rgb;
 }
 
-fn final_output(rgb: vec3<f32>) -> vec4<f32> {
+fn final_output(rgb: vec3<f32>, alpha: f32) -> vec4<f32> {
+    var output_rgb: vec3<f32>;
     if (uniforms.scene_linear != 0u) {
-        return vec4<f32>(max(rgb, vec3<f32>(0.0)), 1.0);
+        output_rgb = max(rgb, vec3<f32>(0.0)) * alpha;
+        return vec4<f32>(output_rgb, alpha);
     }
     if (uniforms.target_transfer == 3u) {
-        return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+        output_rgb = clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)) * alpha;
+        return vec4<f32>(output_rgb, alpha);
     }
     if (uniforms.edr_output != 0u) {
         let headroom = max(target_peak_nits() / target_reference_white_nits(), 1.0);
-        return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(headroom)), 1.0);
+        output_rgb = clamp(rgb, vec3<f32>(0.0), vec3<f32>(headroom)) * alpha;
+        return vec4<f32>(output_rgb, alpha);
     }
-    return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+    output_rgb = clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)) * alpha;
+    return vec4<f32>(output_rgb, alpha);
 }
 
 struct RangeExpandedYCbCr {
@@ -263,22 +268,29 @@ fn erika_video_vertex(@builtin(vertex_index) vertex_id: u32) -> VertexOut {
 
 @fragment
 fn erika_video_fragment(in: VertexOut) -> @location(0) vec4<f32> {
+    let input_mode = uniforms.input_mode & 255u;
+    let packed_alpha = (uniforms.input_mode & 256u) != 0u;
+    var color_coord = in.tex_coord;
+    if (packed_alpha) {
+        color_coord.x *= 0.5;
+    }
+    let alpha_coord = vec2<f32>(0.5 + in.tex_coord.x * 0.5, in.tex_coord.y);
     var rgb: vec3<f32>;
-    if (uniforms.input_mode == 1u) {
-        rgb = textureSample(luma_texture, video_sampler, in.tex_coord).rgb;
-    } else if (uniforms.input_mode == 3u) {
-        let original_rgb = textureSample(chroma_texture, video_sampler, in.tex_coord).rgb;
+    if (input_mode == 1u) {
+        rgb = textureSample(luma_texture, video_sampler, color_coord).rgb;
+    } else if (input_mode == 3u) {
+        let original_rgb = textureSample(chroma_texture, video_sampler, color_coord).rgb;
         let original_luma = dot(uniforms.luma_coefficients.xyz, original_rgb);
-        let enhanced_luma = sample_packed_luma(in.tex_coord);
+        let enhanced_luma = sample_packed_luma(color_coord);
         rgb = original_rgb + vec3<f32>(enhanced_luma - original_luma);
     } else {
         var y_sample: f32;
-        if (uniforms.input_mode == 2u) {
-            y_sample = sample_packed_luma(in.tex_coord);
+        if (input_mode == 2u) {
+            y_sample = sample_packed_luma(color_coord);
         } else {
-            y_sample = textureSample(luma_texture, video_sampler, in.tex_coord).r;
+            y_sample = textureSample(luma_texture, video_sampler, color_coord).r;
         }
-        let cbcr_sample = textureSample(chroma_texture, video_sampler, in.tex_coord).rg;
+        let cbcr_sample = textureSample(chroma_texture, video_sampler, color_coord).rg;
         let expanded = expand_ycbcr_range(y_sample, cbcr_sample);
         let y = expanded.y;
         let cbcr = expanded.cbcr;
@@ -296,5 +308,14 @@ fn erika_video_fragment(in: VertexOut) -> @location(0) vec4<f32> {
     rgb = tone_map_nits(rgb);
     rgb = target_nits_to_reference_linear(rgb);
     rgb = target_reference_linear_to_output(rgb);
-    return final_output(rgb);
+    var alpha = 1.0;
+    if (packed_alpha) {
+        let alpha_sample = textureSample(luma_texture, video_sampler, alpha_coord).r;
+        if (input_mode == 1u || input_mode == 3u) {
+            alpha = clamp(alpha_sample, 0.0, 1.0);
+        } else {
+            alpha = clamp(expand_ycbcr_range(alpha_sample, vec2<f32>(0.5)).y, 0.0, 1.0);
+        }
+    }
+    return final_output(rgb, alpha);
 }

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -167,10 +167,16 @@ typedef enum ErikaUpscalerBackendStatus {
   ErikaUpscalerBackendStatus_SimdgroupMatrix = 4,
 } ErikaUpscalerBackendStatus;
 
+typedef enum ErikaVideoAlphaMode {
+  ErikaVideoAlphaMode_Opaque = 0,
+  ErikaVideoAlphaMode_PackedAlphaRight = 1,
+} ErikaVideoAlphaMode;
+
 typedef struct ErikaPresenterConfig {
   int32_t output_mode;
   float edr_headroom;
   int32_t luma_upscaler;
+  int32_t video_alpha_mode;
 } ErikaPresenterConfig;
 
 #define ERIKA_SUBTITLE_OVERRIDE_FONT_SIZE_FIELDS (1u << 2)
@@ -502,6 +508,10 @@ ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig co
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(
     int32_t output_mode,
     float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(
+    int32_t output_mode,
+    float edr_headroom,
+    int32_t video_alpha_mode);
 void erika_presenter_destroy(ErikaPresenterHandle *handle);
 
 /* Playback and runtime parameters. volume is 0.0–1.0; rate 1.0 is normal speed;
@@ -665,6 +675,24 @@ ErikaStatus erika_presenter_attach_metal_layer(
     uint32_t width,
     uint32_t height,
     double scale);
+
+/* Flutter compositor texture surface. The registrar texture_id identifies the
+ * surface; before every render_tick, select the host-owned GPU target with
+ * set_flutter_texture_buffer. On Apple, raw_texture is an id<MTLTexture> using
+ * BGRA8Unorm. The texture remains owned by the host. */
+ErikaStatus erika_presenter_attach_flutter_texture(
+    ErikaPresenterHandle *handle,
+    ErikaFlutterTextureKind kind,
+    int64_t texture_id,
+    uint32_t width,
+    uint32_t height,
+    double scale);
+
+ErikaStatus erika_presenter_set_flutter_texture_buffer(
+    ErikaPresenterHandle *handle,
+    uint64_t raw_texture,
+    uint32_t width,
+    uint32_t height);
 
 ErikaStatus erika_presenter_attach_wgpu_surface(
     ErikaPresenterHandle *handle,

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -721,6 +721,13 @@ ErikaStatus erika_presenter_attach_windows_hwnd(
     uint32_t height,
     double scale);
 
+/* Windows only. Returns an AddRef'd IUnknown for a DirectComposition swap
+ * chain created by an attachment whose direct_composition capability is true.
+ * The caller owns the returned COM reference and must Release it. */
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_swapchain);
+
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/crates/erika_capi/src/android_jni.rs
+++ b/crates/erika_capi/src/android_jni.rs
@@ -354,12 +354,14 @@ pub extern "system" fn Java_dev_aimesoft_erika_1flutter_ErikaNative_nativeCreate
     output_mode: jint,
     edr_headroom: jfloat,
     upscaler: jint,
+    video_alpha_mode: jint,
 ) -> jlong {
     catch_unwind(AssertUnwindSafe(|| {
         let handle = erika_presenter_create_with_config(ErikaPresenterConfig {
             output_mode,
             edr_headroom,
             luma_upscaler: upscaler,
+            video_alpha_mode,
         });
         if handle.is_null() {
             let reason = last_error_message(ErikaStatus::PlayerError);

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -3534,6 +3534,29 @@ pub unsafe extern "C" fn erika_presenter_attach_windows_hwnd(
     }
 }
 
+/// Returns an AddRef'd IUnknown for the presenter's DirectComposition swap
+/// chain. The caller owns the returned COM reference and must Release it.
+#[cfg(target_os = "windows")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_windows_composition_swapchain_iunknown(
+    handle: *mut ErikaPresenterHandle,
+    out_swapchain: *mut *mut std::ffi::c_void,
+) -> ErikaStatus {
+    if out_swapchain.is_null() {
+        set_last_error("DirectComposition swap chain output pointer is null");
+        return ErikaStatus::NullPointer;
+    }
+    unsafe { *out_swapchain = std::ptr::null_mut() };
+    with_presenter_mut(handle, |handle| {
+        let Some(swapchain) = handle.presenter.composition_swapchain_iunknown() else {
+            set_last_error("presenter does not own a DirectComposition swap chain");
+            return ErikaStatus::PlayerError;
+        };
+        unsafe { *out_swapchain = swapchain };
+        ErikaStatus::Ok
+    })
+}
+
 #[cfg(any(
     target_os = "macos",
     any(target_os = "ios", target_os = "tvos"),

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -58,7 +58,7 @@ use erika::presenter::{
     target_os = "android",
     target_env = "ohos"
 ))]
-use erika::renderer::metal::{MetalOutputMode, MetalRendererConfig};
+use erika::renderer::metal::{MetalOutputMode, MetalRendererConfig, VideoAlphaMode};
 use erika::renderer::output::{
     ActiveOutputEncoding, OutputFallbackReason, OutputMode, OutputRuntimeStatus,
     OutputSurfaceFormat,
@@ -429,6 +429,7 @@ pub struct ErikaPresenterConfig {
     pub output_mode: i32,
     pub edr_headroom: f32,
     pub luma_upscaler: i32,
+    pub video_alpha_mode: i32,
 }
 
 #[repr(C)]
@@ -580,6 +581,7 @@ impl Default for ErikaPresenterConfig {
             output_mode: ErikaPresenterOutputMode::Sdr as i32,
             edr_headroom: 1.0,
             luma_upscaler: ErikaLumaUpscalerMode::Off as i32,
+            video_alpha_mode: VideoAlphaMode::Opaque as i32,
         }
     }
 }
@@ -1197,6 +1199,27 @@ pub extern "C" fn erika_presenter_create_with_output_mode(
     }))
 }
 
+#[cfg(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+))]
+#[unsafe(no_mangle)]
+pub extern "C" fn erika_presenter_create_with_output_mode_and_alpha(
+    output_mode: i32,
+    edr_headroom: f32,
+    video_alpha_mode: i32,
+) -> *mut ErikaPresenterHandle {
+    create_presenter_handle(presenter_config_from_c(ErikaPresenterConfig {
+        output_mode,
+        edr_headroom,
+        video_alpha_mode,
+        ..ErikaPresenterConfig::default()
+    }))
+}
+
 #[cfg(not(any(
     target_os = "macos",
     any(target_os = "ios", target_os = "tvos"),
@@ -1370,6 +1393,7 @@ fn presenter_config_from_c(config: ErikaPresenterConfig) -> PresenterConfig {
         renderer: MetalRendererConfig {
             output_mode,
             luma_upscaler: luma_upscaler_mode_from_c(config.luma_upscaler),
+            video_alpha_mode: VideoAlphaMode::from_raw(config.video_alpha_mode),
             ..MetalRendererConfig::default()
         },
         ..PresenterConfig::default()
@@ -3356,6 +3380,66 @@ pub unsafe extern "C" fn erika_presenter_attach_metal_layer(
         status_from_player_result(handle.presenter.attach_surface(PlatformSurface::Metal(
             MetalSurfaceHandle::new(raw_layer, width, height, scale),
         )))
+    })
+}
+
+#[cfg(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_attach_flutter_texture(
+    handle: *mut ErikaPresenterHandle,
+    kind: ErikaFlutterTextureKind,
+    texture_id: i64,
+    width: u32,
+    height: u32,
+    scale: f64,
+) -> ErikaStatus {
+    if texture_id < 0 || width == 0 || height == 0 {
+        return ErikaStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        status_from_player_result(
+            handle
+                .presenter
+                .attach_surface(PlatformSurface::FlutterTexture(FlutterTextureHandle::new(
+                    flutter_texture_kind_from_c(kind),
+                    texture_id,
+                    width,
+                    height,
+                    scale,
+                ))),
+        )
+    })
+}
+
+#[cfg(any(
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_os = "android",
+    target_env = "ohos"
+))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_set_flutter_texture_buffer(
+    handle: *mut ErikaPresenterHandle,
+    raw_texture: u64,
+    width: u32,
+    height: u32,
+) -> ErikaStatus {
+    if raw_texture == 0 || width == 0 || height == 0 {
+        return ErikaStatus::NullPointer;
+    }
+    with_presenter_mut(handle, |handle| {
+        status_from_player_result(handle.presenter.set_flutter_texture_buffer(
+            raw_texture,
+            width,
+            height,
+        ))
     })
 }
 

--- a/packages/erika_flutter/CHANGELOG.md
+++ b/packages/erika_flutter/CHANGELOG.md
@@ -10,6 +10,9 @@
   per-frame CPU pixel readback.
 - Added native macOS opacity and overlay compositing for transparent video
   platform views when backdrop-aware blending is required.
+- Added Windows DirectComposition presentation for transparent video, with a
+  premultiplied-alpha swap chain attached directly to the Flutter HWND and
+  native overlay blending/opacity instead of a covering popup window.
 - Raised the native playback-rate ceiling to 16× for short-form video effects.
 
 ## 0.1.7

--- a/packages/erika_flutter/CHANGELOG.md
+++ b/packages/erika_flutter/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Added a packed-alpha video mode that stores color and alpha side by side,
+  reconstructs premultiplied transparency in the GPU renderer, and propagates
+  the mode through the C ABI and Flutter platform integrations.
+- Added a macOS `ErikaTextureVideoView` backed by IOSurface and Metal for
+  Flutter-composited opacity, clipping, transforms, and color filters without
+  per-frame CPU pixel readback.
+- Added native macOS opacity and overlay compositing for transparent video
+  platform views when backdrop-aware blending is required.
+- Raised the native playback-rate ceiling to 16× for short-form video effects.
+
 ## 0.1.7
 
 - Published `erika_flutter` as a standalone pub.dev package with package-local

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaFlutterPlugin.kt
@@ -355,11 +355,17 @@ class ErikaFlutterPlugin :
         val edrHeadroom =
             (arguments.number("edrHeadroom")?.toFloat() ?: defaultHeadroom).coerceAtLeast(1f)
         val upscaler = arguments.int("upscaler") ?: arguments.int("lumaUpscaler") ?: 0
+        val videoAlphaMode = arguments.int("videoAlphaMode") ?: 0
         val ownerThread = presenterThread
         val attachmentGeneration = engineAttachmentGeneration
         val posted = ownerThread.post {
             val createResult = runCatching {
-                ErikaNative.nativeCreate(outputMode, edrHeadroom, upscaler)
+                ErikaNative.nativeCreate(
+                    outputMode,
+                    edrHeadroom,
+                    upscaler,
+                    videoAlphaMode,
+                )
             }
             val createFailure = createResult.exceptionOrNull()
             if (createFailure != null) {

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaNative.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaNative.kt
@@ -8,7 +8,12 @@ internal object ErikaNative {
     }
 
     @JvmStatic
-    external fun nativeCreate(outputMode: Int, edrHeadroom: Float, upscaler: Int): Long
+    external fun nativeCreate(
+        outputMode: Int,
+        edrHeadroom: Float,
+        upscaler: Int,
+        videoAlphaMode: Int,
+    ): Long
 
     @JvmStatic
     external fun nativeLastError(): String

--- a/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaTextureView.kt
+++ b/packages/erika_flutter/android/src/main/kotlin/dev/aimesoft/erika_flutter/ErikaTextureView.kt
@@ -53,6 +53,8 @@ internal class ErikaAndroidVideoView(
         (creationParams["requestedHdrHeadroom"] as? Number)?.toFloat()
     private val requestedHdrHeadroom = androidDesiredHdrHeadroom(rawRequestedHdrHeadroom)
     private val hybridComposition = creationParams["composition"] == "hybrid"
+    private val videoAlphaMode =
+        (creationParams["videoAlphaMode"] as? Number)?.toInt() ?: 0
     private val mainHandler = Handler(Looper.getMainLooper())
     private var outputSurface: Surface? = null
     private var ownsOutputSurface = false
@@ -123,7 +125,7 @@ internal class ErikaAndroidVideoView(
             )
         }
         textureView?.apply {
-            isOpaque = true
+            isOpaque = videoAlphaMode == 0
             surfaceTextureListener = this@ErikaAndroidVideoView
         }
         surfaceView?.apply {

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -1576,6 +1576,8 @@ class ErikaPlayer {
   Future<int> attachWindowOverlay({
     int? flutterViewId,
     bool secondaryWindow = false,
+    String blendMode = 'srcOver',
+    double opacity = 1.0,
   }) async {
     final playerId = await ensureCreated();
     final viewId = await _channel.invokeMethod<int>(
@@ -1584,6 +1586,8 @@ class ErikaPlayer {
         'playerId': playerId,
         if (flutterViewId != null) 'flutterViewId': flutterViewId,
         'secondaryWindow': secondaryWindow,
+        if (blendMode != 'srcOver') 'blendMode': blendMode,
+        if (opacity != 1.0) 'opacity': opacity,
       },
     );
     return viewId ?? windowOverlayViewId;
@@ -1607,6 +1611,8 @@ class ErikaPlayer {
     int? flutterViewId,
     bool secondaryWindow = false,
     String? debugLabel,
+    String blendMode = 'srcOver',
+    double opacity = 1.0,
   }) async {
     final playerId = await ensureCreated();
     await _invoke('setOverlayFrame', <String, Object?>{
@@ -1621,6 +1627,8 @@ class ErikaPlayer {
       if (flutterViewId != null) 'flutterViewId': flutterViewId,
       'secondaryWindow': secondaryWindow,
       if (debugLabel != null) 'debugLabel': debugLabel,
+      if (blendMode != 'srcOver') 'blendMode': blendMode,
+      if (opacity != 1.0) 'opacity': opacity,
     });
   }
 

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -77,6 +77,21 @@ enum ErikaOutputMode {
   }
 }
 
+/// How transparency is encoded in a video frame.
+enum ErikaVideoAlphaMode {
+  /// The decoded video is fully opaque.
+  opaque(0),
+
+  /// The left half is colour and the right half is a grayscale alpha mask.
+  /// Erika presents the video at half of its encoded width and reconstructs a
+  /// premultiplied-alpha frame in the GPU presentation shader.
+  packedAlphaRight(1);
+
+  const ErikaVideoAlphaMode(this.nativeValue);
+
+  final int nativeValue;
+}
+
 enum ErikaActiveOutputEncoding {
   sdrSrgb(0),
   appleEdr(1),
@@ -779,6 +794,7 @@ class ErikaPlayer {
     this.outputMode,
     this.edrHeadroom,
     this.upscaler,
+    this.videoAlphaMode = ErikaVideoAlphaMode.opaque,
     this.hdrDebug = false,
     this.allowBackgroundPlayback = false,
   }) {
@@ -844,6 +860,7 @@ class ErikaPlayer {
   final ErikaOutputMode? outputMode;
   final double? edrHeadroom;
   final ErikaUpscalerMode? upscaler;
+  final ErikaVideoAlphaMode videoAlphaMode;
   final bool hdrDebug;
   final bool allowBackgroundPlayback;
 
@@ -1658,6 +1675,8 @@ class ErikaPlayer {
       if (outputMode case final mode?) 'outputMode': mode.nativeValue,
       if (requestedHeadroom case final headroom?) 'edrHeadroom': headroom,
       if (upscaler case final mode?) 'upscaler': mode.nativeValue,
+      if (videoAlphaMode != ErikaVideoAlphaMode.opaque)
+        'videoAlphaMode': videoAlphaMode.nativeValue,
       if (hdrDebug) 'hdrDebug': true,
       if (allowBackgroundPlayback) 'allowBackgroundPlayback': true,
     };

--- a/packages/erika_flutter/lib/src/erika_video_view.dart
+++ b/packages/erika_flutter/lib/src/erika_video_view.dart
@@ -20,6 +20,10 @@ bool get _usesAndroidTextureView =>
 bool get _usesOhosTextureView =>
     !kIsWeb && defaultTargetPlatform.name == 'ohos';
 
+bool get _supportsFlutterTextureVideoView =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.macOS || _usesOhosTextureView);
+
 /// Flutter platform-view video surface backed by AppKit/UIKit.
 ///
 /// This is the compatibility surface. Full-player Apple hosts should usually
@@ -31,14 +35,71 @@ class ErikaVideoView extends StatefulWidget {
     required this.player,
     this.debugLabel,
     this.onPlatformViewIdChanged,
-  });
+    this.blendMode = BlendMode.srcOver,
+    this.opacity = 1.0,
+  }) : assert(opacity >= 0.0 && opacity <= 1.0);
 
   final ErikaPlayer player;
   final String? debugLabel;
   final ValueChanged<int?>? onPlatformViewIdChanged;
+  final BlendMode blendMode;
+  final double opacity;
 
   @override
   State<ErikaVideoView> createState() => _ErikaVideoViewState();
+}
+
+/// Video surface composited as a Flutter [Texture].
+///
+/// On macOS this uses an IOSurface-backed Metal texture, so regular Flutter
+/// effects such as opacity, clipping and color filters apply to the video. On
+/// platforms without a native texture path it falls back to [ErikaVideoView].
+class ErikaTextureVideoView extends StatelessWidget {
+  const ErikaTextureVideoView({
+    super.key,
+    required this.player,
+    this.debugLabel,
+    this.onTextureIdChanged,
+    this.blendMode = BlendMode.srcOver,
+    this.opacity = 1.0,
+  }) : assert(opacity >= 0.0 && opacity <= 1.0);
+
+  final ErikaPlayer player;
+  final String? debugLabel;
+  final ValueChanged<int?>? onTextureIdChanged;
+  final BlendMode blendMode;
+  final double opacity;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.macOS &&
+        blendMode != BlendMode.srcOver) {
+      return ErikaVideoView(
+        player: player,
+        debugLabel: debugLabel,
+        onPlatformViewIdChanged: onTextureIdChanged,
+        blendMode: blendMode,
+        opacity: opacity,
+      );
+    }
+    if (_supportsFlutterTextureVideoView) {
+      return Opacity(
+        opacity: opacity,
+        child: _ErikaOhosVideoView(
+          player: player,
+          onPlatformViewIdChanged: onTextureIdChanged,
+        ),
+      );
+    }
+    return ErikaVideoView(
+      player: player,
+      debugLabel: debugLabel,
+      onPlatformViewIdChanged: onTextureIdChanged,
+      blendMode: blendMode,
+      opacity: opacity,
+    );
+  }
 }
 
 class _ErikaVideoViewState extends State<ErikaVideoView> {
@@ -82,6 +143,11 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
     }
     final creationParams = <String, Object?>{
       if (widget.debugLabel case final label?) 'debugLabel': label,
+      if (widget.player.videoAlphaMode != ErikaVideoAlphaMode.opaque)
+        'videoAlphaMode': widget.player.videoAlphaMode.nativeValue,
+      if (widget.blendMode != BlendMode.srcOver)
+        'blendMode': widget.blendMode.name,
+      if (widget.opacity != 1.0) 'opacity': widget.opacity,
     };
     if (_usesOhosTextureView) {
       return _ErikaOhosVideoView(
@@ -92,6 +158,11 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
     switch (defaultTargetPlatform) {
       case TargetPlatform.macOS:
         return AppKitView(
+          key: ValueKey<Object>((
+            widget.player.videoAlphaMode,
+            widget.blendMode,
+            widget.opacity,
+          )),
           viewType: 'erika_flutter/video_view',
           layoutDirection: TextDirection.ltr,
           creationParamsCodec: const StandardMessageCodec(),
@@ -510,6 +581,8 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
       if (extendedLinear)
         'requestedHdrHeadroom': widget.player.edrHeadroom ?? 0.0,
       if (extendedLinear) 'composition': 'hybrid',
+      if (widget.player.videoAlphaMode != ErikaVideoAlphaMode.opaque)
+        'videoAlphaMode': widget.player.videoAlphaMode.nativeValue,
     };
     if (!extendedLinear) {
       return AndroidView(

--- a/packages/erika_flutter/lib/src/erika_video_view.dart
+++ b/packages/erika_flutter/lib/src/erika_video_view.dart
@@ -184,6 +184,8 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
           player: widget.player,
           debugLabel: widget.debugLabel,
           onPlatformViewIdChanged: widget.onPlatformViewIdChanged,
+          blendMode: widget.blendMode,
+          opacity: widget.opacity,
         );
       case TargetPlatform.android:
         return _ErikaAndroidVideoView(
@@ -643,12 +645,16 @@ class ErikaWindowOverlayVideoView extends StatefulWidget {
     this.debugLabel,
     this.onPlatformViewIdChanged,
     this.onFrameRectChanged,
-  });
+    this.blendMode = BlendMode.srcOver,
+    this.opacity = 1.0,
+  }) : assert(opacity >= 0.0 && opacity <= 1.0);
 
   final ErikaPlayer player;
   final String? debugLabel;
   final ValueChanged<int?>? onPlatformViewIdChanged;
   final ValueChanged<Rect?>? onFrameRectChanged;
+  final BlendMode blendMode;
+  final double opacity;
 
   @override
   State<ErikaWindowOverlayVideoView> createState() =>
@@ -693,6 +699,9 @@ class _ErikaWindowOverlayVideoViewState
       );
       widget.onPlatformViewIdChanged?.call(ErikaPlayer.windowOverlayViewId);
       _scheduleAttach();
+    } else if (oldWidget.blendMode != widget.blendMode ||
+        oldWidget.opacity != widget.opacity) {
+      _scheduleFrameUpdate(force: true);
     }
   }
 
@@ -748,6 +757,8 @@ class _ErikaWindowOverlayVideoViewState
     try {
       await widget.player.attachWindowOverlay(
         flutterViewId: View.of(context).viewId,
+        blendMode: widget.blendMode.name,
+        opacity: widget.opacity,
       );
       _isBound = true;
       _scheduleFrameUpdate(force: true);
@@ -816,6 +827,8 @@ class _ErikaWindowOverlayVideoViewState
       rect.top.toStringAsFixed(2),
       rect.width.toStringAsFixed(2),
       rect.height.toStringAsFixed(2),
+      widget.blendMode.name,
+      widget.opacity.toStringAsFixed(4),
     ].join('|');
     if (!force && signature == _lastFrameSignature) {
       return;
@@ -830,6 +843,8 @@ class _ErikaWindowOverlayVideoViewState
         generation: _surfaceGeneration,
         flutterViewId: View.of(context).viewId,
         debugLabel: widget.debugLabel,
+        blendMode: widget.blendMode.name,
+        opacity: widget.opacity,
       );
     } catch (error) {
       debugPrint('ErikaWindowOverlayVideoView: frame update failed: $error');
@@ -843,6 +858,8 @@ class _ErikaWindowOverlayVideoViewState
         visible: false,
         generation: _surfaceGeneration,
         debugLabel: widget.debugLabel,
+        blendMode: widget.blendMode.name,
+        opacity: widget.opacity,
       );
     } catch (error) {
       debugPrint('ErikaWindowOverlayVideoView: hide overlay failed: $error');

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -111,6 +111,184 @@ private final class ErikaDisplayLinkDriver {
   }
 }
 
+/// A Flutter texture whose backing CVPixelBuffer is also exposed as a Metal
+/// texture. Erika renders into the IOSurface-backed Metal texture directly;
+/// Flutter then composites the same buffer without a CPU readback.
+private final class ErikaFlutterTextureSurface: NSObject, FlutterTexture {
+  struct PreparedFrame {
+    let generation: UInt64
+    let pixelBuffer: CVPixelBuffer
+    let cvMetalTexture: CVMetalTexture
+    let metalTexture: MTLTexture
+    let width: UInt32
+    let height: UInt32
+  }
+
+  private let registry: FlutterTextureRegistry
+  private let lock = NSLock()
+  private let device: MTLDevice
+  private var textureCache: CVMetalTextureCache
+  private var pixelBufferPool: CVPixelBufferPool
+  private var readyPixelBuffer: CVPixelBuffer?
+  private var generation: UInt64 = 1
+  private(set) var textureId: Int64 = 0
+  private(set) var width: UInt32
+  private(set) var height: UInt32
+  private(set) var scale: Double
+  weak var attachedPlayer: ErikaPlayerHost?
+
+  init?(
+    registry: FlutterTextureRegistry,
+    width: UInt32,
+    height: UInt32,
+    scale: Double
+  ) {
+    guard let device = MTLCreateSystemDefaultDevice(),
+          let resources = Self.makeResources(device: device, width: width, height: height) else {
+      return nil
+    }
+    self.registry = registry
+    self.device = device
+    textureCache = resources.textureCache
+    pixelBufferPool = resources.pixelBufferPool
+    self.width = width
+    self.height = height
+    self.scale = scale
+    super.init()
+  }
+
+  func register() -> Int64 {
+    let id = registry.register(self)
+    textureId = id
+    return id
+  }
+
+  func resize(width: UInt32, height: UInt32, scale: Double) -> Bool {
+    guard let resources = Self.makeResources(device: device, width: width, height: height) else {
+      return false
+    }
+    lock.lock()
+    generation &+= 1
+    textureCache = resources.textureCache
+    pixelBufferPool = resources.pixelBufferPool
+    readyPixelBuffer = nil
+    self.width = width
+    self.height = height
+    self.scale = scale
+    lock.unlock()
+    return true
+  }
+
+  func metrics() -> (width: UInt32, height: UInt32, scale: Double) {
+    lock.lock()
+    defer { lock.unlock() }
+    return (width, height, scale)
+  }
+
+  func prepareFrame() -> PreparedFrame? {
+    lock.lock()
+    let cache = textureCache
+    let pool = pixelBufferPool
+    let frameWidth = width
+    let frameHeight = height
+    let frameGeneration = generation
+    lock.unlock()
+
+    var pixelBuffer: CVPixelBuffer?
+    guard CVPixelBufferPoolCreatePixelBuffer(
+      kCFAllocatorDefault,
+      pool,
+      &pixelBuffer
+    ) == kCVReturnSuccess, let pixelBuffer else {
+      return nil
+    }
+    var cvMetalTexture: CVMetalTexture?
+    guard CVMetalTextureCacheCreateTextureFromImage(
+      kCFAllocatorDefault,
+      cache,
+      pixelBuffer,
+      nil,
+      .bgra8Unorm,
+      Int(frameWidth),
+      Int(frameHeight),
+      0,
+      &cvMetalTexture
+    ) == kCVReturnSuccess,
+      let cvMetalTexture,
+      let metalTexture = CVMetalTextureGetTexture(cvMetalTexture) else {
+      return nil
+    }
+    return PreparedFrame(
+      generation: frameGeneration,
+      pixelBuffer: pixelBuffer,
+      cvMetalTexture: cvMetalTexture,
+      metalTexture: metalTexture,
+      width: frameWidth,
+      height: frameHeight
+    )
+  }
+
+  func publish(_ frame: PreparedFrame) {
+    lock.lock()
+    guard frame.generation == generation else {
+      lock.unlock()
+      return
+    }
+    readyPixelBuffer = frame.pixelBuffer
+    let id = textureId
+    lock.unlock()
+    if id != 0 {
+      registry.textureFrameAvailable(id)
+    }
+  }
+
+  func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard let readyPixelBuffer else {
+      return nil
+    }
+    return Unmanaged.passRetained(readyPixelBuffer)
+  }
+
+  private static func makeResources(
+    device: MTLDevice,
+    width: UInt32,
+    height: UInt32
+  ) -> (textureCache: CVMetalTextureCache, pixelBufferPool: CVPixelBufferPool)? {
+    var textureCache: CVMetalTextureCache?
+    guard CVMetalTextureCacheCreate(
+      kCFAllocatorDefault,
+      nil,
+      device,
+      nil,
+      &textureCache
+    ) == kCVReturnSuccess, let textureCache else {
+      return nil
+    }
+    let poolAttributes: [CFString: Any] = [
+      kCVPixelBufferPoolMinimumBufferCountKey: 3,
+    ]
+    let pixelBufferAttributes: [CFString: Any] = [
+      kCVPixelBufferPixelFormatTypeKey: kCVPixelFormatType_32BGRA,
+      kCVPixelBufferWidthKey: Int(width),
+      kCVPixelBufferHeightKey: Int(height),
+      kCVPixelBufferIOSurfacePropertiesKey: [:],
+      kCVPixelBufferMetalCompatibilityKey: true,
+    ]
+    var pixelBufferPool: CVPixelBufferPool?
+    guard CVPixelBufferPoolCreate(
+      kCFAllocatorDefault,
+      poolAttributes as CFDictionary,
+      pixelBufferAttributes as CFDictionary,
+      &pixelBufferPool
+    ) == kCVReturnSuccess, let pixelBufferPool else {
+      return nil
+    }
+    return (textureCache, pixelBufferPool)
+  }
+}
+
 private struct ErikaVideoParamsC {
   var width: UInt32 = 0
   var height: UInt32 = 0
@@ -155,6 +333,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()
 
@@ -378,6 +557,9 @@ private final class ErikaNativeLibrary {
 
   typealias CreateFn = @convention(c) () -> UnsafeMutableRawPointer?
   typealias CreateWithOutputModeFn = @convention(c) (Int32, Float) -> UnsafeMutableRawPointer?
+  typealias CreateWithOutputModeAndAlphaFn = @convention(c) (
+    Int32, Float, Int32
+  ) -> UnsafeMutableRawPointer?
   typealias DestroyFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias OpenFn = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Int32
   typealias OpenWithHeadersFn = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?, UnsafeRawPointer?, UInt) -> Int32
@@ -443,6 +625,12 @@ private final class ErikaNativeLibrary {
   typealias TrackInfoFreeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias DanmakuTrackInfoFreeFn = @convention(c) (UnsafeMutableRawPointer?) -> Void
   typealias AttachMetalLayerFn = @convention(c) (UnsafeMutableRawPointer?, UInt64, UInt32, UInt32, Double) -> Int32
+  typealias AttachFlutterTextureFn = @convention(c) (
+    UnsafeMutableRawPointer?, Int32, Int64, UInt32, UInt32, Double
+  ) -> Int32
+  typealias SetFlutterTextureBufferFn = @convention(c) (
+    UnsafeMutableRawPointer?, UInt64, UInt32, UInt32
+  ) -> Int32
   typealias ResizeSurfaceFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, Double) -> Int32
   typealias RenderTickFn = @convention(c) (UnsafeMutableRawPointer?, Double, UnsafeMutableRawPointer?) -> Int32
   typealias CaptureFrameRgbaFn = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32, UnsafeMutableRawPointer?, Int) -> Int32
@@ -454,6 +642,7 @@ private final class ErikaNativeLibrary {
 
   let create: CreateFn
   let createWithOutputMode: CreateWithOutputModeFn?
+  let createWithOutputModeAndAlpha: CreateWithOutputModeAndAlphaFn?
   let destroy: DestroyFn
   let open: OpenFn
   let openWithHeaders: OpenWithHeadersFn?
@@ -501,6 +690,8 @@ private final class ErikaNativeLibrary {
   let freeTrackInfo: TrackInfoFreeFn
   let freeDanmakuTrackInfo: DanmakuTrackInfoFreeFn?
   let attachMetalLayer: AttachMetalLayerFn
+  let attachFlutterTexture: AttachFlutterTextureFn
+  let setFlutterTextureBuffer: SetFlutterTextureBufferFn
   let resizeSurface: ResizeSurfaceFn
   let detachSurface: CommandFn
   let renderTick: RenderTickFn
@@ -517,6 +708,11 @@ private final class ErikaNativeLibrary {
 
     create = try Self.load("erika_presenter_create", from: libraryHandle, as: CreateFn.self)
     createWithOutputMode = Self.loadOptional("erika_presenter_create_with_output_mode", from: libraryHandle, as: CreateWithOutputModeFn.self)
+    createWithOutputModeAndAlpha = Self.loadOptional(
+      "erika_presenter_create_with_output_mode_and_alpha",
+      from: libraryHandle,
+      as: CreateWithOutputModeAndAlphaFn.self
+    )
     destroy = try Self.load("erika_presenter_destroy", from: libraryHandle, as: DestroyFn.self)
     open = try Self.load("erika_presenter_open", from: libraryHandle, as: OpenFn.self)
     openWithHeaders = Self.loadOptional("erika_presenter_open_with_headers", from: libraryHandle, as: OpenWithHeadersFn.self)
@@ -564,6 +760,8 @@ private final class ErikaNativeLibrary {
     freeTrackInfo = try Self.load("erika_track_info_free", from: libraryHandle, as: TrackInfoFreeFn.self)
     freeDanmakuTrackInfo = Self.loadOptional("erika_danmaku_track_info_free", from: libraryHandle, as: DanmakuTrackInfoFreeFn.self)
     attachMetalLayer = try Self.load("erika_presenter_attach_metal_layer", from: libraryHandle, as: AttachMetalLayerFn.self)
+    attachFlutterTexture = try Self.load("erika_presenter_attach_flutter_texture", from: libraryHandle, as: AttachFlutterTextureFn.self)
+    setFlutterTextureBuffer = try Self.load("erika_presenter_set_flutter_texture_buffer", from: libraryHandle, as: SetFlutterTextureBufferFn.self)
     resizeSurface = try Self.load("erika_presenter_resize_surface", from: libraryHandle, as: ResizeSurfaceFn.self)
     detachSurface = try Self.load("erika_presenter_detach_surface", from: libraryHandle, as: CommandFn.self)
     renderTick = try Self.load("erika_presenter_render_tick", from: libraryHandle, as: RenderTickFn.self)
@@ -679,6 +877,16 @@ private final class ErikaNativeLibrary {
   }
 
   func createPresenter(config: ErikaPresenterConfigC) -> UnsafeMutableRawPointer? {
+    if let createWithOutputModeAndAlpha {
+      return createWithOutputModeAndAlpha(
+        config.outputMode,
+        config.edrHeadroom,
+        config.videoAlphaMode
+      )
+    }
+    if config.videoAlphaMode != 0 {
+      return nil
+    }
     if let createWithOutputMode {
       return createWithOutputMode(config.outputMode, config.edrHeadroom)
     }
@@ -702,6 +910,7 @@ private final class ErikaPlayerHost {
   private let renderQueue: DispatchQueue
   private let nativeCallLock = NSRecursiveLock()
   private weak var attachedView: ErikaMetalSurfaceView?
+  private weak var attachedTexture: ErikaFlutterTextureSurface?
   private var attachedViewId: Int64?
   private var displayLinkDriver: ErikaDisplayLinkDriver?
   private var displayLinkDisplayID: CGDirectDisplayID?
@@ -1377,7 +1586,9 @@ private final class ErikaPlayerHost {
     // Moving the surface between windows re-attaches an already running
     // player. Only a genuinely new attachment restarts the host clock; a
     // migration must not rewind the timeline the engine is already on.
-    let isReattach = attachedView != nil
+    let isReattach = attachedView != nil || attachedTexture != nil
+    attachedTexture?.attachedPlayer = nil
+    attachedTexture = nil
     attachedView = view
     attachedViewId = view.platformViewId
     view.attachedPlayerId = id
@@ -1390,12 +1601,39 @@ private final class ErikaPlayerHost {
     startDisplayDriverIfNeeded(resetClock: !isReattach)
   }
 
+  func attach(texture: ErikaFlutterTextureSurface) throws {
+    let isReattach = attachedView != nil || attachedTexture != nil
+    attachedView?.attachedPlayerId = nil
+    attachedView = nil
+    attachedTexture?.attachedPlayer = nil
+    attachedTexture = texture
+    attachedViewId = texture.textureId
+    texture.attachedPlayer = self
+    let metrics = texture.metrics()
+    try withNativeCall {
+      try check(
+        library.attachFlutterTexture(
+          handle,
+          1, // ErikaFlutterTextureKind_MacOsTextureRegistrar
+          texture.textureId,
+          metrics.width,
+          metrics.height,
+          metrics.scale
+        ),
+        operation: "attach_flutter_texture"
+      )
+    }
+    startDisplayDriverIfNeeded(resetClock: !isReattach)
+  }
+
   func detach(viewId: Int64?) {
     guard viewId == nil || attachedViewId == viewId else {
       return
     }
     attachedView?.attachedPlayerId = nil
+    attachedTexture?.attachedPlayer = nil
     attachedView = nil
+    attachedTexture = nil
     attachedViewId = nil
     stopDisplayDriver()
     withNativeCall {
@@ -1415,6 +1653,24 @@ private final class ErikaPlayerHost {
     }
   }
 
+  func resizeFromAttachedTexture() {
+    guard let texture = attachedTexture else {
+      return
+    }
+    let metrics = texture.metrics()
+    do {
+      try withNativeCall {
+        try check(
+          library.resizeSurface(handle, metrics.width, metrics.height, metrics.scale),
+          operation: "resize_flutter_texture"
+        )
+      }
+      startDisplayDriverIfNeeded(resetClock: false)
+    } catch {
+      NSLog("ErikaFlutterPlugin: texture resize failed: \(error)")
+    }
+  }
+
   func renderTick() {
     if !loggedRenderThread {
       loggedRenderThread = true
@@ -1423,8 +1679,28 @@ private final class ErikaPlayerHost {
       )
     }
     let timeSeconds = CACurrentMediaTime() - startTimeSeconds
+    let textureSurface = attachedTexture
+    let preparedFrame = textureSurface?.prepareFrame()
+    if textureSurface != nil && preparedFrame == nil {
+      return
+    }
+    let previousStats = latestPresenterStats
     var stats = ErikaPresenterStatsC()
     let status = withNativeCall {
+      if let preparedFrame {
+        let rawTexture = UInt64(UInt(bitPattern: Unmanaged.passUnretained(
+          preparedFrame.metalTexture as AnyObject
+        ).toOpaque()))
+        let bufferStatus = library.setFlutterTextureBuffer(
+          handle,
+          rawTexture,
+          preparedFrame.width,
+          preparedFrame.height
+        )
+        if bufferStatus != 0 {
+          return bufferStatus
+        }
+      }
       let status = withUnsafeMutablePointer(to: &stats) { pointer in
         library.renderTick(handle, timeSeconds, UnsafeMutableRawPointer(pointer))
       }
@@ -1435,6 +1711,16 @@ private final class ErikaPlayerHost {
     }
     if status != 0 {
       NSLog("ErikaFlutterPlugin: render_tick failed with status \(status)")
+    } else if let textureSurface, let preparedFrame {
+      let renderedThisTick =
+        stats.renderedVideoFrames > previousStats.renderedVideoFrames ||
+        stats.renderedTestFrames > previousStats.renderedTestFrames ||
+        stats.overlayFrames > previousStats.overlayFrames ||
+        stats.danmakuFrames > previousStats.danmakuFrames
+      guard renderedThisTick else {
+        return
+      }
+      textureSurface.publish(preparedFrame)
     }
   }
 
@@ -1882,13 +2168,23 @@ final class ErikaVideoPlatformView: NSView, ErikaMetalSurfaceView {
     wantsLayer = true
     metalLayer.pixelFormat = .bgra8Unorm
     metalLayer.framebufferOnly = true
-    metalLayer.isOpaque = true
-    metalLayer.backgroundColor = NSColor.black.cgColor
+    let params = arguments as? [String: Any]
+    let alphaVideo = (params?["videoAlphaMode"] as? NSNumber)?.intValue != 0
+    metalLayer.isOpaque = !alphaVideo
+    metalLayer.backgroundColor = alphaVideo
+      ? NSColor.clear.cgColor
+      : NSColor.black.cgColor
+    if params?["blendMode"] as? String == "overlay" {
+      metalLayer.compositingFilter = "overlayBlendMode"
+    }
+    if let opacity = (params?["opacity"] as? NSNumber)?.doubleValue {
+      metalLayer.opacity = Float(min(max(opacity, 0.0), 1.0))
+    }
     layer = metalLayer
     layerContentsRedrawPolicy = .duringViewResize
     autoresizingMask = [.width, .height]
 
-    if let params = arguments as? [String: Any],
+    if let params,
        let debugLabel = params["debugLabel"] as? String,
        !debugLabel.isEmpty,
        ProcessInfo.processInfo.environment["ERIKA_DEBUG_LABELS"] == "1" {
@@ -2134,6 +2430,8 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
 
   private var players: [Int64: ErikaPlayerHost] = [:]
   private var views: [Int64: WeakErikaVideoPlatformViewBox] = [:]
+  private let textureRegistry: FlutterTextureRegistry
+  private var textures: [Int64: ErikaFlutterTextureSurface] = [:]
   private weak var flutterHostView: NSView?
   private weak var flutterHostViewController: NSViewController?
   private var requestedFlutterViewIdentifier: Int64?
@@ -2145,9 +2443,14 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   private var remoteCommandTargets: [(MPRemoteCommand, Any)] = []
   private var systemMediaNavigation: [Int64: (previousEnabled: Bool, nextEnabled: Bool)] = [:]
 
-  init(flutterHostView: NSView?, flutterHostViewController: NSViewController?) {
+  init(
+    flutterHostView: NSView?,
+    flutterHostViewController: NSViewController?,
+    textureRegistry: FlutterTextureRegistry
+  ) {
     self.flutterHostView = flutterHostView
     self.flutterHostViewController = flutterHostViewController
+    self.textureRegistry = textureRegistry
     super.init()
   }
 
@@ -2158,12 +2461,16 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
       command.isEnabled = false
       command.removeTarget(target)
     }
+    for textureId in textures.keys {
+      textureRegistry.unregisterTexture(textureId)
+    }
   }
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = ErikaFlutterPlugin(
       flutterHostView: registrar.view,
-      flutterHostViewController: registrar.viewController
+      flutterHostViewController: registrar.viewController,
+      textureRegistry: registrar.textures
     )
     instance.configureSystemPlayback()
     let playerChannel = FlutterMethodChannel(
@@ -2226,6 +2533,49 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         result(nil)
       case "close":
         try playerHost(from: try dictionaryArgs(call.arguments)).close()
+        result(nil)
+      case "createTexture":
+        let args = try dictionaryArgs(call.arguments)
+        let width = UInt32(clamping: max(1, int64Value(args["width"]) ?? 1))
+        let height = UInt32(clamping: max(1, int64Value(args["height"]) ?? 1))
+        let scale = max(0.1, doubleValue(args["scale"]) ?? 1.0)
+        guard width <= 16384, height <= 16384,
+              let texture = ErikaFlutterTextureSurface(
+                registry: textureRegistry,
+                width: width,
+                height: height,
+                scale: scale
+              ) else {
+          throw ErikaPluginError.invalidArguments("Unable to create Flutter texture surface.")
+        }
+        let textureId = texture.register()
+        guard textureId != 0 else {
+          throw ErikaPluginError.invalidArguments("Flutter rejected the texture surface.")
+        }
+        textures[textureId] = texture
+        result(textureId)
+      case "resizeTexture":
+        let args = try dictionaryArgs(call.arguments)
+        let textureId = try requiredInt64(args["textureId"], name: "textureId")
+        guard let texture = textures[textureId] else {
+          throw ErikaPluginError.viewNotFound(textureId)
+        }
+        let width = UInt32(clamping: max(1, int64Value(args["width"]) ?? 1))
+        let height = UInt32(clamping: max(1, int64Value(args["height"]) ?? 1))
+        let scale = max(0.1, doubleValue(args["scale"]) ?? 1.0)
+        guard width <= 16384, height <= 16384,
+              texture.resize(width: width, height: height, scale: scale) else {
+          throw ErikaPluginError.invalidArguments("Unable to resize Flutter texture surface.")
+        }
+        texture.attachedPlayer?.resizeFromAttachedTexture()
+        result(nil)
+      case "releaseTexture":
+        let args = try dictionaryArgs(call.arguments)
+        let textureId = try requiredInt64(args["textureId"], name: "textureId")
+        if let texture = textures.removeValue(forKey: textureId) {
+          texture.attachedPlayer?.detach(viewId: textureId)
+          textureRegistry.unregisterTexture(textureId)
+        }
         result(nil)
       case "seek":
         let args = try dictionaryArgs(call.arguments)
@@ -2498,10 +2848,13 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
         let args = try dictionaryArgs(call.arguments)
         let host = try playerHost(from: args)
         let viewId = try requiredInt64(args["viewId"], name: "viewId")
-        guard let view = views[viewId]?.view else {
+        if let texture = textures[viewId] {
+          try host.attach(texture: texture)
+        } else if let view = views[viewId]?.view {
+          try host.attach(view: view)
+        } else {
           throw ErikaPluginError.viewNotFound(viewId)
         }
-        try host.attach(view: view)
         result(nil)
       case "detachView":
         let args = try dictionaryArgs(call.arguments)
@@ -3001,24 +3354,32 @@ public final class ErikaFlutterPlugin: NSObject, FlutterPlugin, FlutterStreamHan
   }
 
   private func presenterConfigForNewPlayer(arguments: Any?) throws -> ErikaPresenterConfigC {
+    let alphaMode = (arguments as? [String: Any])
+      .flatMap { int32Value($0["videoAlphaMode"]) } ?? 0
     if let args = arguments as? [String: Any],
        let explicitMode = int32Value(args["outputMode"]) {
       let headroom = floatValue(args["edrHeadroom"]) ?? 4.0
+      var config: ErikaPresenterConfigC
       switch explicitMode {
       case 1:
-        return .appleEdr(headroom: headroom)
+        config = .appleEdr(headroom: headroom)
       case 2:
-        return ErikaPresenterConfigC(outputMode: 2, edrHeadroom: max(1.0, headroom))
+        config = ErikaPresenterConfigC(outputMode: 2, edrHeadroom: max(1.0, headroom))
       case 3:
-        return .auto(headroom: headroom)
+        config = .auto(headroom: headroom)
       default:
-        return .sdr
+        config = .sdr
       }
+      config.videoAlphaMode = alphaMode
+      return config
     }
 
     let headroom = resolvedEdrHeadroom()
     NSLog("ErikaFlutterPlugin: using automatic Apple output, headroom \(headroom)x")
-    return .auto(headroom: headroom)
+    let config = ErikaPresenterConfigC.auto(headroom: headroom)
+    var alphaConfig = config
+    alphaConfig.videoAlphaMode = alphaMode
+    return alphaConfig
   }
 
   private func resolvedEdrHeadroom() -> Float {

--- a/packages/erika_flutter/macos/erika_flutter.podspec
+++ b/packages/erika_flutter/macos/erika_flutter.podspec
@@ -25,6 +25,17 @@ PLUGIN_MACOS_DIR="$(cd "$PODS_TARGET_SRCROOT" && pwd -P)"
 PACKAGE_ROOT="$(cd "$PLUGIN_MACOS_DIR/.." && pwd -P)"
 ERIKA_NATIVE_PROFILE="${ERIKA_NATIVE_PROFILE:-lgpl}"
 HOST_JOBS="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+if [ -n "${ERIKA_REPO_ROOT:-}" ]; then
+  SOURCE_ROOT="$ERIKA_REPO_ROOT"
+elif [ -n "${ERIKA_ROOT:-}" ]; then
+  SOURCE_ROOT="$ERIKA_ROOT"
+else
+  SOURCE_ROOT="$(cd "$PACKAGE_ROOT/../.." && pwd -P)"
+fi
+USE_SOURCE_BUILD="${ERIKA_FORCE_SOURCE_BUILD:-0}"
+if [ "$USE_SOURCE_BUILD" != "1" ] && [ "${ERIKA_FORCE_PREBUILT:-0}" != "1" ] && [ -f "$SOURCE_ROOT/crates/erika_capi/Cargo.toml" ]; then
+  USE_SOURCE_BUILD=1
+fi
 
 if [ -n "${ERIKA_MACOS_CAPI_PROFILE:-}" ]; then
   CARGO_PROFILE="$ERIKA_MACOS_CAPI_PROFILE"
@@ -88,16 +99,9 @@ fi
 SOURCE_DYLIB=""
 if [ -n "${ERIKA_MACOS_CAPI_DYLIB:-}" ]; then
   SOURCE_DYLIB="$ERIKA_MACOS_CAPI_DYLIB"
-elif [ "${ERIKA_FORCE_SOURCE_BUILD:-0}" != "1" ]; then
+elif [ "$USE_SOURCE_BUILD" != "1" ]; then
   sh "$PACKAGE_ROOT/native/prepare_apple_prebuilt.sh"     macos macos "$PREBUILT_ARCH" "$DEST_DYLIB"
 else
-  if [ -n "${ERIKA_REPO_ROOT:-}" ]; then
-    SOURCE_ROOT="$ERIKA_REPO_ROOT"
-  elif [ -n "${ERIKA_ROOT:-}" ]; then
-    SOURCE_ROOT="$ERIKA_ROOT"
-  else
-    SOURCE_ROOT="$(cd "$PACKAGE_ROOT/../.." && pwd -P)"
-  fi
   if [ ! -f "$SOURCE_ROOT/crates/erika_capi/Cargo.toml" ]; then
     echo "error: ERIKA_FORCE_SOURCE_BUILD=1 requires an Erika checkout; set ERIKA_REPO_ROOT" >&2
     exit 1

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -167,10 +167,16 @@ typedef enum ErikaUpscalerBackendStatus {
   ErikaUpscalerBackendStatus_SimdgroupMatrix = 4,
 } ErikaUpscalerBackendStatus;
 
+typedef enum ErikaVideoAlphaMode {
+  ErikaVideoAlphaMode_Opaque = 0,
+  ErikaVideoAlphaMode_PackedAlphaRight = 1,
+} ErikaVideoAlphaMode;
+
 typedef struct ErikaPresenterConfig {
   int32_t output_mode;
   float edr_headroom;
   int32_t luma_upscaler;
+  int32_t video_alpha_mode;
 } ErikaPresenterConfig;
 
 #define ERIKA_SUBTITLE_OVERRIDE_FONT_SIZE_FIELDS (1u << 2)
@@ -502,6 +508,10 @@ ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig co
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(
     int32_t output_mode,
     float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(
+    int32_t output_mode,
+    float edr_headroom,
+    int32_t video_alpha_mode);
 void erika_presenter_destroy(ErikaPresenterHandle *handle);
 
 /* Playback and runtime parameters. volume is 0.0–1.0; rate 1.0 is normal speed;
@@ -665,6 +675,24 @@ ErikaStatus erika_presenter_attach_metal_layer(
     uint32_t width,
     uint32_t height,
     double scale);
+
+/* Flutter compositor texture surface. The registrar texture_id identifies the
+ * surface; before every render_tick, select the host-owned GPU target with
+ * set_flutter_texture_buffer. On Apple, raw_texture is an id<MTLTexture> using
+ * BGRA8Unorm. The texture remains owned by the host. */
+ErikaStatus erika_presenter_attach_flutter_texture(
+    ErikaPresenterHandle *handle,
+    ErikaFlutterTextureKind kind,
+    int64_t texture_id,
+    uint32_t width,
+    uint32_t height,
+    double scale);
+
+ErikaStatus erika_presenter_set_flutter_texture_buffer(
+    ErikaPresenterHandle *handle,
+    uint64_t raw_texture,
+    uint32_t width,
+    uint32_t height);
 
 ErikaStatus erika_presenter_attach_wgpu_surface(
     ErikaPresenterHandle *handle,

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -721,6 +721,13 @@ ErikaStatus erika_presenter_attach_windows_hwnd(
     uint32_t height,
     double scale);
 
+/* Windows only. Returns an AddRef'd IUnknown for a DirectComposition swap
+ * chain created by an attachment whose direct_composition capability is true.
+ * The caller owns the returned COM reference and must Release it. */
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_swapchain);
+
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' show BlendMode;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -40,10 +41,95 @@ void main() {
   });
 
   tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(playerChannel, null);
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(eventsChannel, null);
+  });
+
+  testWidgets('macOS texture video view creates and attaches a Flutter texture',
+      (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final player = ErikaPlayer();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(playerChannel, (MethodCall call) async {
+      playerCalls.add(call);
+      return switch (call.method) {
+        'create' => 7,
+        'createTexture' => 13,
+        _ => null,
+      };
+    });
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox(
+          width: 320,
+          height: 180,
+          child: ErikaTextureVideoView(player: player),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(Texture), findsOneWidget);
+    expect(playerCalls.map((call) => call.method), contains('createTexture'));
+    expect(playerCalls.map((call) => call.method), contains('attachView'));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await player.dispose();
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('macOS overlay video uses a native transparent compositing layer',
+      (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform_views, (
+      MethodCall call,
+    ) async {
+      return null;
+    });
+    final player = ErikaPlayer(
+      videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
+    );
+    try {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            width: 320,
+            height: 180,
+            child: ErikaTextureVideoView(
+              player: player,
+              blendMode: BlendMode.overlay,
+              opacity: 0.2,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(AppKitView), findsOneWidget);
+      expect(find.byType(Texture), findsNothing);
+      final view = tester.widget<AppKitView>(find.byType(AppKitView));
+      expect(view.creationParams, <String, Object?>{
+        'videoAlphaMode': ErikaVideoAlphaMode.packedAlphaRight.nativeValue,
+        'blendMode': 'overlay',
+        'opacity': 0.2,
+      });
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await player.dispose();
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform_views, null);
+    }
   });
 
   test('default player lets native choose output mode', () async {
@@ -350,6 +436,25 @@ void main() {
     );
     final arguments = createCall.arguments as Map<Object?, Object?>;
     expect(arguments['upscaler'], ErikaUpscalerMode.artCnnC4F16Ds.nativeValue);
+
+    await player.dispose();
+  });
+
+  test('packed alpha mode is passed to native create', () async {
+    final player = ErikaPlayer(
+      videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
+    );
+
+    expect(await player.ensureCreated(), 7);
+
+    final createCall = playerCalls.singleWhere(
+      (MethodCall call) => call.method == 'create',
+    );
+    final arguments = createCall.arguments as Map<Object?, Object?>;
+    expect(
+      arguments['videoAlphaMode'],
+      ErikaVideoAlphaMode.packedAlphaRight.nativeValue,
+    );
 
     await player.dispose();
   });

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui' show BlendMode;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -695,6 +694,8 @@ void main() {
     final viewId = await player.attachWindowOverlay(
       flutterViewId: 17,
       secondaryWindow: true,
+      blendMode: 'overlay',
+      opacity: 0.75,
     );
     await player.setWindowOverlayFrame(
       frame: const Rect.fromLTWH(10, 20, 320, 180),
@@ -703,6 +704,8 @@ void main() {
       flutterViewId: 17,
       secondaryWindow: true,
       debugLabel: 'episode.mkv',
+      blendMode: 'overlay',
+      opacity: 0.75,
     );
     await player.detachWindowOverlay(generation: 42);
 
@@ -715,6 +718,8 @@ void main() {
         'playerId': 7,
         'flutterViewId': 17,
         'secondaryWindow': true,
+        'blendMode': 'overlay',
+        'opacity': 0.75,
       },
     );
     expect(
@@ -733,6 +738,8 @@ void main() {
         'flutterViewId': 17,
         'secondaryWindow': true,
         'debugLabel': 'episode.mkv',
+        'blendMode': 'overlay',
+        'opacity': 0.75,
       },
     );
     expect(

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -63,6 +63,35 @@ void main() {
     expect(plugin, contains('metalLayer.opacity = Float('));
   });
 
+  test('Windows transparent video is composed into the Flutter HWND', () {
+    final plugin = File(
+      'windows/erika_flutter_plugin.cpp',
+    ).readAsStringSync();
+    final rendererFile = File('../../crates/erika/src/renderer/d3d11.rs');
+    if (!rendererFile.existsSync()) {
+      return;
+    }
+    final renderer = rendererFile.readAsStringSync();
+
+    expect(plugin, contains('config.video_alpha_mode ='));
+    expect(plugin, contains('capabilities.direct_composition = true'));
+    expect(plugin, contains('DCompositionCreateDevice2'));
+    expect(plugin, contains('CreateTargetForHwnd'));
+    expect(plugin, contains('CreateBlendEffect'));
+    expect(plugin, contains('D2D1_BLEND_MODE_OVERLAY'));
+    expect(plugin, contains('IDCompositionEffectGroup::SetOpacity'));
+    expect(plugin, contains('root_visual->SetEffect(effect)'));
+    expect(
+      plugin,
+      contains('erika_presenter_windows_composition_swapchain_iunknown'),
+    );
+    expect(renderer, contains('DXGI_ALPHA_MODE_PREMULTIPLIED'));
+    expect(
+      renderer,
+      contains('composition && self.video_alpha_mode.has_alpha()'),
+    );
+  });
+
   for (final entry in <(String, String)>[
     ('ios', 'scheduleTick()'),
     ('tvos', 'scheduleRenderTick()'),

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -35,6 +35,34 @@ void main() {
     expect(plugin, contains('stopPollTimerIfIdle()'));
   });
 
+  test('macOS Flutter texture path stays on IOSurface and Metal', () {
+    final plugin = File(
+      'macos/Classes/ErikaFlutterPlugin.swift',
+    ).readAsStringSync();
+
+    expect(plugin, contains('private final class ErikaFlutterTextureSurface'));
+    expect(plugin, contains('kCVPixelBufferIOSurfacePropertiesKey'));
+    expect(plugin, contains('CVMetalTextureCacheCreateTextureFromImage'));
+    expect(plugin, contains('library.setFlutterTextureBuffer('));
+    expect(plugin, contains('registry.textureFrameAvailable(id)'));
+    expect(plugin, isNot(contains('CVPixelBufferLockBaseAddress')));
+  });
+
+  test('macOS transparent platform view applies native overlay compositing',
+      () {
+    final plugin = File(
+      'macos/Classes/ErikaFlutterPlugin.swift',
+    ).readAsStringSync();
+
+    expect(plugin, contains('metalLayer.isOpaque = !alphaVideo'));
+    expect(plugin, contains('NSColor.clear.cgColor'));
+    expect(
+      plugin,
+      contains('metalLayer.compositingFilter = "overlayBlendMode"'),
+    );
+    expect(plugin, contains('metalLayer.opacity = Float('));
+  });
+
   for (final entry in <(String, String)>[
     ('ios', 'scheduleTick()'),
     ('tvos', 'scheduleRenderTick()'),
@@ -70,7 +98,8 @@ void main() {
     });
   }
 
-  test('iOS retries audio-session activation after an allowed interruption', () {
+  test('iOS retries audio-session activation after an allowed interruption',
+      () {
     final plugin = File(
       'ios/Classes/ErikaFlutterPlugin.swift',
     ).readAsStringSync();
@@ -123,7 +152,8 @@ void main() {
     );
   });
 
-  test('Android polls events on the presenter thread with adaptive scheduling', () {
+  test('Android polls events on the presenter thread with adaptive scheduling',
+      () {
     final plugin = File(
       'android/src/main/kotlin/dev/aimesoft/erika_flutter/'
       'ErikaFlutterPlugin.kt',

--- a/packages/erika_flutter/windows/CMakeLists.txt
+++ b/packages/erika_flutter/windows/CMakeLists.txt
@@ -41,6 +41,8 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE
   FLUTTER_PLUGIN_IMPL
+  _WIN32_WINNT=0x0A00
+  WINVER=0x0A00
   _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
 
 target_include_directories(${PLUGIN_NAME} INTERFACE
@@ -48,7 +50,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_include_directories(${PLUGIN_NAME} PRIVATE
   "${ERIKA_NATIVE_HEADER_DIR}")
 target_link_libraries(${PLUGIN_NAME} PRIVATE
-  flutter flutter_wrapper_plugin runtimeobject windowsapp shcore shlwapi)
+  flutter flutter_wrapper_plugin runtimeobject windowsapp dcomp shcore shlwapi)
 
 set(ERIKA_WINDOWS_ARCH "" CACHE STRING
   "Erika Windows architecture: x64, x86_64, arm64, or aarch64")

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -4,6 +4,10 @@
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
 
+#include <d2d1effects.h>
+#include <dcomp.h>
+#include <wrl/client.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cctype>
@@ -45,6 +49,16 @@ class PluginError : public std::runtime_error {
  public:
   explicit PluginError(const std::string& message) : std::runtime_error(message) {}
 };
+
+void CheckHResult(HRESULT result, const char* operation) {
+  if (SUCCEEDED(result)) {
+    return;
+  }
+  std::ostringstream message;
+  message << operation << " failed (HRESULT=0x" << std::hex << std::uppercase
+          << static_cast<uint32_t>(result) << ")";
+  throw PluginError(message.str());
+}
 
 std::string LastErrorMessage() {
   const DWORD error = GetLastError();
@@ -776,6 +790,11 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   using AttachWindowsHwndFn =
       ErikaStatus (*)(ErikaPresenterHandle*, uint64_t, uint64_t, uint32_t,
                       uint32_t, double);
+  using AttachWgpuSurfaceWithOutputCapabilitiesFn = ErikaStatus (*)(
+      ErikaPresenterHandle*, ErikaWgpuSurfaceKind, uint64_t, uint64_t,
+      uint32_t, uint32_t, double, ErikaSurfaceOutputCapabilities);
+  using GetWindowsCompositionSwapchainFn =
+      ErikaStatus (*)(ErikaPresenterHandle*, void**);
   using ResizeSurfaceFn =
       ErikaStatus (*)(ErikaPresenterHandle*, uint32_t, uint32_t, double);
   using RenderTickFn =
@@ -806,6 +825,11 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   ErikaPresenterHandle* CreatePresenter(ErikaPresenterConfig config) const {
     if (create_with_config != nullptr) {
       return create_with_config(config);
+    }
+    if (config.video_alpha_mode != ErikaVideoAlphaMode_Opaque) {
+      throw PluginError(
+          "The loaded erika_capi.dll does not support transparent-video "
+          "presenter configuration. Update the bundled Erika runtime.");
     }
     if (create_with_output_mode != nullptr) {
       return create_with_output_mode(config.output_mode, config.edr_headroom);
@@ -879,6 +903,9 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   TrackInfoFreeFn free_track_info = nullptr;
   DanmakuTrackInfoFreeFn free_danmaku_track_info = nullptr;
   AttachWindowsHwndFn attach_windows_hwnd = nullptr;
+  AttachWgpuSurfaceWithOutputCapabilitiesFn
+      attach_wgpu_surface_with_output_capabilities = nullptr;
+  GetWindowsCompositionSwapchainFn windows_composition_swapchain = nullptr;
   ResizeSurfaceFn resize_surface = nullptr;
   CommandFn detach_surface = nullptr;
   RenderTickFn render_tick = nullptr;
@@ -980,6 +1007,12 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         "erika_danmaku_track_info_free");
     attach_windows_hwnd =
         LoadRequired<AttachWindowsHwndFn>("erika_presenter_attach_windows_hwnd");
+    attach_wgpu_surface_with_output_capabilities =
+        LoadRequired<AttachWgpuSurfaceWithOutputCapabilitiesFn>(
+            "erika_presenter_attach_wgpu_surface_with_output_capabilities");
+    windows_composition_swapchain =
+        LoadOptional<GetWindowsCompositionSwapchainFn>(
+            "erika_presenter_windows_composition_swapchain_iunknown");
     resize_surface =
         LoadRequired<ResizeSurfaceFn>("erika_presenter_resize_surface");
     detach_surface =
@@ -1058,10 +1091,76 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
   }
 
   ~ErikaOverlayWindow() {
+    ShutdownComposition();
     if (hwnd != nullptr) {
       DestroyWindow(hwnd);
       hwnd = nullptr;
     }
+  }
+
+  void ConfigureComposition(std::string requested_blend_mode,
+                            double requested_opacity) {
+    if (requested_blend_mode.empty()) {
+      requested_blend_mode = "srcOver";
+    }
+    if (requested_blend_mode != "srcOver" &&
+        requested_blend_mode != "overlay") {
+      throw PluginError("Windows DirectComposition supports only srcOver and "
+                        "overlay blend modes.");
+    }
+    blend_mode = std::move(requested_blend_mode);
+    opacity = std::clamp(requested_opacity, 0.0, 1.0);
+    if (composition_mode && composition_device) {
+      ApplyCompositionState();
+    }
+  }
+
+  void SetCompositionMode(bool enabled) {
+    if (composition_mode == enabled) {
+      if (enabled) {
+        EnsureComposition();
+        ApplyCompositionState();
+      }
+      return;
+    }
+    composition_mode = enabled;
+    if (enabled) {
+      ShowWindow(hwnd, SW_HIDE);
+      EnsureComposition();
+      ApplyCompositionState();
+      return;
+    }
+    ClearCompositionContent();
+  }
+
+  void SetCompositionContent(void* raw_content) {
+    if (raw_content == nullptr) {
+      throw PluginError("Erika returned a null DirectComposition swap chain.");
+    }
+    Microsoft::WRL::ComPtr<IUnknown> next_content;
+    next_content.Attach(static_cast<IUnknown*>(raw_content));
+    EnsureComposition();
+    if (composition_content.Get() == next_content.Get()) {
+      return;
+    }
+    CheckHResult(content_visual->SetContent(next_content.Get()),
+                 "IDCompositionVisual::SetContent");
+    composition_content = std::move(next_content);
+    ApplyCompositionState();
+  }
+
+  void ClearCompositionContent() {
+    if (!composition_device || !content_visual) {
+      composition_content.Reset();
+      return;
+    }
+    CheckHResult(content_visual->SetContent(nullptr),
+                 "IDCompositionVisual::SetContent(null)");
+    composition_content.Reset();
+    CheckHResult(composition_target->SetRoot(nullptr),
+                 "IDCompositionTarget::SetRoot(null)");
+    CheckHResult(composition_device->Commit(),
+                 "IDCompositionDevice::Commit(clear)");
   }
 
   void SetFrame(double x,
@@ -1084,10 +1183,17 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     logical_height = height;
     visible = is_visible && width > 0.0 && height > 0.0;
     host = RootHostWindow(flutter);
-    scale = ScaleForWindow(host);
+    scale = ScaleForWindow(composition_mode ? flutter : host);
 
     if (debug_label) {
       SetWindowTextW(hwnd, Utf8ToWide(*debug_label).c_str());
+    }
+
+    if (composition_mode) {
+      ShowWindow(hwnd, SW_HIDE);
+      EnsureComposition();
+      ApplyCompositionState();
+      return;
     }
 
     if (!visible) {
@@ -1110,12 +1216,16 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
 
   uint32_t PixelWidth() const {
     return static_cast<uint32_t>(
-        std::max<int64_t>(1, LogicalToPhysical(host, logical_width)));
+        std::max<int64_t>(
+            1, LogicalToPhysical(composition_mode ? flutter : host,
+                                 logical_width)));
   }
 
   uint32_t PixelHeight() const {
     return static_cast<uint32_t>(
-        std::max<int64_t>(1, LogicalToPhysical(host, logical_height)));
+        std::max<int64_t>(
+            1, LogicalToPhysical(composition_mode ? flutter : host,
+                                 logical_height)));
   }
 
   void RefreshScaleAndReposition() {
@@ -1163,6 +1273,92 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     }
   }
 
+  void EnsureComposition() {
+    if (composition_device) {
+      return;
+    }
+    if (flutter == nullptr) {
+      throw PluginError("No Flutter HWND is available for DirectComposition.");
+    }
+
+    CheckHResult(
+        DCompositionCreateDevice2(
+            nullptr, __uuidof(IDCompositionDesktopDevice),
+            reinterpret_cast<void**>(desktop_device.ReleaseAndGetAddressOf())),
+        "DCompositionCreateDevice2");
+    CheckHResult(desktop_device.As(&composition_device),
+                 "QueryInterface(IDCompositionDevice3)");
+    CheckHResult(composition_device->CreateVisual(
+                     root_visual.ReleaseAndGetAddressOf()),
+                 "IDCompositionDevice::CreateVisual(root)");
+    CheckHResult(composition_device->CreateVisual(
+                     content_visual.ReleaseAndGetAddressOf()),
+                 "IDCompositionDevice::CreateVisual(content)");
+    CheckHResult(root_visual->AddVisual(content_visual.Get(), FALSE, nullptr),
+                 "IDCompositionVisual::AddVisual");
+    CheckHResult(composition_device->CreateEffectGroup(
+                     opacity_effect.ReleaseAndGetAddressOf()),
+                 "IDCompositionDevice::CreateEffectGroup");
+    CheckHResult(content_visual->SetEffect(opacity_effect.Get()),
+                 "IDCompositionVisual::SetEffect(opacity)");
+    CheckHResult(composition_device->CreateBlendEffect(
+                     overlay_blend_effect.ReleaseAndGetAddressOf()),
+                 "IDCompositionDevice3::CreateBlendEffect");
+    CheckHResult(overlay_blend_effect->SetMode(D2D1_BLEND_MODE_OVERLAY),
+                 "IDCompositionBlendEffect::SetMode");
+
+    HRESULT target_result = desktop_device->CreateTargetForHwnd(
+        flutter, TRUE, composition_target.ReleaseAndGetAddressOf());
+    if (FAILED(target_result)) {
+      target_result = desktop_device->CreateTargetForHwnd(
+          flutter, FALSE, composition_target.ReleaseAndGetAddressOf());
+    }
+    CheckHResult(target_result,
+                 "IDCompositionDesktopDevice::CreateTargetForHwnd");
+  }
+
+  void ApplyCompositionState() {
+    if (!composition_device) {
+      return;
+    }
+    IDCompositionEffect* effect = blend_mode == "overlay"
+                                     ? overlay_blend_effect.Get()
+                                     : nullptr;
+    CheckHResult(root_visual->SetEffect(effect),
+                 "IDCompositionVisual::SetEffect");
+    CheckHResult(opacity_effect->SetOpacity(static_cast<float>(opacity)),
+                 "IDCompositionEffectGroup::SetOpacity");
+    CheckHResult(content_visual->SetOffsetX(static_cast<float>(
+                     LogicalToPhysical(flutter, logical_x))),
+                 "IDCompositionVisual::SetOffsetX");
+    CheckHResult(content_visual->SetOffsetY(static_cast<float>(
+                     LogicalToPhysical(flutter, logical_y))),
+                 "IDCompositionVisual::SetOffsetY");
+    CheckHResult(
+        composition_target->SetRoot(
+            composition_mode && visible && composition_content
+                ? root_visual.Get()
+                : nullptr),
+        "IDCompositionTarget::SetRoot");
+    CheckHResult(composition_device->Commit(),
+                 "IDCompositionDevice::Commit");
+  }
+
+  void ShutdownComposition() {
+    if (composition_target && composition_device) {
+      composition_target->SetRoot(nullptr);
+      composition_device->Commit();
+    }
+    composition_content.Reset();
+    overlay_blend_effect.Reset();
+    opacity_effect.Reset();
+    content_visual.Reset();
+    root_visual.Reset();
+    composition_target.Reset();
+    composition_device.Reset();
+    desktop_device.Reset();
+  }
+
   HWND flutter = nullptr;
   HWND host = nullptr;
   HWND hwnd = nullptr;
@@ -1172,15 +1368,28 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
   double logical_width = 1.0;
   double logical_height = 1.0;
   bool visible = false;
+  bool composition_mode = false;
+  std::string blend_mode = "srcOver";
+  double opacity = 1.0;
   int64_t active_generation = 0;
   int64_t owner_player_id = 0;
+  Microsoft::WRL::ComPtr<IDCompositionDesktopDevice> desktop_device;
+  Microsoft::WRL::ComPtr<IDCompositionDevice3> composition_device;
+  Microsoft::WRL::ComPtr<IDCompositionTarget> composition_target;
+  Microsoft::WRL::ComPtr<IDCompositionVisual2> root_visual;
+  Microsoft::WRL::ComPtr<IDCompositionVisual2> content_visual;
+  Microsoft::WRL::ComPtr<IDCompositionEffectGroup> opacity_effect;
+  Microsoft::WRL::ComPtr<IDCompositionBlendEffect> overlay_blend_effect;
+  Microsoft::WRL::ComPtr<IUnknown> composition_content;
 };
 
 struct ErikaFlutterPlugin::PlayerHost {
   PlayerHost(int64_t player_id,
              std::shared_ptr<ErikaNativeLibrary> native_library,
              ErikaPresenterConfig config)
-      : id(player_id), library(std::move(native_library)) {
+      : id(player_id),
+        library(std::move(native_library)),
+        video_alpha_mode(config.video_alpha_mode) {
     smtc_state.player_id = player_id;
     handle = library->CreatePresenter(config);
     if (handle == nullptr) {
@@ -1724,12 +1933,31 @@ struct ErikaFlutterPlugin::PlayerHost {
     const uint32_t width = overlay.PixelWidth();
     const uint32_t height = overlay.PixelHeight();
     const double scale = overlay.scale;
-    const uint64_t hwnd = reinterpret_cast<uint64_t>(overlay.hwnd);
     const uint64_t hinstance = reinterpret_cast<uint64_t>(GetModuleHandleW(nullptr));
-    Check(library->attach_windows_hwnd(
-              handle, hwnd, hinstance, width, height, scale),
-          "attach_windows_hwnd", library->TakeLastError());
-    attached_hwnd = overlay.hwnd;
+    composition_surface = RequiresComposition(overlay);
+    overlay.SetCompositionMode(composition_surface);
+    if (composition_surface) {
+      overlay.ClearCompositionContent();
+      ErikaSurfaceOutputCapabilities capabilities{};
+      capabilities.direct_composition = true;
+      capabilities.fallback_reason = ErikaOutputFallbackReason_None;
+      Check(library->attach_wgpu_surface_with_output_capabilities(
+                handle, ErikaWgpuSurfaceKind_WindowsHwnd,
+                reinterpret_cast<uint64_t>(overlay.flutter), hinstance, width,
+                height, scale, capabilities),
+            "attach_wgpu_surface_with_output_capabilities",
+            library->TakeLastError());
+      attached_hwnd = overlay.flutter;
+      attached_overlay = &overlay;
+      RefreshCompositionContent();
+    } else {
+      Check(library->attach_windows_hwnd(
+                handle, reinterpret_cast<uint64_t>(overlay.hwnd), hinstance,
+                width, height, scale),
+            "attach_windows_hwnd", library->TakeLastError());
+      attached_hwnd = overlay.hwnd;
+      attached_overlay = nullptr;
+    }
     attached_view_id = kWindowOverlayViewId;
     surface_attached = true;
     attached_surface_width = width;
@@ -1739,7 +1967,8 @@ struct ErikaFlutterPlugin::PlayerHost {
   }
 
   void ResizeOverlay(ErikaOverlayWindow& overlay) {
-    if (!surface_attached || attached_hwnd != overlay.hwnd) {
+    const HWND expected_hwnd = composition_surface ? overlay.flutter : overlay.hwnd;
+    if (!surface_attached || attached_hwnd != expected_hwnd) {
       return;
     }
     const uint32_t width = overlay.PixelWidth();
@@ -1755,13 +1984,48 @@ struct ErikaFlutterPlugin::PlayerHost {
     attached_surface_width = width;
     attached_surface_height = height;
     attached_surface_scale = scale;
+    if (composition_surface) {
+      RefreshCompositionContent();
+    }
+  }
+
+  bool RequiresComposition(const ErikaOverlayWindow& overlay) const {
+    return video_alpha_mode != ErikaVideoAlphaMode_Opaque ||
+           overlay.blend_mode == "overlay";
+  }
+
+  void RefreshCompositionContent() {
+    if (!composition_surface || attached_overlay == nullptr) {
+      return;
+    }
+    if (library->windows_composition_swapchain == nullptr) {
+      throw PluginError(
+          "The loaded erika_capi.dll does not expose the DirectComposition "
+          "swap chain. Update the bundled Erika runtime.");
+    }
+    void* swapchain = nullptr;
+    Check(library->windows_composition_swapchain(handle, &swapchain),
+          "windows_composition_swapchain_iunknown",
+          library->TakeLastError());
+    attached_overlay->SetCompositionContent(swapchain);
   }
 
   void Detach(std::optional<int64_t> view_id) {
     if (view_id && attached_view_id != *view_id) {
       return;
     }
+    if (composition_surface && attached_overlay != nullptr &&
+        attached_overlay->owner_player_id == id) {
+      try {
+        attached_overlay->ClearCompositionContent();
+      } catch (const std::exception& error) {
+        DebugLog(std::string("DirectComposition detach failed: ") +
+                 error.what());
+      }
+    }
     attached_hwnd = nullptr;
+    attached_overlay = nullptr;
+    composition_surface = false;
     attached_view_id = 0;
     surface_attached = false;
     attached_surface_width = 0;
@@ -1781,6 +2045,14 @@ struct ErikaFlutterPlugin::PlayerHost {
                  library->TakeLastError());
       } else {
         latest_presenter_stats = stats;
+        if (composition_surface) {
+          try {
+            RefreshCompositionContent();
+          } catch (const std::exception& error) {
+            DebugLog(std::string("DirectComposition swap chain rebind failed: ") +
+                     error.what());
+          }
+        }
       }
     }
     PollEvents(event_sink);
@@ -1951,8 +2223,11 @@ struct ErikaFlutterPlugin::PlayerHost {
   std::shared_ptr<ErikaNativeLibrary> library;
   ErikaPresenterHandle* handle = nullptr;
   HWND attached_hwnd = nullptr;
+  ErikaOverlayWindow* attached_overlay = nullptr;
   int64_t attached_view_id = 0;
   bool surface_attached = false;
+  bool composition_surface = false;
+  int32_t video_alpha_mode = ErikaVideoAlphaMode_Opaque;
   uint32_t attached_surface_width = 0;
   uint32_t attached_surface_height = 0;
   double attached_surface_scale = 0.0;
@@ -2396,7 +2671,11 @@ ErikaFlutterPlugin::ErikaOverlayWindow& ErikaFlutterPlugin::EnsureOverlayWindow(
                           : "No Flutter HWND is available for Erika overlay.");
   }
   if (!overlay_window_ || overlay_window_->flutter != parent) {
+    const std::string blend_mode =
+        overlay_window_ ? overlay_window_->blend_mode : "srcOver";
+    const double opacity = overlay_window_ ? overlay_window_->opacity : 1.0;
     overlay_window_ = std::make_unique<ErikaOverlayWindow>(parent);
+    overlay_window_->ConfigureComposition(blend_mode, opacity);
     StartFrameTimer();
     for (auto& entry : players_) {
       if (entry.second->attached_view_id == kWindowOverlayViewId) {
@@ -2446,6 +2725,9 @@ int64_t ErikaFlutterPlugin::CreatePlayer(const EncodableValue* arguments) {
     }
     if (auto value = DoubleValue(FindArg(args, "edrHeadroom"))) {
       config.edr_headroom = static_cast<float>(std::max(1.0, *value));
+    }
+    if (auto value = Int64Value(FindArg(args, "videoAlphaMode"))) {
+      config.video_alpha_mode = static_cast<int32_t>(*value);
     }
   }
 
@@ -2833,6 +3115,9 @@ void ErikaFlutterPlugin::HandleMethodCall(
                           " was not found.");
       }
       auto& overlay = EnsureOverlayWindow();
+      overlay.ConfigureComposition(
+          StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
+          DoubleValue(FindArg(args, "opacity")).value_or(1.0));
       host.AttachOverlay(overlay);
       overlay.owner_player_id = host.id;
       OnFrameTimer();
@@ -2845,6 +3130,9 @@ void ErikaFlutterPlugin::HandleMethodCall(
       auto& host = PlayerFromArgs(args);
       UpdateOverlayTarget(args);
       auto& overlay = EnsureOverlayWindow();
+      overlay.ConfigureComposition(
+          StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
+          DoubleValue(FindArg(args, "opacity")).value_or(1.0));
       host.AttachOverlay(overlay);
       overlay.owner_player_id = host.id;
       OnFrameTimer();
@@ -2879,7 +3167,7 @@ void ErikaFlutterPlugin::HandleMethodCall(
       UpdateOverlayTarget(args);
       auto& overlay = EnsureOverlayWindow();
       const int64_t player_id = RequiredInt64(args, "playerId");
-      PlayerFromArgs(args);
+      auto& host = PlayerFromArgs(args);
       if (!visible && overlay.owner_player_id != 0 &&
           overlay.owner_player_id != player_id) {
         result->Success();
@@ -2887,6 +3175,14 @@ void ErikaFlutterPlugin::HandleMethodCall(
       }
       if (visible) {
         overlay.owner_player_id = player_id;
+      }
+      overlay.ConfigureComposition(
+          StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
+          DoubleValue(FindArg(args, "opacity")).value_or(1.0));
+      if (host.surface_attached &&
+          host.attached_view_id == kWindowOverlayViewId &&
+          host.composition_surface != host.RequiresComposition(overlay)) {
+        host.AttachOverlay(overlay);
       }
       overlay.SetFrame(DoubleValue(FindArg(args, "x")).value_or(0.0),
                        DoubleValue(FindArg(args, "y")).value_or(0.0),

--- a/packages/erika_ohos/src/main/cpp/include/erika.h
+++ b/packages/erika_ohos/src/main/cpp/include/erika.h
@@ -166,10 +166,16 @@ typedef enum ErikaUpscalerBackendStatus {
   ErikaUpscalerBackendStatus_SimdgroupMatrix = 4,
 } ErikaUpscalerBackendStatus;
 
+typedef enum ErikaVideoAlphaMode {
+  ErikaVideoAlphaMode_Opaque = 0,
+  ErikaVideoAlphaMode_PackedAlphaRight = 1,
+} ErikaVideoAlphaMode;
+
 typedef struct ErikaPresenterConfig {
   int32_t output_mode;
   float edr_headroom;
   int32_t luma_upscaler;
+  int32_t video_alpha_mode;
 } ErikaPresenterConfig;
 
 #define ERIKA_SUBTITLE_OVERRIDE_FONT_SIZE_FIELDS (1u << 2)
@@ -501,6 +507,10 @@ ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig co
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(
     int32_t output_mode,
     float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(
+    int32_t output_mode,
+    float edr_headroom,
+    int32_t video_alpha_mode);
 void erika_presenter_destroy(ErikaPresenterHandle *handle);
 
 /* Playback and runtime parameters. volume is 0.0–1.0; rate 1.0 is normal speed;


### PR DESCRIPTION
## 概述

本 PR 为 Erika 增加透明视频输入以及 macOS、Windows 原生 GPU 合成能力，使动画素材可以使用硬件视频解码替代 Dart/WebP 逐帧软件解码，同时保留透明度、Overlay 混合和现有 Flutter 布局能力。

## 主要变更

- 新增 `PackedAlphaRight` 视频 Alpha 模式：编码画面左半保存颜色、右半保存 Alpha，渲染时将逻辑宽度还原为一半。
- Metal、WGPU 和 D3D11 着色器在 GPU 中重建 Alpha，并输出预乘 Alpha 颜色；透明模式使用透明清屏。
- C ABI、Android JNI、Flutter Dart API 和 OpenHarmony 头文件完整传递视频 Alpha 模式，同时保留原有创建入口。
- macOS 新增基于 IOSurface 与 Metal 的 Flutter Texture 路径，无需逐帧 CPU 回读即可支持 Flutter 的透明度、裁剪、变换和颜色滤镜。
- macOS 对需要背景感知混合的透明视频改走原生 `CAMetalLayer`，支持 Core Animation 的 `overlayBlendMode` 与图层透明度。
- Windows 新增 D3D11 + DirectComposition 合成路径：
  - 透明视频使用 BGRA8 预乘 Alpha Composition Swap Chain。
  - 合成目标直接绑定 Flutter HWND，不再使用独立不透明弹窗覆盖游戏画面。
  - 支持 `srcOver`、`overlay` 和 `opacity`；Overlay 可以采样同一 HWND 中真实的游戏背景。
  - 解码器或输出设备重建 Swap Chain 后自动重新绑定 DirectComposition 内容。
  - 普通不透明视频保留原有 HWND 播放路径，避免影响现有行为。
- Android 透明视频表面改为非不透明，并将 Alpha 模式传入原生播放器。
- 将原生播放速率上限从 4× 提高至 16×，支持短动画和特效素材加速播放。
- 补充 Flutter 路由、Windows/macOS 合成契约、Packed Alpha 着色器及播放速率测试，并更新变更日志。

## 本次 Windows 修复

- 修复 Windows 创建播放器时漏传 `videoAlphaMode`，导致透明视频按不透明内容处理的问题。
- 修复 Windows Flutter 层未向原生插件传递 `blendMode` 与 `opacity` 的问题。
- 新增安全的 C ABI，用 AddRef/Release 所有权规则向插件提供 Erika Composition Swap Chain。
- 透明视频固定使用兼容 Alpha 的 SDR 合成输出；HDR 源会在 Erika 内部映射到该合成空间。
- 旧版 `erika_capi.dll` 仍可播放普通不透明视频；请求透明合成时会给出明确的运行库升级错误。

## 验证

- `cargo fmt --all -- --check`
- `flutter analyze --no-pub lib test`：无问题
- `flutter test --no-pub`：88 项测试全部通过
- Windows 插件完整 C++ 语法交叉检查通过至 Flutter SDK 自身的 MinGW 非兼容边界
- GitHub Windows x64 / ARM64 原生构建与 Flutter Windows 应用构建全部通过
- GitHub 全矩阵检查通过（20 项通过，1 项仅发布步骤按 PR 规则跳过）
- 使用本地 SakiEngine 游戏工程完成 macOS Debug 全量构建
- macOS 实际运行确认 H.264 由 VideoToolbox 解码，透明 CRT 视频能够以 Overlay 模式叠加，底层游戏画面保持可见

## 兼容性

- 默认 `Opaque + srcOver` 行为保持不变。
- 只有显式选择 Packed Alpha 的播放器才会按左右分区解释视频画面。
- Windows 透明或 Overlay 视频使用 DirectComposition；普通视频继续使用原有 HWND 路径。
- macOS 普通视频继续使用 Flutter Texture；只有非 `srcOver` 混合请求切换到原生 AppKit/Metal 合成层。
