### PR TITLE
fix(abi): make ErikaPresenterConfigC a true mirror of ErikaPresenterConfig

### DIFF
--- a/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/ios/Classes/ErikaFlutterPlugin.swift
@@ -196,6 +196,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var lumaUpscaler: Int32 = 0
   var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()

--- a/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/macos/Classes/ErikaFlutterPlugin.swift
@@ -333,6 +333,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var lumaUpscaler: Int32 = 0
   var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()

--- a/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
+++ b/packages/erika_flutter/tvos/Classes/ErikaFlutterPlugin.swift
@@ -178,6 +178,7 @@ private struct ErikaTrackInfoC {
 private struct ErikaPresenterConfigC {
   var outputMode: Int32 = 0
   var edrHeadroom: Float = 1.0
+  var lumaUpscaler: Int32 = 0
   var videoAlphaMode: Int32 = 0
 
   static let sdr = ErikaPresenterConfigC()


### PR DESCRIPTION
Addresses the P3 follow-up on #127.

The Swift `ErikaPresenterConfigC` on macOS/iOS/tvOS placed `videoAlphaMode` directly after `edrHeadroom`, but `ErikaPresenterConfig` in `erika.h` has `luma_upscaler` between them:

| | size | `video_alpha_mode` offset |
|---|---|---|
| C `ErikaPresenterConfig` | 16 B | 12 |
| Swift (before) | 12 B | 8 |
| Swift (after) | 16 B | 12 |

Nothing passes the struct through FFI today — all three platforms call the scalar entry points (`erika_presenter_create`, `create_with_output_mode`, `create_with_output_mode_and_alpha`) — so there was no live bug, but the first future `erika_presenter_create_with_config` caller would have had alpha silently read as the upscaler mode with a garbage fourth field.

This inserts `lumaUpscaler: Int32 = 0` on all three platforms so field order, offsets, and size match the C layout exactly. Existing call sites are unaffected (labeled memberwise init; omitted defaulted parameter).