### PR TITLE
docs: document transparent video, blend modes, and new presenter ABI

### DIFF
--- a/docs/building.ja.md
+++ b/docs/building.ja.md
@@ -122,6 +122,8 @@ package します。
 
 Flutter の依存 project は、macOS では `ERIKA_MACOS_ARCHS=arm64|x86_64|universal`、Windows では `ERIKA_WINDOWS_ARCH=x64|arm64`、Android では `ERIKA_ANDROID_ABIS=arm64-v8a,armeabi-v7a,x86_64,x86` で architecture を選択します。`ERIKA_FORCE_SOURCE_BUILD=1` を設定すると prebuilt download を無効化できます。
 
+Apple plugin の既定は checksum 検証済み prebuilt アーカイブですが、Erika checkout 内の macOS だけは例外です。pod script が package の上位に `crates/erika_capi/Cargo.toml` を見つけた場合（または `ERIKA_REPO_ROOT` が指す場合）、新しい prebuilt release を待たずにローカルの変更を取り込めるよう、`erika_capi` をソースからビルドします。`ERIKA_FORCE_PREBUILT=1` を設定すると常にアーカイブのダウンロードになります——Rust toolchain の無いリポジトリ内 consumer はこちらを使ってください。pub cache に解決された git dependency はリポジトリ全体を保持するため、こちらもソースビルドに切り替わる点に注意してください。
+
 native library を直接 build する場合、3 つの target 指定を一致させます：
 
 ```sh

--- a/docs/building.md
+++ b/docs/building.md
@@ -143,6 +143,15 @@ Windows with `ERIKA_WINDOWS_ARCH=x64|arm64`, and Android with
 `ERIKA_ANDROID_ABIS=arm64-v8a,armeabi-v7a,x86_64,x86`. Set
 `ERIKA_FORCE_SOURCE_BUILD=1` to bypass prebuilt downloads.
 
+The Apple plugins default to the checksummed prebuilt archive, except on macOS
+inside an Erika checkout: when the pod script finds
+`crates/erika_capi/Cargo.toml` above the package (or `ERIKA_REPO_ROOT` points
+at one), it builds `erika_capi` from source so local changes are picked up
+without a new prebuilt release. `ERIKA_FORCE_PREBUILT=1` always downloads the
+archive instead — use this for in-repo consumers without a Rust toolchain;
+note that git dependencies resolved into the pub cache keep the whole
+repository and therefore also switch to source builds.
+
 For direct native builds, keep all three target selectors identical:
 
 ```sh

--- a/docs/building.zh.md
+++ b/docs/building.zh.md
@@ -129,6 +129,8 @@ Hvigor/CMake 构建会自动执行这条链路，并把 `liberika_capi.so` 与
 
 Flutter 依赖项目通过 `ERIKA_MACOS_ARCHS=arm64|x86_64|universal` 选择 macOS 架构，通过 `ERIKA_WINDOWS_ARCH=x64|arm64` 选择 Windows 架构，通过 `ERIKA_ANDROID_ABIS=arm64-v8a,armeabi-v7a,x86_64,x86` 选择 Android ABI。设置 `ERIKA_FORCE_SOURCE_BUILD=1` 可强制跳过预构建包。
 
+Apple 插件默认使用带校验的预构建归档，唯一例外是 Erika checkout 内的 macOS：pod 脚本在包上层发现 `crates/erika_capi/Cargo.toml`（或 `ERIKA_REPO_ROOT` 指向 checkout）时，会改为从源码构建 `erika_capi`，使本地改动无需等待新的预构建发布即可生效。设置 `ERIKA_FORCE_PREBUILT=1` 可强制始终下载归档——仓库内没有 Rust 工具链的消费者请使用该开关；注意解析到 pub cache 的 git 依赖保留了整个仓库，因此同样会切换为源码构建。
+
 直接构建原生库时，三个目标参数必须一致：
 
 ```sh

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -217,13 +217,17 @@ Erika がフルスタックを所有し、ホストは surface を提供して `
 ErikaPresenterHandle *erika_presenter_create(void);
 ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig config);
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(int32_t output_mode, float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t output_mode, float edr_headroom,
+                                                                        int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
 
 `ErikaPresenterConfig` は出力モード（`Sdr`、Apple `AppleEdr`、Android
-`ExtendedLinear`）、requested EDR/scRGB content-headroom ceiling、初期輝度アップスケーラを選びます。
+`ExtendedLinear`）、requested EDR/scRGB content-headroom ceiling、初期輝度アップスケーラ、そして
+`video_alpha_mode`（`ErikaVideoAlphaMode`）を選びます。
 Android `ExtendedLinear` は FP16 extended-linear scRGB で HDR10/PQ ではありません。
-`create_with_output_mode` は短縮形、`create` は既定値（SDR、アップスケーラ無し）。
+`create_with_output_mode` と `create_with_output_mode_and_alpha` は短縮形、`create` は既定値
+（SDR、不透明 video、アップスケーラ無し）。
 `NULL` が返れば作成失敗——`erika_last_error_message` を確認。
 
 ### 再生とランタイムパラメータ
@@ -454,6 +458,38 @@ Android extended-linear では Flutter Hybrid Composition `SurfaceView` の
 Erika は Vulkan、`Rgba16Float`、`ADATASPACE_SCRGB_LINEAR` も検証します。どれかが失敗
 すると SDR に fallback し、その理由を取得できます。
 
+### Flutter texture surface
+
+```c
+ErikaStatus erika_presenter_attach_flutter_texture(ErikaPresenterHandle *, ErikaFlutterTextureKind kind,
+                                                   int64_t texture_id, uint32_t w, uint32_t h, double scale);
+ErikaStatus erika_presenter_set_flutter_texture_buffer(ErikaPresenterHandle *, uint64_t raw_texture,
+                                                       uint32_t w, uint32_t h);
+```
+
+`attach_flutter_texture` は `texture_id` で識別される texture-registrar surface に
+presenter を紐づけます（現在は Apple の
+`MacOsTextureRegistrar` / `IosTextureRegistrar`）。pixel buffer は host が所有します。**毎**
+`render_tick` の前に `set_flutter_texture_buffer` で次フレームの GPU target を選択し、
+`uint64_t` にキャストした `id<MTLTexture>` ポインタを渡します。`BGRA8Unorm` で宣言された
+`w`×`h` と一致している必要があります。texture はそのフレームの間だけ借用され、所有権は
+host 側に残るため、`render_tick` が返れば再利用も解放も可能です。Flutter plugin が macOS で
+使う `ErikaTextureVideoView` はこの surface です。
+
+### Windows DirectComposition swap chain
+
+```c
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(ErikaPresenterHandle *, void **out_swapchain);
+```
+
+Windows のみ。presenter が `attach_wgpu_surface_with_output_capabilities`
+（`direct_composition = true`）で attach され、透明 video alpha mode または overlay
+blend で再生する場合、Erika は対象 HWND 向けに premultiplied alpha の composition
+swap chain を作成します。この getter は **AddRef 済みの `IUnknown*`** として返します。
+返された COM reference の所有者は呼び出し側で、`Release` が必須です。decoder や device
+喪失の後は再取得してください——Erika は swap chain を再構築し、新しいオブジェクトを
+公開します。ポインタが同じなら再構築はありません。
+
 ### レンダーループとイベント
 
 ```c
@@ -588,6 +624,7 @@ free(rgba);
 | `ErikaTrackSource` | `Embedded` `External` |
 | `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
+| `ErikaVideoAlphaMode` | `Opaque` `PackedAlphaRight` |
 | `ErikaPresenterOutputMode` | `Auto` `Sdr` `AppleEdr` `ExtendedLinear` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
@@ -597,8 +634,9 @@ free(rgba);
 
 ## 構造体
 
-- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; }` —
-  `create_with_config` に値で渡す。
+- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; int32 video_alpha_mode; }` —
+  `create_with_config` に値で渡す。`video_alpha_mode` は `ErikaVideoAlphaMode`
+  （既定 `Opaque`、左右分割の color/alpha asset には `PackedAlphaRight`）。
 - **`ErikaSurfaceOutputCapabilities`** `{ bool extended_linear; bool direct_composition; float desired_headroom; int32 fallback_reason; }` —— attach 時に渡す Android host の display/surface probe result。`desired_headroom == 0` は system auto。
 - **`ErikaUpscalerStatus`** —— 要求モード、現在の backend、フォールバック回数、
   アップスケール済みフレーム数、直近の encode/GPU マイクロ秒。

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -236,16 +236,19 @@ Erika owns the full stack; the host supplies a surface and calls `render_tick`.
 ErikaPresenterHandle *erika_presenter_create(void);
 ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig config);
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(int32_t output_mode, float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t output_mode, float edr_headroom,
+                                                                        int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
 
 `ErikaPresenterConfig` selects the output mode (`Sdr`, Apple `AppleEdr`, or
 Android `ExtendedLinear`), the requested EDR/scRGB content-headroom ceiling,
-and the initial
-luma upscaler. Android `ExtendedLinear` means FP16 extended-linear scRGB, not
-HDR10/PQ. `create_with_output_mode` is a shorthand; `create` uses defaults
-(SDR, no upscaler). A `NULL` return means creation failed — check
-`erika_last_error_message`.
+the initial luma upscaler, and the `video_alpha_mode`
+(`ErikaVideoAlphaMode`). Android `ExtendedLinear` means FP16 extended-linear
+scRGB, not HDR10/PQ. `create_with_output_mode` and
+`create_with_output_mode_and_alpha` are shorthands; `create` uses defaults
+(SDR, opaque video, no upscaler). A `NULL` return means creation failed —
+check `erika_last_error_message`.
 
 ### Playback and runtime parameters
 
@@ -499,6 +502,40 @@ per-`SurfaceView` `setDesiredHdrHeadroom`. Erika still verifies Vulkan,
 `Rgba16Float`, and `ADATASPACE_SCRGB_LINEAR` itself; failure of any condition
 falls back to SDR and remains queryable.
 
+### Flutter texture surfaces
+
+```c
+ErikaStatus erika_presenter_attach_flutter_texture(ErikaPresenterHandle *, ErikaFlutterTextureKind kind,
+                                                   int64_t texture_id, uint32_t w, uint32_t h, double scale);
+ErikaStatus erika_presenter_set_flutter_texture_buffer(ErikaPresenterHandle *, uint64_t raw_texture,
+                                                       uint32_t w, uint32_t h);
+```
+
+`attach_flutter_texture` binds the presenter to a texture-registrar surface
+identified by `texture_id` (Apple `MacOsTextureRegistrar`/`IosTextureRegistrar`
+today). The host owns the pixel buffers; before **every** `render_tick` it
+selects the GPU target for the next frame with
+`set_flutter_texture_buffer`, passing an `id<MTLTexture>` pointer cast to
+`uint64_t` that must use `BGRA8Unorm` and match the declared `w`×`h`. The
+texture is only borrowed for the duration of the frame — the host keeps
+ownership and may reuse or free it once `render_tick` returns. This is the
+surface the Flutter plugin's `ErikaTextureVideoView` uses on macOS.
+
+### Windows DirectComposition swap chain
+
+```c
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(ErikaPresenterHandle *, void **out_swapchain);
+```
+
+Windows only. When the presenter was attached through
+`attach_wgpu_surface_with_output_capabilities` with `direct_composition = true`
+(and the presenter plays with a transparent video alpha mode or an overlay
+blend), Erika creates a premultiplied-alpha composition swap chain for the
+target HWND. This getter returns it as an **AddRef'd `IUnknown*`**: the caller
+owns the returned COM reference and must `Release` it. Re-fetch it after
+decoder/device loss — Erika recreates the swap chain and exposes the new
+object; the same pointer means nothing was rebuilt.
+
 ### Render loop and events
 
 ```c
@@ -653,6 +690,7 @@ snapshots from the same runtime state as `get_output_status`.
 | `ErikaTrackSource` | `Embedded` `External` |
 | `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
+| `ErikaVideoAlphaMode` | `Opaque` `PackedAlphaRight` |
 | `ErikaPresenterOutputMode` | `Sdr` `AppleEdr` `ExtendedLinear` `Auto` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
@@ -662,8 +700,10 @@ snapshots from the same runtime state as `get_output_status`.
 
 ## Structs
 
-- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; }` —
-  passed by value to `create_with_config`.
+- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; int32 video_alpha_mode; }` —
+  passed by value to `create_with_config`; `video_alpha_mode` is an
+  `ErikaVideoAlphaMode` (`Opaque` default, `PackedAlphaRight` for side-by-side
+  colour/alpha assets).
 - **`ErikaSurfaceOutputCapabilities`** `{ bool extended_linear; bool direct_composition; float desired_headroom; int32 fallback_reason; }` — host-side Android display/surface probe supplied at attach time; `desired_headroom == 0` selects system auto.
 - **`ErikaUpscalerStatus`** — requested mode, active backend, fallback count,
   upscaled frames, last encode/GPU micros.

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -215,13 +215,17 @@ Erika 拥有完整栈；宿主提供 surface 并调用 `render_tick`。
 ErikaPresenterHandle *erika_presenter_create(void);
 ErikaPresenterHandle *erika_presenter_create_with_config(ErikaPresenterConfig config);
 ErikaPresenterHandle *erika_presenter_create_with_output_mode(int32_t output_mode, float edr_headroom);
+ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t output_mode, float edr_headroom,
+                                                                        int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
 
 `ErikaPresenterConfig` 选择输出模式（`Sdr`、Apple `AppleEdr`、Android
-`ExtendedLinear`）、请求的 EDR/scRGB 内容 headroom 上限和初始亮度超分。Android
+`ExtendedLinear`）、请求的 EDR/scRGB 内容 headroom 上限、初始亮度超分，以及
+`video_alpha_mode`（`ErikaVideoAlphaMode`）。Android
 `ExtendedLinear` 是 FP16 extended-linear scRGB，不是 HDR10/PQ。
-`create_with_output_mode` 是简写；`create` 用默认值（SDR、无超分）。返回 `NULL` 表示
+`create_with_output_mode` 与 `create_with_output_mode_and_alpha` 是简写；`create` 用默认值
+（SDR、不透明视频、无超分）。返回 `NULL` 表示
 创建失败——检查 `erika_last_error_message`。
 
 ### 播放与运行时参数
@@ -429,6 +433,37 @@ Android extended-linear 应把 Flutter Hybrid Composition `SurfaceView` 对应�
 验证 Vulkan、`Rgba16Float` 和 `ADATASPACE_SCRGB_LINEAR`；任何一项失败都会回退 SDR，
 且原因可查询。
 
+### Flutter texture surface
+
+```c
+ErikaStatus erika_presenter_attach_flutter_texture(ErikaPresenterHandle *, ErikaFlutterTextureKind kind,
+                                                   int64_t texture_id, uint32_t w, uint32_t h, double scale);
+ErikaStatus erika_presenter_set_flutter_texture_buffer(ErikaPresenterHandle *, uint64_t raw_texture,
+                                                       uint32_t w, uint32_t h);
+```
+
+`attach_flutter_texture` 把 presenter 绑定到由 `texture_id` 标识的
+texture-registrar surface（目前为 Apple 的
+`MacOsTextureRegistrar`/`IosTextureRegistrar`）。pixel buffer 由宿主持有；在**每次**
+`render_tick` 之前，用 `set_flutter_texture_buffer` 选定下一帧的 GPU 目标，传入
+强制转换为 `uint64_t` 的 `id<MTLTexture>` 指针，且必须是 `BGRA8Unorm` 格式并与声明的
+`w`×`h` 一致。该纹理只在当帧内被借用——宿主保持所有权，可在 `render_tick`
+返回后复用或释放。Flutter 插件在 macOS 上的 `ErikaTextureVideoView`
+使用的就是这个 surface。
+
+### Windows DirectComposition swap chain
+
+```c
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(ErikaPresenterHandle *, void **out_swapchain);
+```
+
+仅限 Windows。当 presenter 通过
+`attach_wgpu_surface_with_output_capabilities`（`direct_composition = true`）attach，
+且以透明视频 alpha 模式或 overlay 混合播放时，Erika 会为目标 HWND 创建预乘 alpha 的
+composition swap chain。此 getter 以 **AddRef 后的 `IUnknown*`** 返回它：调用者拥有返回的
+COM 引用，必须自行 `Release`。解码器/设备丢失后应重新获取——Erika 会重建 swap chain
+并暴露新对象；指针未变说明没有重建。
+
 ### 渲染循环与事件
 
 ```c
@@ -554,6 +589,7 @@ free(rgba);
 | `ErikaTrackSource` | `Embedded` `External` |
 | `ErikaWgpuSurfaceKind` | `Unknown` `MacOsNsView` `MacOsCaMetalLayer` `IosUiView` `WindowsHwnd` `XlibWindow` `WaylandSurface` `AndroidNativeWindow` `OhosNativeWindow` |
 | `ErikaFlutterTextureKind` | `Unknown` `MacOsTextureRegistrar` `IosTextureRegistrar` `AndroidSurfaceTexture` `WindowsTextureRegistrar` `LinuxTextureRegistrar` |
+| `ErikaVideoAlphaMode` | `Opaque` `PackedAlphaRight` |
 | `ErikaPresenterOutputMode` | `Auto` `Sdr` `AppleEdr` `ExtendedLinear` |
 | `ErikaActiveOutputEncoding` | `SdrSrgb` `AppleEdr` `AndroidExtendedLinearScRgb` `Hdr10Pq` |
 | `ErikaOutputSurfaceFormat` | `EightBitUnorm` `TenBitUnorm` `SixteenBitFloat` |
@@ -563,8 +599,9 @@ free(rgba);
 
 ## 结构体
 
-- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; }` —
-  按值传给 `create_with_config`。
+- **`ErikaPresenterConfig`** `{ int32 output_mode; float edr_headroom; int32 luma_upscaler; int32 video_alpha_mode; }` —
+  按值传给 `create_with_config`；`video_alpha_mode` 是 `ErikaVideoAlphaMode`
+  （默认 `Opaque`，左右分区颜色/alpha 素材用 `PackedAlphaRight`）。
 - **`ErikaSurfaceOutputCapabilities`** `{ bool extended_linear; bool direct_composition; float desired_headroom; int32 fallback_reason; }` —— attach 时传入的 Android 宿主显示器/surface 探测结果；`desired_headroom == 0` 表示系统 auto。
 - **`ErikaUpscalerStatus`** —— 请求模式、当前后端、fallback 次数、超分帧数、最近
   encode/GPU 微秒。

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -37,6 +37,12 @@ HDR/EDR の推奨 path は、Flutter の platform-view compositor の外側に�
 
 touch events は両方の native video strategy を通過するので、Flutter controls を video surface の上や周囲に置けます。
 
+### ErikaTextureVideoView (Flutter Texture)
+
+`ErikaTextureVideoView` は platform view ではなく Flutter の texture registrar 経由で描画します。macOS では plugin が IOSurface-backed の `CVPixelBuffer` pool を確保し、その Metal texture に直接描画（フレームごとの CPU readback なし）して Flutter へ frame を publish するため、`Opacity`、clipping、transform、color filter といった通常の Flutter effect が video に適用されます。OpenHarmony では登録済みの external texture を再利用します。それ以外の platform では `ErikaVideoView` に fallback します。
+
+macOS で `blendMode` が `srcOver` 以外の場合、widget は native platform view に切り替え、Core Animation に実際の背景に対する blending を任せます（下記「透明 video と blend mode」を参照）。
+
 ## Android Surface Strategies
 
 Android では 2 つの video widget が同じ native-view selector を使います。SDR は実体のある
@@ -71,6 +77,39 @@ fallback します。fallback は再生を失敗させず、`VideoDecoderChanged
 presenter diagnostics から報告されます。HarmonyOS path は実機で検証済みですが、
 CI は OpenHarmony C ABI をビルドしますが、デバイス側の実行検証はありません。
 
+## 透明 video と blend mode
+
+Erika は Flutter の layout / composition を保ったまま alpha を持つ video asset を表示できます。透明は player ごとに要求します。
+
+```dart
+final player = ErikaPlayer(
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
+);
+```
+
+`ErikaVideoAlphaMode.packedAlphaRight` は左右分割の encoded frame を前提とします。左半分が color、右半分が grayscale alpha mask です。GPU の presentation shader（Metal / wgpu / D3D11）が premultiplied alpha の frame を再構築し、video は encoded width の半分のサイズで表示されます。この mode を要求しない player は frame を完全な不透明として扱うため、既存 content には影響しません。
+
+blending と opacity は video widget に指定します。
+
+```dart
+ErikaTextureVideoView(
+  player: player,
+  blendMode: BlendMode.overlay,
+  opacity: 0.8,
+)
+```
+
+対応状況は platform によって異なります。
+
+| Platform と path | `blendMode` | `opacity` |
+|------------------|-------------|-----------|
+| macOS、`ErikaTextureVideoView`（Flutter texture） | `srcOver` のみ。それ以外は native layer に切替 | Flutter `Opacity` |
+| macOS、native layer（`blendMode != srcOver`） | `overlay` 対応。他の値は無視 | native `CALayer` opacity |
+| Windows window overlay（DirectComposition） | `srcOver` / `overlay`。他の値は plugin error | `IDCompositionEffectGroup` opacity |
+| Android / iOS / OpenHarmony | creation parameter としては受け取るが未使用 | texture path では Flutter 側で適用 |
+
+overlay blending は backdrop-aware です。macOS の native layer は window 内で video の背後にある content に対して合成し、Windows の blend effect は同じ HWND を sampling するため、背後の Flutter や game の画面は見えたまま維持されます。Windows の透明 overlay video は Flutter HWND に bind した SDR BGRA8 premultiplied composition swap chain を使い、HDR source は Erika 内部でその合成空間へ tone map されます。不透明な Windows overlay video は従来どおり専用 child HWND path を使います。decoder や output device が swap chain を再構築した場合は composition content が自動で再 bind されます。
+
 ## iOS Build Path
 
 iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を app にリンクします。既定では一致する prebuilt アーカイブをダウンロードし、`ERIKA_FORCE_SOURCE_BUILD=1`（`ERIKA_REPO_ROOT` と併用）で初めて対象 iOS architecture 向けに Rust の `erika_capi` crate をビルドします。
@@ -78,6 +117,10 @@ iOS plugin は CocoaPod script phase 経由で Erika C ABI static library を ap
 ## tvOS Build Path
 
 tvOS plugin は CocoaPod script phase 経由で Erika C ABI static library をリンクします。iOS と同様に既定では prebuilt アーカイブをダウンロードし、`ERIKA_FORCE_SOURCE_BUILD=1` のときのみソースビルドします。tvOS 13+、arm64 実機、arm64/x86_64 simulator に対応します。Rust nightly、prebuilt bundle、source build の詳細は [`packages/erika_flutter/README.ja.md`](../packages/erika_flutter/README.ja.md) を参照してください。
+
+## macOS Build Path
+
+macOS pod も同じ script-phase build を使います。Erika checkout の内部（package の上位に `crates/erika_capi/Cargo.toml` がある、または `ERIKA_REPO_ROOT` が checkout を指す場合）では、既定で Rust `erika_capi` をソースからビルドします。そのため local renderer の変更は新しい prebuilt release を待たずに取り込まれます。公開 package と isolated consumer——pub cache に解決された git dependency を含みます（リポジトリ全体が保持されるため、これもソースビルドになります）——でこの path を使うには Rust toolchain が必要です。`ERIKA_FORCE_PREBUILT=1` を設定すると、 checksum 検証済みの prebuilt アーカイブのダウンロードに固定できます。
 
 ## Minimal Presenter Flow
 
@@ -111,9 +154,10 @@ Flutter Texture は機能が限定された compatibility path です。
 用途:
 - SDR fallback。
 - native view composition がまだ使えない platform。
+- Flutter compositor に入るべき透明 video（macOS / OpenHarmony の `ErikaTextureVideoView`）。
 - test surface や制約の強い embedding 環境。
 
-HDR/EDR の推奨 path ではありません。video が Flutter compositor に入ってしまうためです。C ABI はこの path のために `erika_attach_flutter_texture` を確保しています。
+HDR/EDR の推奨 path ではありません。video が Flutter compositor に入ってしまうためです。Apple では surface は IOSurface-backed の `CVPixelBuffer` です。host が Flutter texture を登録し、毎 render tick の前に `erika_presenter_attach_flutter_texture` と `erika_presenter_set_flutter_texture_buffer` でその frame の Metal texture を選択すると、Flutter が同じ buffer を CPU readback なしで合成します。pixel buffer の所有権は host 側にあります。
 
 ## wgpu と Android
 
@@ -131,6 +175,8 @@ API 35 HDR device の active-path acceptance は未完了です。Linux support 
 final player = ErikaPlayer(
   outputMode: ErikaOutputMode.appleEdr,  // optional: force EDR
   edrHeadroom: 4.0,                      // optional: EDR headroom
+  // optional: 左右分割の color/alpha asset を透明で表示
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
 );
 
 await player.open(
@@ -144,6 +190,9 @@ await player.play();
 
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
+
+// Flutter 合成の video。opacity / clipping / filter に対応（macOS/OpenHarmony）:
+ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility/diagnostic platform-view path:
 ErikaVideoView(player: player)

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -59,6 +59,20 @@ sibling `NSView`/`CAMetalLayer`.
 Touch events pass through both native video strategies, so Flutter controls can
 remain above or around the video surface.
 
+### ErikaTextureVideoView (Flutter Texture)
+
+`ErikaTextureVideoView` renders through Flutter's texture registrar instead of a
+platform view. On macOS the plugin allocates an IOSurface-backed
+`CVPixelBuffer` pool, renders into its Metal texture directly (no per-frame CPU
+readback), and publishes frames to Flutter, so regular Flutter effects —
+`Opacity`, clipping, transforms, and color filters — apply to the video. On
+OpenHarmony it reuses the registered external texture. On other platforms it
+falls back to `ErikaVideoView`.
+
+When `blendMode` is not `srcOver` on macOS, the widget routes back to the native
+platform view so Core Animation can blend the video against the real backdrop
+(see Transparent Video and Blend Modes below).
+
 ## Android Surface Strategies
 
 On Android, both video widgets use the same native-view selector. SDR uses a
@@ -95,6 +109,52 @@ events and presenter diagnostics instead of failing playback. The HarmonyOS
 path is validated on device; CI builds the OpenHarmony C ABI but has no
 device-side run verification.
 
+## Transparent Video and Blend Modes
+
+Erika can present alpha-bearing video assets while keeping Flutter layout and
+composition. Transparency is requested per player:
+
+```dart
+final player = ErikaPlayer(
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
+);
+```
+
+`ErikaVideoAlphaMode.packedAlphaRight` expects a side-by-side encoded frame:
+the left half is colour and the right half is a grayscale alpha mask. The GPU
+presentation shaders (Metal, wgpu, D3D11) reconstruct a premultiplied-alpha
+frame, and the video is presented at half the encoded width. Players that do
+not request the mode interpret the frame as fully opaque, so existing content
+is unaffected.
+
+Blending and opacity are requested on the video widgets:
+
+```dart
+ErikaTextureVideoView(
+  player: player,
+  blendMode: BlendMode.overlay,
+  opacity: 0.8,
+)
+```
+
+Platform support differs:
+
+| Platform and path | `blendMode` | `opacity` |
+|-------------------|-------------|-----------|
+| macOS, `ErikaTextureVideoView` (Flutter texture) | `srcOver` only; other modes route to the native layer | Flutter `Opacity` |
+| macOS, native layer (`blendMode != srcOver`) | `overlay` supported; other values ignored | Native `CALayer` opacity |
+| Windows window overlay (DirectComposition) | `srcOver`, `overlay`; other values raise a plugin error | `IDCompositionEffectGroup` opacity |
+| Android / iOS / OpenHarmony | Accepted in creation parameters; not consumed | Flutter-side on texture paths |
+
+Overlay blending is backdrop-aware: the macOS native layer composites against
+the content behind the video inside the window, and the Windows blend effect
+samples the same HWND, so the underlying Flutter or game content stays visible.
+Transparent Windows overlay video uses an SDR BGRA8 premultiplied composition
+swap chain bound to the Flutter HWND; HDR sources are tone-mapped into that
+composition space inside Erika. Opaque Windows overlay video keeps the
+dedicated child-HWND path used previously, and the composition content is
+rebound automatically if the decoder or output device rebuilds the swap chain.
+
 ## iOS Build Path
 
 The iOS plugin links the Erika C ABI static library into the app through a
@@ -110,6 +170,17 @@ phase. Like iOS it downloads the prebuilt archive by default, with
 tvOS 13+, arm64 devices, and arm64/x86_64 simulators. See
 [`packages/erika_flutter/README.md`](../packages/erika_flutter/README.md) for
 nightly, prebuilt-bundle, and source-build options.
+
+## macOS Build Path
+
+The macOS pod uses the same script-phase build. Inside an Erika checkout (when
+`crates/erika_capi/Cargo.toml` exists above the package, or `ERIKA_REPO_ROOT`
+points at one) it builds the Rust `erika_capi` from source by default, so local
+renderer changes are picked up without a new prebuilt release. Published
+packages and isolated consumers — including git dependencies resolved into the
+pub cache, which keep the whole repository and therefore also build from
+source — need a Rust toolchain for that path; set `ERIKA_FORCE_PREBUILT=1` to
+always download the checksummed prebuilt archive instead.
 
 ## Minimal Presenter Flow
 
@@ -143,10 +214,17 @@ Flutter Texture is a lower-capability compatibility path.
 Useful for:
 - SDR fallback.
 - Platforms where native view composition is not ready.
+- Transparent video that should participate in Flutter's compositor
+  (`ErikaTextureVideoView` on macOS and OpenHarmony).
 - Test surfaces or constrained embedding environments.
 
-Not the preferred HDR/EDR route because video enters Flutter's compositor. The
-C ABI reserves `erika_attach_flutter_texture` for this path.
+It is not the preferred HDR/EDR route because video enters Flutter's
+compositor. On Apple the surface is an IOSurface-backed `CVPixelBuffer`: the
+host registers a Flutter texture, selects the frame's Metal texture with
+`erika_presenter_attach_flutter_texture` and
+`erika_presenter_set_flutter_texture_buffer` before every render tick, and
+Flutter composites the same buffer without a CPU readback. The host keeps
+ownership of the pixel buffers.
 
 ## wgpu and Android
 
@@ -165,6 +243,8 @@ acceptance remains pending. Linux support remains planned.
 final player = ErikaPlayer(
   outputMode: ErikaOutputMode.appleEdr,  // optional: force EDR
   edrHeadroom: 4.0,                      // optional: EDR headroom
+  // optional: side-by-side colour/alpha assets presented with transparency
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
 );
 
 await player.open(
@@ -178,6 +258,9 @@ await player.play();
 
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
+
+// Flutter-composited video with opacity/clipping/filters (macOS/OpenHarmony):
+ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility/diagnostic platform-view path:
 ErikaVideoView(player: player)

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -37,6 +37,12 @@ Apple HDR 路径使用 native Metal-backed surface，而不是 Flutter Texture�
 
 触摸事件会穿透两种 native video strategy，因此 Flutter controls 可以保持在视频 surface 上方或周围。
 
+### ErikaTextureVideoView (Flutter Texture)
+
+`ErikaTextureVideoView` 通过 Flutter 的 texture registrar 渲染，而不是 platform view。macOS 上 plugin 会分配 IOSurface-backed 的 `CVPixelBuffer` 池，直接渲染进其 Metal texture（无逐帧 CPU 回读），再把帧发布给 Flutter，因此 `Opacity`、裁剪、变换和颜色滤镜等常规 Flutter 效果都作用在视频上。OpenHarmony 上复用已注册的外部纹理。其他平台回退到 `ErikaVideoView`。
+
+macOS 上当 `blendMode` 不是 `srcOver` 时，widget 会改走 native platform view，让 Core Animation 基于真实背景做混合（见下文"透明视频与混合模式"）。
+
 ## Android Surface Strategies
 
 Android 上两个视频 widget 都使用同一套 native-view selector。SDR 使用真实的
@@ -65,6 +71,39 @@ surface 取为 `OHNativeWindow` 并 attach 给 presenter；wgpu 随后通过 Vul
 `VideoDecoderChanged` 事件和 presenter 诊断上报，而不是让播放失败。HarmonyOS
 路径已在真机验证；CI 构建 OpenHarmony C ABI，但无设备侧运行验证。
 
+## 透明视频与混合模式
+
+Erika 可以呈现带透明度的视频素材，同时保留 Flutter 的布局与合成能力。透明度按 player 请求：
+
+```dart
+final player = ErikaPlayer(
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
+);
+```
+
+`ErikaVideoAlphaMode.packedAlphaRight` 要求左右分区的编码帧：左半是颜色，右半是灰度 alpha 蒙版。GPU 呈现着色器（Metal、wgpu、D3D11）会重建预乘 alpha 的帧，视频以编码宽度的一半呈现。未请求该模式的 player 仍将画面视为完全不透明，因此既有内容不受影响。
+
+混合与不透明度在视频 widget 上请求：
+
+```dart
+ErikaTextureVideoView(
+  player: player,
+  blendMode: BlendMode.overlay,
+  opacity: 0.8,
+)
+```
+
+各平台支持范围不同：
+
+| 平台与路径 | `blendMode` | `opacity` |
+|------------|-------------|-----------|
+| macOS，`ErikaTextureVideoView`（Flutter texture） | 仅 `srcOver`；其他值改走 native 层 | Flutter `Opacity` |
+| macOS，native 层（`blendMode != srcOver`） | 支持 `overlay`；其他值忽略 | Native `CALayer` opacity |
+| Windows 窗口 overlay（DirectComposition） | `srcOver`、`overlay`；其他值抛插件错误 | `IDCompositionEffectGroup` opacity |
+| Android / iOS / OpenHarmony | 接受创建参数但不消费 | texture 路径上由 Flutter 侧应用 |
+
+overlay 混合是背景感知的：macOS 的 native 层基于窗口内视频背后的内容合成，Windows 的 blend effect 采样同一个 HWND，因此底层的 Flutter 或游戏画面保持可见。Windows 透明 overlay 视频使用绑定到 Flutter HWND 的 SDR BGRA8 预乘 composition swap chain；HDR 片源会在 Erika 内部 tone map 到该合成空间。不透明的 Windows overlay 视频仍沿用之前的专用子 HWND 路径；解码器或输出设备重建 swap chain 时会自动重新绑定 composition 内容。
+
 ## iOS Build Path
 
 iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进 app。默认下载匹配的预构建归档；设 `ERIKA_FORCE_SOURCE_BUILD=1`（配合 `ERIKA_REPO_ROOT`）才会为目标 iOS architecture 从源码构建 Rust `erika_capi` crate。
@@ -72,6 +111,10 @@ iOS plugin 通过 CocoaPod script phase 把 Erika C ABI static library 链接进
 ## tvOS Build Path
 
 tvOS plugin 通过 CocoaPod script phase 链接 Erika C ABI static library；与 iOS 一样默认下载预构建归档，`ERIKA_FORCE_SOURCE_BUILD=1` 时才从源码构建。支持 tvOS 13+、arm64 真机，以及 arm64/x86_64 模拟器。详细的 Rust nightly、预构建包和源码构建选项见 [`packages/erika_flutter/README.zh.md`](../packages/erika_flutter/README.zh.md)。
+
+## macOS Build Path
+
+macOS pod 使用同样的 script-phase 构建。在 Erika checkout 内（包上层存在 `crates/erika_capi/Cargo.toml`，或 `ERIKA_REPO_ROOT` 指向 checkout 时）默认从源码构建 Rust `erika_capi`，这样本地渲染器改动无需等待新的预构建发布即可生效。已发布的包与隔离消费者——包括解析到 pub cache 的 git 依赖（它们保留了整个仓库，因此同样走源码构建）——该路径需要 Rust 工具链；设 `ERIKA_FORCE_PREBUILT=1` 可改为始终下载带校验的预构建归档。
 
 ## Minimal Presenter Flow
 
@@ -105,9 +148,10 @@ Flutter Texture 是一个能力更低的兼容路径。
 适合：
 - SDR fallback。
 - native view composition 尚未准备好的平台。
+- 需要进入 Flutter compositor 的透明视频（macOS/OpenHarmony 上的 `ErikaTextureVideoView`）。
 - 测试 surface 或受限 embedding 环境。
 
-它不是首选 HDR/EDR 路径，因为视频会进入 Flutter compositor。C ABI 为此路径保留了 `erika_attach_flutter_texture`。
+它不是首选 HDR/EDR 路径，因为视频会进入 Flutter compositor。Apple 上 surface 是 IOSurface-backed 的 `CVPixelBuffer`：宿主注册 Flutter texture，在每个 render tick 前用 `erika_presenter_attach_flutter_texture` 和 `erika_presenter_set_flutter_texture_buffer` 选定该帧的 Metal texture，Flutter 随后合成同一个 buffer，无 CPU 回读。pixel buffer 的所有权始终在宿主侧。
 
 ## wgpu 与 Android
 
@@ -124,6 +168,8 @@ GLES 或能力协商失败会明确回退 SDR。Android SDR 已验证，API 35 H
 final player = ErikaPlayer(
   outputMode: ErikaOutputMode.appleEdr,  // optional: force EDR
   edrHeadroom: 4.0,                      // optional: EDR headroom
+  // optional: 左右分区颜色/alpha 素材以透明方式呈现
+  videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight,
 );
 
 await player.open(
@@ -137,6 +183,9 @@ await player.play();
 
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
+
+// Flutter 合成的视频，支持不透明度/裁剪/滤镜（macOS/OpenHarmony）：
+ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility / diagnostic platform-view path:
 ErikaVideoView(player: player)


### PR DESCRIPTION
## Summary

Fast-follow documentation for #124 (transparent video and cross-platform native GPU composition), which changed no docs.

- **flutter_embedding (en/zh/ja)**
  - New `ErikaTextureVideoView` subsection (IOSurface + Metal texture path, no per-frame CPU readback, OHOS external-texture reuse, fallback behavior).
  - New **Transparent Video and Blend Modes** section: `ErikaVideoAlphaMode.packedAlphaRight` asset format, premultiplied GPU reconstruction at half encoded width, and a per-platform `blendMode`/`opacity` support matrix (Windows DirectComposition accepts only `srcOver`/`overlay` and errors otherwise; macOS native layer supports `overlay`; Android/iOS accept but do not consume). Documents the Windows window-overlay behavior change: transparent/overlay video now composites into the Flutter HWND via a premultiplied DirectComposition swap chain instead of the separate popup window.
  - New **macOS Build Path** section: the pod now builds `erika_capi` from source by default inside an Erika checkout, `ERIKA_FORCE_PREBUILT=1` forces the archive, and git dependencies resolved into the pub cache keep the repo and therefore also switch to source builds (Rust toolchain required).
  - Updated the Flutter Texture Path section (`erika_attach_flutter_texture` is no longer just reserved) and the Dart API sample.
- **capi_reference (en/zh/ja)**
  - Documented `erika_presenter_create_with_output_mode_and_alpha`, `erika_presenter_attach_flutter_texture` + `erika_presenter_set_flutter_texture_buffer` (per-tick buffer selection, BGRA8Unorm requirement, host ownership), and `erika_presenter_windows_composition_swapchain_iunknown` (AddRef/Release ownership, re-fetch after device loss).
  - Added `ErikaVideoAlphaMode` to the enum table and `video_alpha_mode` to the `ErikaPresenterConfig` struct entry.
- **building (en/zh/ja)**: podspec auto-detection and `ERIKA_FORCE_PREBUILT` escape hatch in the source-build architecture section.

## Validation

- Docs-only change; no code touched.
- Link targets are existing in-repo paths.