### PR TITLE
fix(abi): re-sync erika.h mirrors and Apple Swift config structs

### DIFF
--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -196,6 +196,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()
 

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -764,9 +764,10 @@ char *erika_presenter_render_tick_json(
     double time_seconds);
 char *erika_presenter_poll_event_json(ErikaPresenterHandle *handle);
 
-/* Screenshot: render the current composited frame (video + subtitle + danmaku)
- * off-screen into a caller-allocated RGBA8 buffer at the requested size.
- * out_capacity must be >= width*height*4. Fails if no frame is available yet. */
+/* Screenshot: render the current composited frame (video + subtitle, no
+ * danmaku) off-screen into a caller-allocated RGBA8 buffer at the requested
+ * size. out_capacity must be >= width*height*4. Fails if no frame is
+ * available yet. */
 ErikaStatus erika_presenter_capture_frame_rgba(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
@@ -178,6 +178,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()
 

--- a/packages/erika_ohos/src/main/cpp/include/erika.h
+++ b/packages/erika_ohos/src/main/cpp/include/erika.h
@@ -42,6 +42,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 /* Opaque handles. ErikaHandle = pull model, ErikaPresenterHandle = push model. */
 typedef struct ErikaHandle ErikaHandle;
 typedef struct ErikaPresenterHandle ErikaPresenterHandle;
@@ -675,6 +676,24 @@ ErikaStatus erika_presenter_attach_metal_layer(
     uint32_t height,
     double scale);
 
+/* Flutter compositor texture surface. The registrar texture_id identifies the
+ * surface; before every render_tick, select the host-owned GPU target with
+ * set_flutter_texture_buffer. On Apple, raw_texture is an id<MTLTexture> using
+ * BGRA8Unorm. The texture remains owned by the host. */
+ErikaStatus erika_presenter_attach_flutter_texture(
+    ErikaPresenterHandle *handle,
+    ErikaFlutterTextureKind kind,
+    int64_t texture_id,
+    uint32_t width,
+    uint32_t height,
+    double scale);
+
+ErikaStatus erika_presenter_set_flutter_texture_buffer(
+    ErikaPresenterHandle *handle,
+    uint64_t raw_texture,
+    uint32_t width,
+    uint32_t height);
+
 ErikaStatus erika_presenter_attach_wgpu_surface(
     ErikaPresenterHandle *handle,
     ErikaWgpuSurfaceKind kind,
@@ -701,6 +720,13 @@ ErikaStatus erika_presenter_attach_windows_hwnd(
     uint32_t width,
     uint32_t height,
     double scale);
+
+/* Windows only. Returns an AddRef'd IUnknown for a DirectComposition swap
+ * chain created by an attachment whose direct_composition capability is true.
+ * The caller owns the returned COM reference and must Release it. */
+ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_swapchain);
 
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
@@ -738,9 +764,10 @@ char *erika_presenter_render_tick_json(
     double time_seconds);
 char *erika_presenter_poll_event_json(ErikaPresenterHandle *handle);
 
-/* Screenshot: render the current composited frame (video + subtitle + danmaku)
- * off-screen into a caller-allocated RGBA8 buffer at the requested size.
- * out_capacity must be >= width*height*4. Fails if no frame is available yet. */
+/* Screenshot: render the current composited frame (video + subtitle, no
+ * danmaku) off-screen into a caller-allocated RGBA8 buffer at the requested
+ * size. out_capacity must be >= width*height*4. Fails if no frame is
+ * available yet. */
 ErikaStatus erika_presenter_capture_frame_rgba(
     ErikaPresenterHandle *handle,
     uint32_t width,


### PR DESCRIPTION
Follow-up audit of #124 against the project's ABI-mirror conventions.

## Findings

- `ErikaPresenterStats` mirrors (macOS/iOS/tvOS) are **fine** — #124 did not touch that struct, and all three Swift field lists are identical.
- `crates/erika_capi/include/erika.h` vs `packages/erika_flutter/native/include/erika.h` vs `packages/erika_ohos/.../erika.h` had **drifted**.

## Fixes

1. **OHOS header** missed the three new #124 declarations — `erika_presenter_attach_flutter_texture`, `erika_presenter_set_flutter_texture_buffer`, and `erika_presenter_windows_composition_swapchain_iunknown` — including their doc comments, and kept the stale capture comment claiming danmaku is included in screenshots. The OHOS dylib already exports all three symbols (the Rust `#[cfg]` includes ohos), so the header was the only gap.
2. **Flutter native header** carried the same stale screenshot comment ("video + subtitle + danmaku"; the correct contract is "video + subtitle, no danmaku", as documented in `docs/capi_reference.md`).
3. Both copies are now **byte-identical** to `crates/erika_capi/include/erika.h`.
4. **iOS/tvOS `ErikaPresenterConfigC`** gained the `videoAlphaMode: Int32` field to match the widened `ErikaPresenterConfig` (macOS got this in #124, ios/tvos did not). Note: neither platform passes the struct across FFI today — both call the scalar entry points — so this was mirror drift, not a live stack mismatch.

## Validation

- `diff` confirms all three `erika.h` copies are identical.
- Swift change is a default-initialized struct field; behavior unchanged (both platforms still call `erika_presenter_create` / `create_with_output_mode`).