### PR TITLE
修复 Windows 扫描线视频 DWM 崩溃、铺满尺寸及 D3D11VA 帧复用

### DIFF
--- a/.github/workflows/flutter-package.yml
+++ b/.github/workflows/flutter-package.yml
@@ -168,6 +168,21 @@ jobs:
           Set-Location (Join-Path $root "app")
           flutter pub add erika_flutter --path ../erika_flutter
           flutter build windows --debug
+      - name: Test Windows GPU publication and plugin compilation
+        shell: pwsh
+        run: |
+          $flutterSdk = Split-Path (Split-Path (Get-Command flutter).Source)
+          $engine = Join-Path $flutterSdk "bin/cache/artifacts/engine/windows-x64"
+          $nativeTests = Join-Path $env:RUNNER_TEMP "erika-windows-native-tests"
+          $consumer = Join-Path $env:RUNNER_TEMP "erika-windows/app/build/windows"
+          $compatDll = Get-ChildItem $consumer -Recurse -Filter erika_capi.dll | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $compatDll) { throw "Missing bundled compatibility runtime" }
+          cmake -S packages/erika_flutter/windows/tests -B $nativeTests -A x64 "-DFLUTTER_ENGINE_DIR=$engine" "-DERIKA_COMPAT_DLL=$compatDll"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cmake --build $nativeTests --config Debug
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          ctest --test-dir $nativeTests -C Debug --output-on-failure
+          exit $LASTEXITCODE
 
   openharmony:
     name: OpenHarmony bridge from isolated package

--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -864,6 +864,15 @@ pub trait RendererBackend {
     fn composition_swapchain_iunknown(&self) -> Option<*mut std::ffi::c_void> {
         None
     }
+
+    /// AddRef'd `IUnknown` for the active Windows Flutter output texture.
+    ///
+    /// The caller owns the reference and must `Release` it. This lets the
+    /// Windows embedder expose the renderer-owned, shareable D3D11 texture to
+    /// Flutter without falling back to an HWND overlay.
+    fn windows_flutter_texture_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/erika/src/core.rs
+++ b/crates/erika/src/core.rs
@@ -865,11 +865,11 @@ pub trait RendererBackend {
         None
     }
 
-    /// AddRef'd `IUnknown` for the active Windows Flutter output texture.
+    /// AddRef'd `IUnknown` for the latest completed Windows Flutter SDR frame.
     ///
     /// The caller owns the reference and must `Release` it. This lets the
-    /// Windows embedder expose the renderer-owned, shareable D3D11 texture to
-    /// Flutter without falling back to an HWND overlay.
+    /// Windows embedder expose a shareable D3D11 snapshot to Flutter. Published
+    /// resources are immutable, even after the renderer produces another frame.
     fn windows_flutter_texture_iunknown(&self) -> Option<*mut std::ffi::c_void> {
         None
     }

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -1465,21 +1465,6 @@ impl Decoder {
     }
 
     fn configure_d3d11va(&mut self, codec: *const sys::AVCodec) -> Result<()> {
-        // The D3D11VA frame context is a fixed-size texture array. FFmpeg's
-        // codec minimum only covers decoder work/reference surfaces, while
-        // Erika can retain another 16 decoded outputs outside libavcodec:
-        // eight in PlaybackSession, three in the player-to-presenter handoff,
-        // one as the renderer's current frame, and four waiting for D3D11 GPU
-        // completion fences. Without this budget the fixed pool can run out
-        // while presentation still owns decoded texture-array slices.
-        #[cfg(target_os = "windows")]
-        {
-            unsafe {
-                (*self.context).extra_hw_frames = (*self.context)
-                    .extra_hw_frames
-                    .max(D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES);
-            }
-        }
         self.configure_hardware(
             codec,
             sys::AVHWDeviceType_AV_HWDEVICE_TYPE_D3D11VA,
@@ -1727,9 +1712,7 @@ unsafe fn ensure_d3d11va_frames_for_context(
         let alignment = d3d11va_surface_alignment(unsafe { (*context).codec_id });
         frames_ctx.width = align_i32(unsafe { (*context).coded_width }, alignment);
         frames_ctx.height = align_i32(unsafe { (*context).coded_height }, alignment);
-        frames_ctx.initial_pool_size = d3d11va_pool_size(unsafe { (*context).codec_id }, unsafe {
-            (*context).extra_hw_frames
-        });
+        frames_ctx.initial_pool_size = d3d11va_pool_size(unsafe { (*context).codec_id });
         d3d11_frames.BindFlags = D3D11_BIND_DECODER | D3D11_BIND_SHADER_RESOURCE;
         d3d11_frames.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
         let code = unsafe { sys::av_hwframe_ctx_init(frames_ref) };
@@ -1776,25 +1759,16 @@ fn d3d11va_surface_alignment(codec_id: sys::AVCodecID) -> i32 {
 }
 
 #[cfg(target_os = "windows")]
-const D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES: i32 = 16;
-
-#[cfg(target_os = "windows")]
-fn d3d11va_pool_size(codec_id: sys::AVCodecID, extra_hw_frames: i32) -> i32 {
-    let decoder_surfaces: i32 = if codec_id == sys::AVCodecID_AV_CODEC_ID_H264
-        || codec_id == sys::AVCodecID_AV_CODEC_ID_HEVC
-    {
-        // Four base work surfaces plus up to sixteen reference surfaces.
+fn d3d11va_pool_size(codec_id: sys::AVCodecID) -> i32 {
+    if codec_id == sys::AVCodecID_AV_CODEC_ID_H264 || codec_id == sys::AVCodecID_AV_CODEC_ID_HEVC {
         20
     } else if codec_id == sys::AVCodecID_AV_CODEC_ID_VP9
         || codec_id == sys::AVCodecID_AV_CODEC_ID_AV1
     {
-        // Four base work surfaces plus up to eight reference surfaces.
         12
     } else {
-        // Four base work surfaces plus two reference surfaces.
-        6
-    };
-    decoder_surfaces.saturating_add(extra_hw_frames.max(0))
+        5
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -4587,52 +4561,6 @@ mod tests {
     #[test]
     fn linked_ffmpeg_reports_version() {
         assert!(!version().is_empty());
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn d3d11va_pool_includes_erika_retained_outputs() {
-        assert_eq!(
-            d3d11va_pool_size(
-                sys::AVCodecID_AV_CODEC_ID_H264,
-                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
-            ),
-            36
-        );
-        assert_eq!(
-            d3d11va_pool_size(
-                sys::AVCodecID_AV_CODEC_ID_HEVC,
-                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
-            ),
-            36
-        );
-        assert_eq!(
-            d3d11va_pool_size(
-                sys::AVCodecID_AV_CODEC_ID_VP9,
-                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
-            ),
-            28
-        );
-        assert_eq!(
-            d3d11va_pool_size(
-                sys::AVCodecID_AV_CODEC_ID_AV1,
-                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
-            ),
-            28
-        );
-        assert_eq!(
-            d3d11va_pool_size(
-                sys::AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
-                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
-            ),
-            22
-        );
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn d3d11va_pool_never_shrinks_for_negative_extra_frames() {
-        assert_eq!(d3d11va_pool_size(sys::AVCodecID_AV_CODEC_ID_H264, -1), 20);
     }
 
     #[test]

--- a/crates/erika/src/ffmpeg.rs
+++ b/crates/erika/src/ffmpeg.rs
@@ -1465,6 +1465,21 @@ impl Decoder {
     }
 
     fn configure_d3d11va(&mut self, codec: *const sys::AVCodec) -> Result<()> {
+        // The D3D11VA frame context is a fixed-size texture array. FFmpeg's
+        // codec minimum only covers decoder work/reference surfaces, while
+        // Erika can retain another 16 decoded outputs outside libavcodec:
+        // eight in PlaybackSession, three in the player-to-presenter handoff,
+        // one as the renderer's current frame, and four waiting for D3D11 GPU
+        // completion fences. Without this budget the fixed pool can run out
+        // while presentation still owns decoded texture-array slices.
+        #[cfg(target_os = "windows")]
+        {
+            unsafe {
+                (*self.context).extra_hw_frames = (*self.context)
+                    .extra_hw_frames
+                    .max(D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES);
+            }
+        }
         self.configure_hardware(
             codec,
             sys::AVHWDeviceType_AV_HWDEVICE_TYPE_D3D11VA,
@@ -1712,7 +1727,9 @@ unsafe fn ensure_d3d11va_frames_for_context(
         let alignment = d3d11va_surface_alignment(unsafe { (*context).codec_id });
         frames_ctx.width = align_i32(unsafe { (*context).coded_width }, alignment);
         frames_ctx.height = align_i32(unsafe { (*context).coded_height }, alignment);
-        frames_ctx.initial_pool_size = d3d11va_pool_size(unsafe { (*context).codec_id });
+        frames_ctx.initial_pool_size = d3d11va_pool_size(unsafe { (*context).codec_id }, unsafe {
+            (*context).extra_hw_frames
+        });
         d3d11_frames.BindFlags = D3D11_BIND_DECODER | D3D11_BIND_SHADER_RESOURCE;
         d3d11_frames.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
         let code = unsafe { sys::av_hwframe_ctx_init(frames_ref) };
@@ -1759,16 +1776,25 @@ fn d3d11va_surface_alignment(codec_id: sys::AVCodecID) -> i32 {
 }
 
 #[cfg(target_os = "windows")]
-fn d3d11va_pool_size(codec_id: sys::AVCodecID) -> i32 {
-    if codec_id == sys::AVCodecID_AV_CODEC_ID_H264 || codec_id == sys::AVCodecID_AV_CODEC_ID_HEVC {
+const D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES: i32 = 16;
+
+#[cfg(target_os = "windows")]
+fn d3d11va_pool_size(codec_id: sys::AVCodecID, extra_hw_frames: i32) -> i32 {
+    let decoder_surfaces: i32 = if codec_id == sys::AVCodecID_AV_CODEC_ID_H264
+        || codec_id == sys::AVCodecID_AV_CODEC_ID_HEVC
+    {
+        // Four base work surfaces plus up to sixteen reference surfaces.
         20
     } else if codec_id == sys::AVCodecID_AV_CODEC_ID_VP9
         || codec_id == sys::AVCodecID_AV_CODEC_ID_AV1
     {
+        // Four base work surfaces plus up to eight reference surfaces.
         12
     } else {
-        5
-    }
+        // Four base work surfaces plus two reference surfaces.
+        6
+    };
+    decoder_surfaces.saturating_add(extra_hw_frames.max(0))
 }
 
 #[cfg(target_os = "windows")]
@@ -4561,6 +4587,52 @@ mod tests {
     #[test]
     fn linked_ffmpeg_reports_version() {
         assert!(!version().is_empty());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn d3d11va_pool_includes_erika_retained_outputs() {
+        assert_eq!(
+            d3d11va_pool_size(
+                sys::AVCodecID_AV_CODEC_ID_H264,
+                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
+            ),
+            36
+        );
+        assert_eq!(
+            d3d11va_pool_size(
+                sys::AVCodecID_AV_CODEC_ID_HEVC,
+                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
+            ),
+            36
+        );
+        assert_eq!(
+            d3d11va_pool_size(
+                sys::AVCodecID_AV_CODEC_ID_VP9,
+                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
+            ),
+            28
+        );
+        assert_eq!(
+            d3d11va_pool_size(
+                sys::AVCodecID_AV_CODEC_ID_AV1,
+                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
+            ),
+            28
+        );
+        assert_eq!(
+            d3d11va_pool_size(
+                sys::AVCodecID_AV_CODEC_ID_MPEG2VIDEO,
+                D3D11VA_ERIKA_RETAINED_OUTPUT_FRAMES,
+            ),
+            22
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn d3d11va_pool_never_shrinks_for_negative_extra_frames() {
+        assert_eq!(d3d11va_pool_size(sys::AVCodecID_AV_CODEC_ID_H264, -1), 20);
     }
 
     #[test]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -414,6 +414,8 @@ struct AsyncDanmakuPlanner {
     shared: Arc<(Mutex<AsyncDanmakuPlannerState>, Condvar)>,
     results: Receiver<AsyncDanmakuPlanResult>,
     last_requested: Option<DanmakuPlanKey>,
+    #[cfg(target_os = "windows")]
+    worker: Option<thread::JoinHandle<()>>,
 }
 
 #[derive(Debug, Clone)]
@@ -445,7 +447,7 @@ impl AsyncDanmakuPlanner {
         let shared = Arc::new((Mutex::new(state), Condvar::new()));
         let (result_tx, results) = crossbeam_channel::unbounded();
         let worker_shared = Arc::clone(&shared);
-        thread::Builder::new()
+        let _worker = thread::Builder::new()
             .name("erika-danmaku".to_string())
             .spawn(move || run_async_danmaku_planner(worker_shared, result_tx, engine))
             .expect("spawn erika danmaku planner");
@@ -453,6 +455,8 @@ impl AsyncDanmakuPlanner {
             shared,
             results,
             last_requested: None,
+            #[cfg(target_os = "windows")]
+            worker: Some(_worker),
         }
     }
 
@@ -547,11 +551,20 @@ impl AsyncDanmakuPlanner {
 
 impl Drop for AsyncDanmakuPlanner {
     fn drop(&mut self) {
-        let (lock, cvar) = &*self.shared;
-        let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        state.shutdown = true;
-        state.revision = state.revision.saturating_add(1);
-        cvar.notify_one();
+        {
+            let (lock, cvar) = &*self.shared;
+            let mut state = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.shutdown = true;
+            state.revision = state.revision.saturating_add(1);
+            cvar.notify_one();
+        }
+        // The Windows plugin unloads the native DLL after the last presenter.
+        // A shutdown notification alone leaves the worker executing (or even
+        // starting) in unmapped code. Release the state lock before joining.
+        #[cfg(target_os = "windows")]
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
     }
 }
 
@@ -4619,6 +4632,23 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             6.0
         );
         assert_eq!(danmaku_motion_backstep(DanmakuMode::Top, 100.0, 140.0), 0.0);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_danmaku_worker_exits_before_presenter_can_unload() {
+        for _ in 0..32 {
+            let planner = AsyncDanmakuPlanner::new(
+                danmaku_engine("shutdown"),
+                DanmakuTimeline::default(),
+                DanmakuLayoutConfig::default(),
+            );
+            let shared = Arc::clone(&planner.shared);
+            drop(planner);
+            // No worker, including one not yet scheduled, may retain state
+            // and execute Rust code after the containing DLL is unloaded.
+            assert_eq!(Arc::strong_count(&shared), 1);
+        }
     }
 
     #[test]

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -773,6 +773,12 @@ impl PresenterRuntime {
         self.renderer.composition_swapchain_iunknown()
     }
 
+    /// AddRef'd `IUnknown` for the renderer-owned Windows Flutter texture.
+    /// The caller owns the returned reference.
+    pub fn windows_flutter_texture_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        self.renderer.windows_flutter_texture_iunknown()
+    }
+
     pub fn resize_surface(&mut self, width: u32, height: u32, scale: f64) -> Result<()> {
         let metrics = SurfaceMetrics::new(width, height, scale);
         let previous_metrics = self.current_surface_metrics;

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -668,22 +668,50 @@ impl FlutterTextureScene {
         self.frame_token == frame_token
             && self.generation == context.generation
             && self.upscaler == upscaler
-            && match (self.overlay.as_ref(), context.overlay) {
-                (Some(a), Some(b)) => {
-                    a.viewport == b.viewport
-                        && a.subtitle_planes == b.subtitle_planes
-                        && a.subtitle_alpha_planes == b.subtitle_alpha_planes
-                }
-                (None, None) => true,
-                _ => false,
+            && self.overlay_matches(context.overlay)
+            && self.danmaku_matches(context.danmaku)
+    }
+
+    fn overlay_matches(&self, overlay: Option<&OverlayFrame>) -> bool {
+        match (self.overlay.as_ref(), overlay) {
+            (Some(a), Some(b)) => {
+                a.viewport == b.viewport
+                    && a.subtitle_planes == b.subtitle_planes
+                    && a.subtitle_alpha_planes == b.subtitle_alpha_planes
             }
-            && match (self.danmaku.as_ref(), context.danmaku) {
-                (Some(a), Some(b)) => {
-                    a.viewport == b.viewport && a.atlas == b.atlas && a.items == b.items
-                }
-                (None, None) => true,
-                _ => false,
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn danmaku_matches(&self, danmaku: Option<&DanmakuRenderPlan>) -> bool {
+        match (self.danmaku.as_ref(), danmaku) {
+            (Some(a), Some(b)) => {
+                a.viewport == b.viewport && a.atlas == b.atlas && a.items == b.items
             }
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn update(
+        &mut self,
+        frame_token: u64,
+        upscaler: LumaUpscalerMode,
+        context: RenderFrameContext<'_>,
+    ) {
+        // A new video frame need not copy unchanged subtitle/HUD pixels or
+        // danmaku instances. Retain each cached buffer until its own content
+        // changes; keep exact comparisons rather than lossy fingerprints.
+        if !self.overlay_matches(context.overlay) {
+            self.overlay = context.overlay.cloned();
+        }
+        if !self.danmaku_matches(context.danmaku) {
+            self.danmaku = context.danmaku.cloned();
+        }
+        self.frame_token = frame_token;
+        self.generation = context.generation;
+        self.upscaler = upscaler;
     }
 }
 
@@ -1689,11 +1717,15 @@ impl D3d11Renderer {
         }
         if flutter_texture {
             self.publish_flutter_texture()?;
-            self.flutter_scene = Some(FlutterTextureScene::new(
-                frame_token,
-                self.upscaler_mode,
-                context,
-            ));
+            if let Some(scene) = self.flutter_scene.as_mut() {
+                scene.update(frame_token, self.upscaler_mode, context);
+            } else {
+                self.flutter_scene = Some(FlutterTextureScene::new(
+                    frame_token,
+                    self.upscaler_mode,
+                    context,
+                ));
+            }
         }
         self.stats.rendered_frames += 1;
         if !danmaku_draws.is_empty() {
@@ -3263,6 +3295,129 @@ mod tests {
             7,
             LumaUpscalerMode::Off,
             RenderFrameContext::new(Duration::ZERO, 1)
+        ));
+    }
+
+    #[test]
+    fn flutter_scene_reuses_unchanged_cpu_buffers_across_video_frames() {
+        use crate::danmaku::DanmakuViewport;
+        use crate::overlay::OverlayViewport;
+        use crate::subtitle::{SubtitleAlphaBitmap, SubtitleBitmapPlacement, SubtitleBitmapPlane};
+        let mut overlay = OverlayFrame {
+            pts: Duration::ZERO,
+            viewport: OverlayViewport::new(128, 64),
+            subtitle_planes: vec![SubtitleBitmapPlane::new(
+                0,
+                0,
+                128,
+                64,
+                vec![255; 128 * 64 * 4],
+            )],
+            subtitle_alpha_planes: vec![SubtitleAlphaBitmap::new(
+                SubtitleBitmapPlacement::new(0, 0, 128, 64),
+                128,
+                0xffffffff,
+                vec![255; 128 * 64],
+            )],
+            subtitle_changed: true,
+        };
+        let mut plan = DanmakuRenderPlan::empty(Duration::ZERO, 1, DanmakuViewport::new(128, 64));
+        plan.items.push(DanmakuGlyphInstance {
+            item_id: 1,
+            rect: [0.0, 0.0, 1.0, 1.0],
+            tex_rect: [0.0, 0.0, 1.0, 1.0],
+            color_rgba: [1.0; 4],
+            outline_rgba: [0.0; 4],
+            shadow_rgba: [0.0; 4],
+            shadow_offset: [0.0; 2],
+        });
+        let mut scene = FlutterTextureScene::new(
+            1,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1)
+                .overlay(Some(&overlay))
+                .danmaku(Some(&plan)),
+        );
+        let rgba = scene.overlay.as_ref().unwrap().subtitle_planes[0]
+            .rgba
+            .as_ptr();
+        let alpha = scene.overlay.as_ref().unwrap().subtitle_alpha_planes[0]
+            .alpha
+            .as_ptr();
+        let items = scene.danmaku.as_ref().unwrap().items.as_ptr();
+        for token in 2..=121 {
+            overlay.pts = Duration::from_millis(token * 10);
+            overlay.subtitle_changed = false;
+            plan.media_time = overlay.pts;
+            let context = RenderFrameContext::new(overlay.pts, 1)
+                .overlay(Some(&overlay))
+                .danmaku(Some(&plan));
+            assert!(!scene.matches(token, LumaUpscalerMode::Off, context));
+            scene.update(token, LumaUpscalerMode::Off, context);
+            assert!(scene.matches(token, LumaUpscalerMode::Off, context));
+            assert_eq!(
+                scene.overlay.as_ref().unwrap().subtitle_planes[0]
+                    .rgba
+                    .as_ptr(),
+                rgba
+            );
+            assert_eq!(
+                scene.overlay.as_ref().unwrap().subtitle_alpha_planes[0]
+                    .alpha
+                    .as_ptr(),
+                alpha
+            );
+            assert_eq!(scene.danmaku.as_ref().unwrap().items.as_ptr(), items);
+        }
+
+        // A real subtitle/HUD change still replaces the cached pixels even
+        // when the video frame is paused and subtitle_changed is false.
+        overlay.subtitle_planes[0].rgba[0] = 17;
+        overlay.subtitle_alpha_planes[0].alpha[0] = 23;
+        let context = RenderFrameContext::new(overlay.pts, 1)
+            .overlay(Some(&overlay))
+            .danmaku(Some(&plan));
+        assert!(!scene.matches(121, LumaUpscalerMode::Off, context));
+        scene.update(121, LumaUpscalerMode::Off, context);
+        assert!(scene.matches(121, LumaUpscalerMode::Off, context));
+        assert_eq!(
+            scene.overlay.as_ref().unwrap().subtitle_planes[0].rgba[0],
+            17
+        );
+        assert_eq!(
+            scene.overlay.as_ref().unwrap().subtitle_alpha_planes[0].alpha[0],
+            23
+        );
+        assert_eq!(scene.danmaku.as_ref().unwrap().items.as_ptr(), items);
+
+        let rgba = scene.overlay.as_ref().unwrap().subtitle_planes[0]
+            .rgba
+            .as_ptr();
+        plan.items[0].rect[0] = 2.0;
+        let context = RenderFrameContext::new(overlay.pts, 1)
+            .overlay(Some(&overlay))
+            .danmaku(Some(&plan));
+        assert!(!scene.matches(121, LumaUpscalerMode::Off, context));
+        scene.update(121, LumaUpscalerMode::Off, context);
+        assert!(scene.matches(121, LumaUpscalerMode::Off, context));
+        assert_eq!(
+            scene.overlay.as_ref().unwrap().subtitle_planes[0]
+                .rgba
+                .as_ptr(),
+            rgba
+        );
+        assert_eq!(scene.danmaku.as_ref().unwrap().items[0].rect[0], 2.0);
+
+        scene.update(
+            121,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 2),
+        );
+        assert!(scene.overlay.is_none() && scene.danmaku.is_none());
+        assert!(scene.matches(
+            121,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 2)
         ));
     }
 

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -1,7 +1,7 @@
-use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::mem;
 use std::ptr;
+use std::time::{Duration, Instant};
 
 use ::windows::Win32::Foundation::{HMODULE, HWND};
 use ::windows::Win32::Graphics::Direct3D::Fxc::D3DCompile;
@@ -607,6 +607,9 @@ struct AttachedSurface {
     output_mode: D3d11OutputMode,
     swapchain: Option<IDXGISwapChain1>,
     output_texture: Option<ID3D11Texture2D>,
+    // Immutable, GPU-complete snapshot exported to Flutter. Never render into
+    // this resource again: opening its handle is not GPU consumer completion.
+    published_texture: Option<ID3D11Texture2D>,
     render_target: Option<ID3D11RenderTargetView>,
     linear_render_target: Option<ID3D11RenderTargetView>,
     linear_shader_resource: Option<ID3D11ShaderResourceView>,
@@ -637,10 +640,51 @@ struct ImportedVideoFrame {
     constants: VideoUniforms,
 }
 
-struct RetiredVideoFrame {
-    _video: ImportedVideoFrame,
-    context: ID3D11DeviceContext,
-    completion: Option<ID3D11Query>,
+struct FlutterTextureScene {
+    frame_token: u64,
+    generation: u64,
+    upscaler: LumaUpscalerMode,
+    overlay: Option<OverlayFrame>,
+    danmaku: Option<DanmakuRenderPlan>,
+}
+
+impl FlutterTextureScene {
+    fn new(frame_token: u64, upscaler: LumaUpscalerMode, context: RenderFrameContext<'_>) -> Self {
+        Self {
+            frame_token,
+            generation: context.generation,
+            upscaler,
+            overlay: context.overlay.cloned(),
+            danmaku: context.danmaku.cloned(),
+        }
+    }
+
+    fn matches(
+        &self,
+        frame_token: u64,
+        upscaler: LumaUpscalerMode,
+        context: RenderFrameContext<'_>,
+    ) -> bool {
+        self.frame_token == frame_token
+            && self.generation == context.generation
+            && self.upscaler == upscaler
+            && match (self.overlay.as_ref(), context.overlay) {
+                (Some(a), Some(b)) => {
+                    a.viewport == b.viewport
+                        && a.subtitle_planes == b.subtitle_planes
+                        && a.subtitle_alpha_planes == b.subtitle_alpha_planes
+                }
+                (None, None) => true,
+                _ => false,
+            }
+            && match (self.danmaku.as_ref(), context.danmaku) {
+                (Some(a), Some(b)) => {
+                    a.viewport == b.viewport && a.atlas == b.atlas && a.items == b.items
+                }
+                (None, None) => true,
+                _ => false,
+            }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -760,7 +804,7 @@ pub struct D3d11Renderer {
     state: Option<D3d11DeviceState>,
     surface: Option<AttachedSurface>,
     current_video: Option<ImportedVideoFrame>,
-    retired_video: VecDeque<RetiredVideoFrame>,
+    flutter_scene: Option<FlutterTextureScene>,
     danmaku_atlas_cache: Option<D3d11DanmakuAtlasCache>,
     requested_output_mode: crate::renderer::output::OutputMode,
     video_alpha_mode: VideoAlphaMode,
@@ -781,7 +825,7 @@ impl D3d11Renderer {
             state: None,
             surface: None,
             current_video: None,
-            retired_video: VecDeque::new(),
+            flutter_scene: None,
             danmaku_atlas_cache: None,
             requested_output_mode: config.output_mode,
             video_alpha_mode: config.video_alpha_mode,
@@ -797,57 +841,42 @@ impl D3d11Renderer {
         self.stats
     }
 
-    fn collect_completed_video_frames(&mut self) {
-        let mut first_error = None;
-        self.retired_video.retain(|retired| {
-            let Some(completion) = retired.completion.as_ref() else {
-                return true;
-            };
-            match d3d11_event_query_complete(&retired.context, completion) {
-                Ok(true) => false,
-                Ok(false) => true,
-                Err(error) => {
-                    first_error.get_or_insert(error);
-                    true
-                }
+    fn retire_current_video(&mut self) -> Result<()> {
+        // Preserve main's HWND playback policy. Only compositor-owned surfaces
+        // need this additional handoff barrier. Do not grow the decoder pool or
+        // accumulate an unbounded queue of AVFrames on delayed/failed fences.
+        if self.current_video.is_some()
+            && self
+                .surface
+                .as_ref()
+                .is_some_and(|s| s.composition || s.flutter_texture)
+        {
+            if let Some(state) = self.state.as_ref() {
+                wait_for_gpu(&state.device, &state.context)?;
             }
-        });
-        if let Some(error) = first_error {
-            trace(&format!("video frame retirement query failed: {error}"));
         }
+        self.current_video = None;
+        Ok(())
     }
 
-    fn retire_current_video(&mut self) {
-        self.collect_completed_video_frames();
-        let Some(video) = self.current_video.take() else {
-            return;
-        };
-        let Some(state) = self.state.as_ref() else {
-            return;
-        };
-        let context = state.context.clone();
-        let completion = match create_d3d11_event_query(&state.device) {
-            Ok(query) => {
-                unsafe {
-                    context.End(&query);
-                    context.Flush();
-                }
-                Some(query)
-            }
-            Err(error) => {
-                // Retaining the AVFrame is safer than returning its texture
-                // array slice to the decoder without a GPU completion fence.
-                trace(&format!(
-                    "video frame retirement fence unavailable: {error}"
-                ));
-                None
-            }
-        };
-        self.retired_video.push_back(RetiredVideoFrame {
-            _video: video,
-            context,
-            completion,
-        });
+    fn publish_flutter_texture(&mut self) -> Result<()> {
+        let surface = self.surface.as_mut().expect("surface ensured");
+        if !surface.flutter_texture {
+            return Ok(());
+        }
+        let state = self.state.as_ref().expect("device ensured");
+        let source = surface.output_texture.as_ref().expect("texture ensured");
+        let extent = surface.metrics.physical_extent;
+        let (snapshot, _) =
+            create_flutter_texture_target(&state.device, extent.width, extent.height)?;
+        unsafe {
+            state.context.CopyResource(&snapshot, source);
+        }
+        // Flush only submits work. Complete the copy before another D3D device
+        // opens this immutable snapshot. The extra GPU copy is texture-only.
+        wait_for_gpu(&state.device, &state.context)?;
+        surface.published_texture = Some(snapshot);
+        Ok(())
     }
 
     fn ensure_default_device(&mut self) -> Result<()> {
@@ -870,7 +899,7 @@ impl D3d11Renderer {
         }
         let context = unsafe { frame_device.GetImmediateContext() }
             .map_err(|error| d3d_error("ID3D11Device::GetImmediateContext", error))?;
-        self.retire_current_video();
+        self.retire_current_video()?;
         self.danmaku_atlas_cache = None;
         self.set_device(frame_device, context)
     }
@@ -1006,7 +1035,7 @@ impl D3d11Renderer {
             return Ok(());
         }
         surface.output_mode = output_mode;
-        self.retire_current_video();
+        self.retire_current_video()?;
         self.recreate_surface_targets()
     }
 
@@ -1022,7 +1051,12 @@ impl D3d11Renderer {
         // swap-chain path. Packed-alpha assets are effects/UI content rather
         // than an HDR presentation plane, so keep their color and alpha in one
         // stable BGRA8 composition space.
-        if self.video_alpha_mode.has_alpha() {
+        if self.video_alpha_mode.has_alpha()
+            || self
+                .surface
+                .as_ref()
+                .is_some_and(|surface| surface.flutter_texture)
+        {
             self.set_output_mode(D3d11OutputMode::Sdr)?;
             if source_is_hdr {
                 self.stats.sdr_tonemap_frames += 1;
@@ -1151,7 +1185,7 @@ impl D3d11Renderer {
             constants: constants_for_frame(source_color, texture_format, target_color)
                 .packed_alpha_right(self.video_alpha_mode.has_alpha()),
         };
-        self.retire_current_video();
+        self.retire_current_video()?;
         self.current_video = Some(imported);
         Ok(())
     }
@@ -1512,12 +1546,30 @@ impl D3d11Renderer {
     }
 
     fn render_video(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {
-        self.collect_completed_video_frames();
         if self.current_video.is_none() {
             return Ok(false);
         }
         self.ensure_default_device()?;
         self.ensure_surface_ready()?;
+        let flutter_texture = self
+            .surface
+            .as_ref()
+            .expect("surface ensured")
+            .flutter_texture;
+        let frame_token = self
+            .current_video
+            .as_ref()
+            .expect("video checked")
+            .frame_token;
+        if flutter_texture
+            && self.surface.as_ref().unwrap().published_texture.is_some()
+            && self
+                .flutter_scene
+                .as_ref()
+                .is_some_and(|scene| scene.matches(frame_token, self.upscaler_mode, context))
+        {
+            return Ok(true);
+        }
         let overlay_draws = self.prepare_overlay_draws(context.overlay)?;
         let danmaku_draws = self.prepare_danmaku_draws(context.danmaku)?;
         let (video_width, video_height, frame_token, native_luma) = {
@@ -1634,11 +1686,14 @@ impl D3d11Renderer {
         }
         if let Some(swapchain) = surface.swapchain.as_ref() {
             present_swapchain(swapchain, "IDXGISwapChain1::Present1")?;
-        } else if surface.flutter_texture {
-            // A legacy DXGI shared handle has no keyed mutex. Flush the
-            // producer context before Flutter opens/samples it on ANGLE's
-            // device so the completed frame is externally visible.
-            unsafe { state.context.Flush() };
+        }
+        if flutter_texture {
+            self.publish_flutter_texture()?;
+            self.flutter_scene = Some(FlutterTextureScene::new(
+                frame_token,
+                self.upscaler_mode,
+                context,
+            ));
         }
         self.stats.rendered_frames += 1;
         if !danmaku_draws.is_empty() {
@@ -1669,6 +1724,14 @@ impl D3d11Renderer {
         self.ensure_default_device()?;
         trace("render_clear: ensure_surface_ready");
         self.ensure_surface_ready()?;
+        if self
+            .surface
+            .as_ref()
+            .is_some_and(|surface| surface.flutter_texture && surface.published_texture.is_some())
+            && self.flutter_scene.is_none()
+        {
+            return Ok(());
+        }
         let state = self.state.as_ref().expect("device ensured");
         let surface = self.surface.as_ref().expect("surface ensured");
         let rtv = surface
@@ -1692,10 +1755,10 @@ impl D3d11Renderer {
             trace("render_clear: present");
             if let Some(swapchain) = surface.swapchain.as_ref() {
                 present_swapchain(swapchain, "IDXGISwapChain1::Present1(clear)")?;
-            } else if surface.flutter_texture {
-                state.context.Flush();
             }
         }
+        self.publish_flutter_texture()?;
+        self.flutter_scene = None;
         trace("render_clear: done");
         self.stats.rendered_frames += 1;
         Ok(())
@@ -1750,6 +1813,7 @@ impl RendererBackend for D3d11Renderer {
             output_mode: D3d11OutputMode::Sdr,
             swapchain: None,
             output_texture: None,
+            published_texture: None,
             render_target: None,
             linear_render_target: None,
             linear_shader_resource: None,
@@ -1761,7 +1825,7 @@ impl RendererBackend for D3d11Renderer {
     }
 
     fn detach_surface(&mut self) -> Result<()> {
-        self.retire_current_video();
+        self.retire_current_video()?;
         self.surface = None;
         self.danmaku_atlas_cache = None;
         self.stats.attached = false;
@@ -1782,7 +1846,12 @@ impl RendererBackend for D3d11Renderer {
         }
         surface.metrics = metrics;
         self.hdr10_output_unavailable = false;
-        self.recreate_surface_targets()
+        let flutter_texture = surface.flutter_texture;
+        self.recreate_surface_targets()?;
+        if flutter_texture && self.current_video.is_none() {
+            self.render_clear(0.0)?;
+        }
+        Ok(())
     }
 
     fn render_test_frame(&mut self, time_seconds: f64) -> Result<()> {
@@ -1808,7 +1877,7 @@ impl RendererBackend for D3d11Renderer {
     }
 
     fn clear_current_frame(&mut self) -> Result<()> {
-        self.retire_current_video();
+        self.retire_current_video()?;
         self.danmaku_atlas_cache = None;
         if self.surface.is_some() {
             self.render_clear(0.0)?;
@@ -1912,7 +1981,7 @@ impl RendererBackend for D3d11Renderer {
         if !surface.flutter_texture {
             return None;
         }
-        let unknown: IUnknown = surface.output_texture.as_ref()?.cast().ok()?;
+        let unknown: IUnknown = surface.published_texture.as_ref()?.cast().ok()?;
         Some(unknown.into_raw())
     }
 }
@@ -2435,6 +2504,7 @@ fn release_backbuffer_views(context: &ID3D11DeviceContext, surface: &mut Attache
     }
     surface.render_target = None;
     surface.output_texture = None;
+    surface.published_texture = None;
     surface.linear_render_target = None;
     surface.linear_shader_resource = None;
 }
@@ -2466,6 +2536,25 @@ fn d3d11_event_query_complete(context: &ID3D11DeviceContext, query: &ID3D11Query
             .map_err(|error| d3d_error("ID3D11DeviceContext::GetData(video retirement)", error))?;
     }
     Ok(complete.as_bool())
+}
+
+fn wait_for_gpu(device: &ID3D11Device, context: &ID3D11DeviceContext) -> Result<()> {
+    let query = create_d3d11_event_query(device)?;
+    unsafe {
+        context.End(&query);
+        context.Flush();
+    }
+    let started = Instant::now();
+    while !d3d11_event_query_complete(context, &query)? {
+        if started.elapsed() >= Duration::from_millis(100) {
+            return Err(PlayerError::Renderer(
+                "d3d11: compositor GPU handoff timed out; retaining the current decoder frame"
+                    .into(),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    Ok(())
 }
 
 fn create_flutter_texture_target(
@@ -3136,6 +3225,236 @@ fn d3d_error(operation: &'static str, error: ::windows::core::Error) -> PlayerEr
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn flutter_scene_ignores_clock_ticks_but_detects_output_changes() {
+        use crate::overlay::OverlayViewport;
+        use crate::subtitle::SubtitleBitmapPlane;
+        let mut overlay = OverlayFrame {
+            pts: Duration::ZERO,
+            viewport: OverlayViewport::new(8, 8),
+            subtitle_planes: vec![SubtitleBitmapPlane::new(0, 0, 1, 1, vec![255; 4])],
+            subtitle_alpha_planes: vec![],
+            subtitle_changed: true,
+        };
+        let scene = FlutterTextureScene::new(
+            7,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).overlay(Some(&overlay)),
+        );
+        overlay.pts = Duration::from_secs(2);
+        overlay.subtitle_changed = false;
+        let context = RenderFrameContext::new(Duration::from_secs(2), 1).overlay(Some(&overlay));
+        assert!(scene.matches(7, LumaUpscalerMode::Off, context));
+        assert!(!scene.matches(8, LumaUpscalerMode::Off, context));
+        assert!(!scene.matches(7, LumaUpscalerMode::ArtCnnC4F16, context));
+        assert!(!scene.matches(
+            7,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 2).overlay(Some(&overlay))
+        ));
+        overlay.subtitle_planes[0].rgba[0] = 0; // Includes HUD pixel changes.
+        assert!(!scene.matches(
+            7,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).overlay(Some(&overlay))
+        ));
+        assert!(!scene.matches(
+            7,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1)
+        ));
+    }
+
+    #[test]
+    fn flutter_publication_is_sdr_immutable_and_stable_while_idle() {
+        use crate::core::FlutterTextureHandle;
+        let mut renderer = D3d11Renderer::new().unwrap();
+        // WARP keeps this GPU/API contract test runnable on headless CI too.
+        let mut device = None;
+        let mut device_context = None;
+        unsafe {
+            D3D11CreateDevice(
+                None,
+                ::windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_WARP,
+                HMODULE::default(),
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                None,
+                D3D11_SDK_VERSION,
+                Some(&mut device),
+                None,
+                Some(&mut device_context),
+            )
+            .unwrap();
+        }
+        renderer
+            .set_device(device.unwrap(), device_context.unwrap())
+            .unwrap();
+        renderer
+            .attach_surface(PlatformSurface::FlutterTexture(FlutterTextureHandle::new(
+                FlutterTextureKind::WindowsTextureRegistrar,
+                1,
+                4,
+                4,
+                1.0,
+            )))
+            .unwrap();
+        let first = renderer
+            .surface
+            .as_ref()
+            .unwrap()
+            .published_texture
+            .as_ref()
+            .unwrap()
+            .clone();
+        let mut desc = D3D11_TEXTURE2D_DESC::default();
+        unsafe {
+            first.GetDesc(&mut desc);
+        }
+        assert_eq!(desc.Format, SDR_SWAPCHAIN_FORMAT);
+        let source = SourceColorState::new(ColorPrimaries::Bt2020, TransferFunction::Pq);
+        assert!(matches!(
+            renderer.select_output_mode_for_source(source).unwrap(),
+            D3d11OutputMode::Sdr
+        ));
+        assert_eq!(renderer.stats.hdr10_metadata_failures, 0);
+        renderer.render_clear(1.0).unwrap();
+        assert_eq!(
+            first.as_raw(),
+            renderer
+                .surface
+                .as_ref()
+                .unwrap()
+                .published_texture
+                .as_ref()
+                .unwrap()
+                .as_raw()
+        );
+
+        let state = renderer.state.as_ref().unwrap();
+        unsafe {
+            state.context.ClearRenderTargetView(
+                renderer
+                    .surface
+                    .as_ref()
+                    .unwrap()
+                    .render_target
+                    .as_ref()
+                    .unwrap(),
+                &[1.0, 0.0, 0.0, 1.0],
+            );
+        }
+        renderer.publish_flutter_texture().unwrap();
+        let next = renderer
+            .surface
+            .as_ref()
+            .unwrap()
+            .published_texture
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert_ne!(first.as_raw(), next.as_raw());
+        assert_eq!(
+            read_bgra_pixel(renderer.state.as_ref().unwrap(), &first),
+            [0, 0, 0, 255]
+        );
+        assert_eq!(
+            read_bgra_pixel(renderer.state.as_ref().unwrap(), &next),
+            [0, 0, 255, 255]
+        );
+        renderer
+            .resize_surface(SurfaceMetrics::new(8, 6, 1.0))
+            .unwrap();
+        unsafe {
+            first.GetDesc(&mut desc);
+        }
+        assert_eq!((desc.Width, desc.Height), (4, 4));
+        let mut resized = D3D11_TEXTURE2D_DESC::default();
+        unsafe {
+            renderer
+                .surface
+                .as_ref()
+                .unwrap()
+                .published_texture
+                .as_ref()
+                .unwrap()
+                .GetDesc(&mut resized);
+        }
+        assert_eq!((resized.Width, resized.Height), (8, 6));
+    }
+
+    fn read_bgra_pixel(state: &D3d11DeviceState, texture: &ID3D11Texture2D) -> [u8; 4] {
+        use ::windows::Win32::Graphics::Direct3D11::{
+            D3D11_CPU_ACCESS_READ, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_USAGE_STAGING,
+        };
+        let mut desc = D3D11_TEXTURE2D_DESC::default();
+        unsafe {
+            texture.GetDesc(&mut desc);
+        }
+        desc.Usage = D3D11_USAGE_STAGING;
+        desc.BindFlags = 0;
+        desc.MiscFlags = 0;
+        desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ.0 as u32;
+        let mut staging = None;
+        unsafe {
+            state
+                .device
+                .CreateTexture2D(&desc, None, Some(&mut staging))
+                .unwrap();
+        }
+        let staging = staging.unwrap();
+        unsafe {
+            state.context.CopyResource(&staging, texture);
+        }
+        let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+        unsafe {
+            state
+                .context
+                .Map(&staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+                .unwrap();
+            let bytes = *(mapped.pData as *const [u8; 4]);
+            state.context.Unmap(&staging, 0);
+            bytes
+        }
+    }
+
+    #[test]
+    fn flutter_scene_detects_danmaku_motion_and_visibility_changes() {
+        use crate::danmaku::DanmakuViewport;
+        let mut plan = DanmakuRenderPlan::empty(Duration::ZERO, 1, DanmakuViewport::new(8, 8));
+        plan.items.push(DanmakuGlyphInstance {
+            item_id: 1,
+            rect: [0.0, 0.0, 1.0, 1.0],
+            tex_rect: [0.0, 0.0, 1.0, 1.0],
+            color_rgba: [1.0; 4],
+            outline_rgba: [0.0; 4],
+            shadow_rgba: [0.0; 4],
+            shadow_offset: [0.0; 2],
+        });
+        let scene = FlutterTextureScene::new(
+            1,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).danmaku(Some(&plan)),
+        );
+        plan.media_time = Duration::from_secs(1);
+        assert!(scene.matches(
+            1,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).danmaku(Some(&plan))
+        ));
+        plan.items[0].rect[0] = 2.0;
+        assert!(!scene.matches(
+            1,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).danmaku(Some(&plan))
+        ));
+        plan.items.clear();
+        assert!(!scene.matches(
+            1,
+            LumaUpscalerMode::Off,
+            RenderFrameContext::new(Duration::ZERO, 1).danmaku(Some(&plan))
+        ));
+    }
 
     fn assert_close(actual: f32, expected: f32) {
         assert!(

--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::mem;
 use std::ptr;
@@ -10,17 +11,18 @@ use ::windows::Win32::Graphics::Direct3D::{
     D3D_SRV_DIMENSION_TEXTURE2DARRAY, ID3DBlob,
 };
 use ::windows::Win32::Graphics::Direct3D11::{
-    D3D11_BIND_CONSTANT_BUFFER, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE,
-    D3D11_BLEND_DESC, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD,
-    D3D11_BLEND_SRC_ALPHA, D3D11_BOX, D3D11_BUFFER_DESC, D3D11_COLOR_WRITE_ENABLE_ALL,
-    D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_VERTEX_DATA,
-    D3D11_RENDER_TARGET_BLEND_DESC, D3D11_SAMPLER_DESC, D3D11_SDK_VERSION,
-    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA,
-    D3D11_TEX2D_ARRAY_SRV, D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
-    D3D11_VIEWPORT, D3D11CreateDevice, ID3D11BlendState, ID3D11Buffer, ID3D11Device,
-    ID3D11DeviceContext, ID3D11InputLayout, ID3D11Multithread, ID3D11PixelShader,
-    ID3D11RenderTargetView, ID3D11Resource, ID3D11SamplerState, ID3D11ShaderResourceView,
-    ID3D11Texture2D, ID3D11VertexShader,
+    D3D11_ASYNC_GETDATA_DONOTFLUSH, D3D11_BIND_CONSTANT_BUFFER, D3D11_BIND_RENDER_TARGET,
+    D3D11_BIND_SHADER_RESOURCE, D3D11_BLEND_DESC, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_ONE,
+    D3D11_BLEND_OP_ADD, D3D11_BLEND_SRC_ALPHA, D3D11_BOX, D3D11_BUFFER_DESC,
+    D3D11_COLOR_WRITE_ENABLE_ALL, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_INPUT_ELEMENT_DESC,
+    D3D11_INPUT_PER_VERTEX_DATA, D3D11_QUERY_DESC, D3D11_QUERY_EVENT,
+    D3D11_RENDER_TARGET_BLEND_DESC, D3D11_RESOURCE_MISC_SHARED, D3D11_SAMPLER_DESC,
+    D3D11_SDK_VERSION, D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0,
+    D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_ARRAY_SRV, D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC,
+    D3D11_USAGE_DEFAULT, D3D11_VIEWPORT, D3D11CreateDevice, ID3D11BlendState, ID3D11Buffer,
+    ID3D11Device, ID3D11DeviceContext, ID3D11InputLayout, ID3D11Multithread, ID3D11PixelShader,
+    ID3D11Query, ID3D11RenderTargetView, ID3D11Resource, ID3D11SamplerState,
+    ID3D11ShaderResourceView, ID3D11Texture2D, ID3D11VertexShader,
 };
 use ::windows::Win32::Graphics::Dxgi::Common::{
     DXGI_ALPHA_MODE_IGNORE, DXGI_ALPHA_MODE_PREMULTIPLIED, DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
@@ -37,12 +39,12 @@ use ::windows::Win32::Graphics::Dxgi::{
     DXGI_SWAP_CHAIN_FLAG, DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_USAGE_RENDER_TARGET_OUTPUT,
     IDXGIAdapter, IDXGIDevice, IDXGIFactory2, IDXGISwapChain1, IDXGISwapChain3, IDXGISwapChain4,
 };
-use ::windows::core::{IUnknown, Interface, PCSTR};
+use ::windows::core::{BOOL, IUnknown, Interface, PCSTR};
 
 use crate::core::{
-    ColorPrimaries, LumaUpscalerBackendStatus, PlatformSurface, PlayerError, PlayerVideoFrame,
-    RenderFrameContext, RendererBackend, RendererRuntimeStats, Result, SurfaceMetrics,
-    TransferFunction, WgpuSurfaceKind,
+    ColorPrimaries, FlutterTextureKind, LumaUpscalerBackendStatus, PlatformSurface, PlayerError,
+    PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererRuntimeStats, Result,
+    SurfaceMetrics, TransferFunction, WgpuSurfaceKind,
 };
 use crate::danmaku::{
     DanmakuAtlasUpdate, DanmakuGlyphAtlas, DanmakuGlyphInstance, DanmakuRenderPlan,
@@ -600,9 +602,11 @@ struct D3d11DeviceState {
 struct AttachedSurface {
     hwnd: HWND,
     composition: bool,
+    flutter_texture: bool,
     metrics: SurfaceMetrics,
     output_mode: D3d11OutputMode,
     swapchain: Option<IDXGISwapChain1>,
+    output_texture: Option<ID3D11Texture2D>,
     render_target: Option<ID3D11RenderTargetView>,
     linear_render_target: Option<ID3D11RenderTargetView>,
     linear_shader_resource: Option<ID3D11ShaderResourceView>,
@@ -610,8 +614,11 @@ struct AttachedSurface {
 
 impl AttachedSurface {
     fn targets_ready(&self) -> bool {
-        self.swapchain.is_some()
-            && self.render_target.is_some()
+        (if self.flutter_texture {
+            self.output_texture.is_some()
+        } else {
+            self.swapchain.is_some()
+        }) && self.render_target.is_some()
             && (!matches!(self.output_mode, D3d11OutputMode::Hdr10)
                 || (self.linear_render_target.is_some() && self.linear_shader_resource.is_some()))
     }
@@ -628,6 +635,12 @@ struct ImportedVideoFrame {
     _array_index: u32,
     frame_token: u64,
     constants: VideoUniforms,
+}
+
+struct RetiredVideoFrame {
+    _video: ImportedVideoFrame,
+    context: ID3D11DeviceContext,
+    completion: Option<ID3D11Query>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -747,6 +760,7 @@ pub struct D3d11Renderer {
     state: Option<D3d11DeviceState>,
     surface: Option<AttachedSurface>,
     current_video: Option<ImportedVideoFrame>,
+    retired_video: VecDeque<RetiredVideoFrame>,
     danmaku_atlas_cache: Option<D3d11DanmakuAtlasCache>,
     requested_output_mode: crate::renderer::output::OutputMode,
     video_alpha_mode: VideoAlphaMode,
@@ -767,6 +781,7 @@ impl D3d11Renderer {
             state: None,
             surface: None,
             current_video: None,
+            retired_video: VecDeque::new(),
             danmaku_atlas_cache: None,
             requested_output_mode: config.output_mode,
             video_alpha_mode: config.video_alpha_mode,
@@ -780,6 +795,59 @@ impl D3d11Renderer {
 
     pub fn stats(&self) -> D3d11RendererStats {
         self.stats
+    }
+
+    fn collect_completed_video_frames(&mut self) {
+        let mut first_error = None;
+        self.retired_video.retain(|retired| {
+            let Some(completion) = retired.completion.as_ref() else {
+                return true;
+            };
+            match d3d11_event_query_complete(&retired.context, completion) {
+                Ok(true) => false,
+                Ok(false) => true,
+                Err(error) => {
+                    first_error.get_or_insert(error);
+                    true
+                }
+            }
+        });
+        if let Some(error) = first_error {
+            trace(&format!("video frame retirement query failed: {error}"));
+        }
+    }
+
+    fn retire_current_video(&mut self) {
+        self.collect_completed_video_frames();
+        let Some(video) = self.current_video.take() else {
+            return;
+        };
+        let Some(state) = self.state.as_ref() else {
+            return;
+        };
+        let context = state.context.clone();
+        let completion = match create_d3d11_event_query(&state.device) {
+            Ok(query) => {
+                unsafe {
+                    context.End(&query);
+                    context.Flush();
+                }
+                Some(query)
+            }
+            Err(error) => {
+                // Retaining the AVFrame is safer than returning its texture
+                // array slice to the decoder without a GPU completion fence.
+                trace(&format!(
+                    "video frame retirement fence unavailable: {error}"
+                ));
+                None
+            }
+        };
+        self.retired_video.push_back(RetiredVideoFrame {
+            _video: video,
+            context,
+            completion,
+        });
     }
 
     fn ensure_default_device(&mut self) -> Result<()> {
@@ -802,7 +870,7 @@ impl D3d11Renderer {
         }
         let context = unsafe { frame_device.GetImmediateContext() }
             .map_err(|error| d3d_error("ID3D11Device::GetImmediateContext", error))?;
-        self.current_video = None;
+        self.retire_current_video();
         self.danmaku_atlas_cache = None;
         self.set_device(frame_device, context)
     }
@@ -827,6 +895,7 @@ impl D3d11Renderer {
             if let Some(surface) = self.surface.as_mut() {
                 release_backbuffer_views(&old.context, surface);
                 surface.swapchain = None;
+                surface.output_texture = None;
             }
         }
         self.state = Some(state);
@@ -849,6 +918,20 @@ impl D3d11Renderer {
         let format = output_mode.swapchain_format();
         let hwnd = surface.hwnd;
         let composition = surface.composition;
+
+        if surface.flutter_texture {
+            surface.swapchain = None;
+            let (texture, render_target) =
+                create_flutter_texture_target(&state.device, width, height)?;
+            surface.output_texture = Some(texture);
+            surface.render_target = Some(render_target);
+            surface.output_mode = D3d11OutputMode::Sdr;
+            self.stats.surface_width = surface.metrics.physical_extent.width;
+            self.stats.surface_height = surface.metrics.physical_extent.height;
+            self.stats.hdr10_output_active = false;
+            return Ok(());
+        }
+        surface.output_texture = None;
 
         // Size and SDR↔HDR format changes keep the same IDXGISwapChain1 so a
         // DirectComposition visual's SetContent stays valid. Device changes
@@ -913,12 +996,17 @@ impl D3d11Renderer {
             self.stats.hdr10_output_active = false;
             return Ok(());
         };
+        let output_mode = if surface.flutter_texture {
+            D3d11OutputMode::Sdr
+        } else {
+            output_mode
+        };
         if surface.output_mode == output_mode && surface.targets_ready() {
             self.stats.hdr10_output_active = matches!(output_mode, D3d11OutputMode::Hdr10);
             return Ok(());
         }
         surface.output_mode = output_mode;
-        self.current_video = None;
+        self.retire_current_video();
         self.recreate_surface_targets()
     }
 
@@ -1045,7 +1133,7 @@ impl D3d11Renderer {
         self.stats.hardware_video_frames += 1;
         self.stats.zero_copy_video_frames += 1;
         self.stats.direct_zero_copy_video_frames += 1;
-        self.current_video = Some(ImportedVideoFrame {
+        let imported = ImportedVideoFrame {
             _frame: retained_frame,
             _texture: texture,
             luma,
@@ -1062,7 +1150,9 @@ impl D3d11Renderer {
             frame_token,
             constants: constants_for_frame(source_color, texture_format, target_color)
                 .packed_alpha_right(self.video_alpha_mode.has_alpha()),
-        });
+        };
+        self.retire_current_video();
+        self.current_video = Some(imported);
         Ok(())
     }
 
@@ -1422,6 +1512,7 @@ impl D3d11Renderer {
     }
 
     fn render_video(&mut self, context: RenderFrameContext<'_>) -> Result<bool> {
+        self.collect_completed_video_frames();
         if self.current_video.is_none() {
             return Ok(false);
         }
@@ -1498,10 +1589,6 @@ impl D3d11Renderer {
             None
         };
         let scene_rtv = linear_target.map_or(rtv, |(linear_rtv, _)| linear_rtv);
-        let swapchain = surface
-            .swapchain
-            .as_ref()
-            .ok_or_else(|| PlayerError::Renderer("d3d11: no swapchain attached".to_string()))?;
         unsafe {
             state.context.ClearRenderTargetView(
                 scene_rtv,
@@ -1545,7 +1632,14 @@ impl D3d11Renderer {
                 video.constants,
             )?;
         }
-        present_swapchain(swapchain, "IDXGISwapChain1::Present1")?;
+        if let Some(swapchain) = surface.swapchain.as_ref() {
+            present_swapchain(swapchain, "IDXGISwapChain1::Present1")?;
+        } else if surface.flutter_texture {
+            // A legacy DXGI shared handle has no keyed mutex. Flush the
+            // producer context before Flutter opens/samples it on ANGLE's
+            // device so the completed frame is externally visible.
+            unsafe { state.context.Flush() };
+        }
         self.stats.rendered_frames += 1;
         if !danmaku_draws.is_empty() {
             self.stats.danmaku_passes += 1;
@@ -1557,7 +1651,7 @@ impl D3d11Renderer {
     fn ensure_surface_ready(&mut self) -> Result<()> {
         if self.surface.is_none() {
             return Err(PlayerError::Renderer(
-                "d3d11: no HWND surface attached".to_string(),
+                "d3d11: no output surface attached".to_string(),
             ));
         }
         if self
@@ -1596,10 +1690,11 @@ impl D3d11Renderer {
             trace("render_clear: clear");
             state.context.ClearRenderTargetView(rtv, &color);
             trace("render_clear: present");
-            present_swapchain(
-                surface.swapchain.as_ref().expect("swapchain ensured"),
-                "IDXGISwapChain1::Present1(clear)",
-            )?;
+            if let Some(swapchain) = surface.swapchain.as_ref() {
+                present_swapchain(swapchain, "IDXGISwapChain1::Present1(clear)")?;
+            } else if surface.flutter_texture {
+                state.context.Flush();
+            }
         }
         trace("render_clear: done");
         self.stats.rendered_frames += 1;
@@ -1609,29 +1704,52 @@ impl D3d11Renderer {
 
 impl RendererBackend for D3d11Renderer {
     fn attach_surface(&mut self, surface: PlatformSurface) -> Result<()> {
-        let PlatformSurface::Wgpu(handle) = surface else {
-            return Err(PlayerError::Renderer(
-                "d3d11: only Windows HWND surfaces are supported".to_string(),
-            ));
+        let (hwnd, composition, flutter_texture, metrics) = match surface {
+            PlatformSurface::Wgpu(handle) => {
+                if handle.kind != WgpuSurfaceKind::WindowsHwnd {
+                    return Err(PlayerError::Renderer(format!(
+                        "d3d11: surface kind {:?} is not supported",
+                        handle.kind
+                    )));
+                }
+                let composition = handle.output_capabilities.direct_composition;
+                if !composition && handle.raw_window == 0 {
+                    return Err(PlayerError::Renderer(
+                        "d3d11: Windows HWND surface handle is null".to_string(),
+                    ));
+                }
+                (
+                    HWND(handle.raw_window as *mut c_void),
+                    composition,
+                    false,
+                    handle.metrics,
+                )
+            }
+            PlatformSurface::FlutterTexture(handle)
+                if handle.kind == FlutterTextureKind::WindowsTextureRegistrar =>
+            {
+                (HWND::default(), false, true, handle.metrics)
+            }
+            PlatformSurface::FlutterTexture(handle) => {
+                return Err(PlayerError::Renderer(format!(
+                    "d3d11: Flutter texture kind {:?} is not supported",
+                    handle.kind
+                )));
+            }
+            PlatformSurface::Metal(_) => {
+                return Err(PlayerError::Renderer(
+                    "d3d11: Metal surfaces are not supported".to_string(),
+                ));
+            }
         };
-        if handle.kind != WgpuSurfaceKind::WindowsHwnd {
-            return Err(PlayerError::Renderer(format!(
-                "d3d11: surface kind {:?} is not supported",
-                handle.kind
-            )));
-        }
-        let composition = handle.output_capabilities.direct_composition;
-        if !composition && handle.raw_window == 0 {
-            return Err(PlayerError::Renderer(
-                "d3d11: Windows HWND surface handle is null".to_string(),
-            ));
-        }
         self.surface = Some(AttachedSurface {
-            hwnd: HWND(handle.raw_window as *mut c_void),
+            hwnd,
             composition,
-            metrics: handle.metrics,
+            flutter_texture,
+            metrics,
             output_mode: D3d11OutputMode::Sdr,
             swapchain: None,
+            output_texture: None,
             render_target: None,
             linear_render_target: None,
             linear_shader_resource: None,
@@ -1643,8 +1761,8 @@ impl RendererBackend for D3d11Renderer {
     }
 
     fn detach_surface(&mut self) -> Result<()> {
+        self.retire_current_video();
         self.surface = None;
-        self.current_video = None;
         self.danmaku_atlas_cache = None;
         self.stats.attached = false;
         self.stats.surface_width = 0;
@@ -1655,7 +1773,7 @@ impl RendererBackend for D3d11Renderer {
     fn resize_surface(&mut self, metrics: SurfaceMetrics) -> Result<()> {
         let Some(surface) = self.surface.as_mut() else {
             return Err(PlayerError::Renderer(
-                "d3d11: no HWND surface attached".to_string(),
+                "d3d11: no output surface attached".to_string(),
             ));
         };
         if surface.metrics.physical_extent == metrics.physical_extent {
@@ -1690,7 +1808,7 @@ impl RendererBackend for D3d11Renderer {
     }
 
     fn clear_current_frame(&mut self) -> Result<()> {
-        self.current_video = None;
+        self.retire_current_video();
         self.danmaku_atlas_cache = None;
         if self.surface.is_some() {
             self.render_clear(0.0)?;
@@ -1786,6 +1904,15 @@ impl RendererBackend for D3d11Renderer {
 
     fn composition_swapchain_iunknown(&self) -> Option<*mut std::ffi::c_void> {
         let unknown: IUnknown = self.composition_swapchain()?.cast().ok()?;
+        Some(unknown.into_raw())
+    }
+
+    fn windows_flutter_texture_iunknown(&self) -> Option<*mut std::ffi::c_void> {
+        let surface = self.surface.as_ref()?;
+        if !surface.flutter_texture {
+            return None;
+        }
+        let unknown: IUnknown = surface.output_texture.as_ref()?.cast().ok()?;
         Some(unknown.into_raw())
     }
 }
@@ -2307,8 +2434,84 @@ fn release_backbuffer_views(context: &ID3D11DeviceContext, surface: &mut Attache
         context.PSSetShaderResources(0, Some(&[None, None]));
     }
     surface.render_target = None;
+    surface.output_texture = None;
     surface.linear_render_target = None;
     surface.linear_shader_resource = None;
+}
+
+fn create_d3d11_event_query(device: &ID3D11Device) -> Result<ID3D11Query> {
+    let desc = D3D11_QUERY_DESC {
+        Query: D3D11_QUERY_EVENT,
+        MiscFlags: 0,
+    };
+    let mut query = None;
+    unsafe {
+        device
+            .CreateQuery(&desc, Some(&mut query))
+            .map_err(|error| d3d_error("ID3D11Device::CreateQuery(video retirement)", error))?;
+    }
+    query.ok_or_else(|| PlayerError::Renderer("d3d11: video retirement query was null".to_string()))
+}
+
+fn d3d11_event_query_complete(context: &ID3D11DeviceContext, query: &ID3D11Query) -> Result<bool> {
+    let mut complete = BOOL::default();
+    unsafe {
+        context
+            .GetData(
+                query,
+                Some((&mut complete as *mut BOOL).cast::<c_void>()),
+                mem::size_of::<BOOL>() as u32,
+                D3D11_ASYNC_GETDATA_DONOTFLUSH.0 as u32,
+            )
+            .map_err(|error| d3d_error("ID3D11DeviceContext::GetData(video retirement)", error))?;
+    }
+    Ok(complete.as_bool())
+}
+
+fn create_flutter_texture_target(
+    device: &ID3D11Device,
+    width: u32,
+    height: u32,
+) -> Result<(ID3D11Texture2D, ID3D11RenderTargetView)> {
+    let desc = D3D11_TEXTURE2D_DESC {
+        Width: width.max(1),
+        Height: height.max(1),
+        MipLevels: 1,
+        ArraySize: 1,
+        Format: SDR_SWAPCHAIN_FORMAT,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Usage: D3D11_USAGE_DEFAULT,
+        BindFlags: D3D11_BIND_RENDER_TARGET.0 as u32 | D3D11_BIND_SHADER_RESOURCE.0 as u32,
+        CPUAccessFlags: 0,
+        MiscFlags: D3D11_RESOURCE_MISC_SHARED.0 as u32,
+    };
+    let mut texture = None;
+    unsafe {
+        device
+            .CreateTexture2D(&desc, None, Some(&mut texture))
+            .map_err(|error| d3d_error("ID3D11Device::CreateTexture2D(Flutter)", error))?;
+    }
+    let texture = texture.ok_or_else(|| {
+        PlayerError::Renderer("d3d11: Flutter output texture was null".to_string())
+    })?;
+    let resource: ID3D11Resource = texture
+        .cast()
+        .map_err(|error| d3d_error("ID3D11Texture2D::cast<ID3D11Resource>(Flutter)", error))?;
+    let mut render_target = None;
+    unsafe {
+        device
+            .CreateRenderTargetView(&resource, None, Some(&mut render_target))
+            .map_err(|error| d3d_error("ID3D11Device::CreateRenderTargetView(Flutter)", error))?;
+    }
+    Ok((
+        texture,
+        render_target.ok_or_else(|| {
+            PlayerError::Renderer("d3d11: Flutter render target view was null".to_string())
+        })?,
+    ))
 }
 
 fn create_render_target(
@@ -2981,6 +3184,7 @@ mod tests {
         let renderer = D3d11Renderer::with_config(MetalRendererConfig {
             output_mode: crate::renderer::metal::MetalOutputMode::Sdr,
             luma_upscaler: LumaUpscalerMode::ArtCnnC4F16,
+            video_alpha_mode: VideoAlphaMode::Opaque,
         })
         .unwrap();
 

--- a/crates/erika_capi/include/erika.h
+++ b/crates/erika_capi/include/erika.h
@@ -752,6 +752,13 @@ ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
     ErikaPresenterHandle *handle,
     void **out_swapchain);
 
+/* Windows only. Returns an AddRef'd IUnknown for the latest completed,
+ * immutable SDR Flutter GPU frame. The caller owns the COM reference and
+ * must Release it. The texture remains unchanged for its entire lifetime. */
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_texture);
+
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -3610,6 +3610,30 @@ pub unsafe extern "C" fn erika_presenter_windows_composition_swapchain_iunknown(
     })
 }
 
+/// Returns an AddRef'd IUnknown for the presenter's renderer-owned, shareable
+/// Windows Flutter output texture. The caller owns the returned COM reference
+/// and must Release it.
+#[cfg(target_os = "windows")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn erika_presenter_windows_flutter_texture_iunknown(
+    handle: *mut ErikaPresenterHandle,
+    out_texture: *mut *mut std::ffi::c_void,
+) -> ErikaStatus {
+    if out_texture.is_null() {
+        set_last_error("Windows Flutter texture output pointer is null");
+        return ErikaStatus::NullPointer;
+    }
+    unsafe { *out_texture = std::ptr::null_mut() };
+    with_presenter_mut(handle, |handle| {
+        let Some(texture) = handle.presenter.windows_flutter_texture_iunknown() else {
+            set_last_error("presenter does not own a Windows Flutter texture");
+            return ErikaStatus::PlayerError;
+        };
+        unsafe { *out_texture = texture };
+        ErikaStatus::Ok
+    })
+}
+
 #[cfg(any(
     target_os = "macos",
     any(target_os = "ios", target_os = "tvos"),

--- a/crates/erika_capi/src/lib.rs
+++ b/crates/erika_capi/src/lib.rs
@@ -3610,9 +3610,8 @@ pub unsafe extern "C" fn erika_presenter_windows_composition_swapchain_iunknown(
     })
 }
 
-/// Returns an AddRef'd IUnknown for the presenter's renderer-owned, shareable
-/// Windows Flutter output texture. The caller owns the returned COM reference
-/// and must Release it.
+/// Returns an AddRef'd IUnknown for the latest completed, immutable Windows
+/// Flutter SDR frame. The caller owns the COM reference and must Release it.
 #[cfg(target_os = "windows")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn erika_presenter_windows_flutter_texture_iunknown(
@@ -5322,6 +5321,10 @@ mod tests {
         );
         let expected_backend = if cfg!(all(target_os = "android", feature = "wgpu")) {
             ErikaUpscalerBackendStatus::Scalar
+        } else if cfg!(target_os = "windows") {
+            // D3D11 initializes the requested GPU upscaler after attaching a
+            // device; before attachment the existing backend reports Building.
+            ErikaUpscalerBackendStatus::Building
         } else {
             ErikaUpscalerBackendStatus::Inactive
         };

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -66,12 +66,33 @@ platform view. On macOS the plugin allocates an IOSurface-backed
 `CVPixelBuffer` pool, renders into its Metal texture directly (no per-frame CPU
 readback), and publishes frames to Flutter, so regular Flutter effects —
 `Opacity`, clipping, transforms, and color filters — apply to the video. On
-OpenHarmony it reuses the registered external texture. On other platforms it
+OpenHarmony it reuses the registered external texture. On Windows it offers
+explicit SDR BGRA8 output (see below). On other platforms it
 falls back to `ErikaVideoView`.
 
 When `blendMode` is not `srcOver` on macOS, the widget routes back to the native
 platform view so Core Animation can blend the video against the real backdrop
 (see Transparent Video and Blend Modes below).
+
+Windows `ErikaVideoView` keeps the native HWND/swapchain path and HDR10
+negotiation for ordinary opaque playback. Only explicitly selecting
+`ErikaTextureVideoView` opts into SDR texture composition. `srcOver` supports
+Flutter opacity/clipping/filters; `overlay` uses native Windows Composition;
+other Windows blend modes are rejected.
+
+Each changed texture frame is copied on the GPU into a completed, immutable
+shared snapshot, without CPU pixel readback. Paused output is reused until the
+video, subtitles, danmaku, HUD, seek generation or surface size changes. The
+plugin holds only the latest and raster-acquired snapshots. Opening a shared
+handle does not signal GPU sampling completion, so published textures are never
+overwritten. These extra copies and GPU handoff barriers do not apply to native
+opaque HWND playback, and the decoder pool retains main's existing size.
+
+The new texture API requires a matching source runtime
+(`ERIKA_FORCE_SOURCE_BUILD=1` from a checkout). The pinned v0.1.7 prebuilt lacks
+it; missing optional texture symbols do not prevent native player creation.
+Publish matching native artifacts and update their version/checksums before
+releasing this capability.
 
 ## Android Surface Strategies
 

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -43,6 +43,12 @@ Apple HDR 路径使用 native Metal-backed surface，而不是 Flutter Texture�
 
 macOS 上当 `blendMode` 不是 `srcOver` 时，widget 会改走 native platform view，让 Core Animation 基于真实背景做混合（见下文"透明视频与混合模式"）。
 
+Windows 上 `ErikaVideoView` 默认继续使用原生 HWND/swapchain，保留普通视频的 HDR10 输出；不会根据当前片源或 `outputMode` 自动切入 Flutter Texture。显式使用 `ErikaTextureVideoView` 才启用 SDR BGRA8 texture；`srcOver` 支持 Flutter 的透明度、裁剪、变换和颜色滤镜，`overlay` 转入原生 Windows Composition，其余混合模式明确报错。
+
+Windows texture 每次画面内容变化后通过 GPU copy 发布完成且不可变的快照，无 CPU 像素回读；复制完成前不会交给 Flutter。暂停且字幕/弹幕/HUD 未变化时复用已发布快照，不重复通知 Flutter。尺寸变化、seek、字幕、弹幕和 HUD 更新均会使输出失效。Flutter 打开共享句柄不等于 GPU 采样结束，因此已发布快照永不被再次写入。插件仅保留最新和正在被 raster callback 读取的快照，未消费的中间 resize 快照可立即回收。
+
+此能力需要配套源码版本的 native runtime（在仓库中设置 `ERIKA_FORCE_SOURCE_BUILD=1`）；当前固定的 v0.1.7 预编译库缺少新 API。缺少 texture 符号仅使显式 texture 绑定报错，不影响原生播放器创建。发布新能力前必须更新匹配的 native artifact 版本和校验值。
+
 ## Android Surface Strategies
 
 Android 上两个视频 widget 都使用同一套 native-view selector。SDR 使用真实的

--- a/docs/investigations/pr129-native-hdr-compatibility.zh.md
+++ b/docs/investigations/pr129-native-hdr-compatibility.zh.md
@@ -56,3 +56,12 @@ ctest --test-dir target/windows-plugin-tests -C Debug --output-on-failure
 - 尚未执行 HDR 显示器上的实际视频播放、NipaPlay 集成和真实 DWM Composition 压力测试。无窗口 GPU/API 测试不等于这些场景已验收。
 - 合并前建议验证：普通 SDR/HDR10 的默认主组件播放与输出状态、暂停/seek/字幕/弹幕/超分、窗口缩放和跨显示器移动；透明扫描线 overlay；显式 texture 的暂停通知、裁剪/透明度、快速缩放及播放器切换/关闭。
 - 修改保存在独立 worktree，不改用户 main 工作区的已有修改；推送到原 PR 分支须经用户明确要求，不合并到 main。
+
+## 2026-09-07：Copilot 意见的实质性修复
+
+- 只处理已确认的 overlay 所有权错误及重复 CPU 缓冲复制。没有增加未经复现的 `isTopmost=FALSE` 回退，也没有调整诊断文案。
+- HWND 重建只恢复原 owner 的绑定；不再依赖无序容器的最后一个元素。显式切换 owner 时先解绑旧 producer；旧播放器迟到的 detach/hide 不得隐藏当前画面或切换共享 HWND。无 owner 或 owner 已解绑时，不擅自选择其他播放器。
+- 同一已绑定播放器隐藏后再次显示，不因 owner 标记暂时清空而重新创建 swapchain。默认原生 HWND/HDR 路径、解码池和输出格式协商不变。
+- texture 场景缓存按字幕/HUD、弹幕各自的实际内容更新；新视频帧不再导致未变化的 CPU 像素缓冲和实例列表被重新深拷贝。保留精确内容比较，没有引入可能漏更新的哈希或仅视频帧号判定；弹幕 atlas 继续使用已有 Arc 共享。
+- 新增测试验证连续 120 个视频帧沿用同一份缓存分配，同时字幕像素、alpha、弹幕位置及清除操作仍正确失效。Windows native 测试用隐藏 HWND 和真实插件状态逻辑覆盖 owner 保持、独占交接、迟到解绑、无 owner、绑定失败；仅 surface attach/detach 的 C 入口被替换，不测试真实 DWM 图像效果。
+- 本轮完整回归：Flutter 104/104，analyze 无问题；联合 Rust 核心 529/529、C API 41/41；插件编译及 native CTest 3/3。

--- a/docs/investigations/pr129-native-hdr-compatibility.zh.md
+++ b/docs/investigations/pr129-native-hdr-compatibility.zh.md
@@ -1,0 +1,58 @@
+# PR #129 修复与验证记录
+
+## 范围
+
+- 原 PR：AimesSoft/Erika#129，head `2c5e470fd33b4a7297fa5b15bb22cb65ace1899e`。
+- 对照 main：`7b0fa9179d0cd3b85e28974844f213d0e00aa058`。
+- 本地修复分支：`codex/pr129-preserve-native-hdr`。
+- 普通播放继续沿用 main 的原生 Windows HWND/swapchain 和 HDR10 协商路径；不以 Flutter texture 替换主路径。
+
+## 修复结果
+
+1. 恢复 Windows `ErikaVideoView` 到 `ErikaWindowOverlayVideoView`，透传 blendMode、opacity、debugLabel 和回调。默认 srcOver、auto/extendedLinear 不会隐式创建 texture。
+2. `ErikaTextureVideoView` 才显式选择 Windows SDR BGRA8 texture。srcOver 支持 Flutter 透明度、裁剪和滤镜；overlay 转原生 Composition；其他 Windows 混合模式明确报错。删除了不能跨 TextureLayer 生效的 canvas saveLayer 包装。
+3. 保留 PR 的双输入 Composition effect graph 和 FittedBox 变换矩形修复。
+4. 新增纹理 API 改为可选加载，在解绑现有表面前检查能力。旧 DLL 缺少新符号不再阻止普通播放器创建。两份 C 头文件同步声明新 API。
+5. GPU 输出发布为复制完成、之后不再写入的共享快照。插件仅持有 latest 和 raster callback 获取的 sampled 描述符；跳过的 resize 快照可回收。不能用 release_callback 或固定帧数推断 Flutter 已完成 GPU 采样，因此没有采用“超时强制删除快照”的建议。
+6. 只有画面内容或尺寸变化才发布新快照并通知 Flutter。内容判定包括视频帧、seek generation、字幕/HUD、弹幕和超分模式；仅时钟推进不构成新画面。
+7. 修复播放器销毁后纹理 owner 未清空，以及替换 overlay HWND 前旧对象引用未解绑的问题。
+8. 撤回全局 D3D11VA 表面池扩容和无界退休帧队列。`ffmpeg.rs` 与上述 main 完全一致；额外 GPU handoff 等待只用于 Composition/texture，不加到普通不透明 HWND 播放。
+
+显式 texture 为安全跨设备交接，每次画面变化会增加 GPU snapshot 分配、copy 和有界完成等待；没有 CPU 像素回读。这些开销不进入默认原生播放路径。
+
+## 验证时发现的既有问题
+
+- C API 的超分状态测试只对 Android 特判。Windows D3D11 在设备未绑定时本来就报告 Building，而测试期待 Inactive。在原始 main 上复现相同失败；只修改 Windows 测试预期，未修改超分行为。
+- main 的异步弹幕 planner 在销毁时只发 shutdown 通知，没有等待线程结束。插件最后一个播放器释放后会卸载 DLL，尚未启动/退出的线程可能执行已卸载代码。异常地址解析到了 Rust 线程启动和分配函数；旧版 v0.1.7 DLL 压力测试也复现退出异常。修复只在 Windows 销毁时保存并 join 弹幕工作线程，先释放共享状态锁再等待，不改正常弹幕规划、播放、解码或 HDR 策略。其他平台保留原有退出策略。
+
+## 已完成验证
+
+- `flutter test --no-pub --reporter expanded`：104/104。
+- `flutter analyze --no-pub`：无问题。
+- `cargo test -p erika -p erika_capi --lib -- --test-threads=1`：核心 528/528、C API 41/41。联合运行启用了 C API 依赖的特性集合，因此数量高于单独的默认核心测试。
+- `cargo build -p erika_capi`：成功生成 DLL；保留已有 unused/dead-code 和 LNK4098 警告。
+- Windows 插件使用真实 Flutter SDK 完整编译、链接成功。
+- 原生 CTest：3/3（GPU publication、旧 runtime API 兼容性、新 runtime texture 生命周期）。
+- 新 runtime 实际插件连接与 DLL 卸载连续 50/50 次通过；不固定持有 DLL。
+- GPU 测试包含 WARP 像素读回验证快照不可变、跳过 100 次 resize 发布的引用回收、10,000 次并发发布/读取，以及 idle/resize 内容失效。
+- `git diff --check`、`cargo fmt --all -- --check`：通过。
+
+旧 runtime 的兼容性测试明确固定持有 DLL，仅验证加载、创建、能力检查和纹理 owner 清理；不声称修复已发布二进制内部的线程退出缺陷。源码 runtime 测试必须实际卸载 DLL，覆盖本次退出竞态修复。
+
+原生测试可独立配置：
+
+```powershell
+cmake -S packages/erika_flutter/windows/tests -B target/windows-plugin-tests -A x64 `
+  -DFLUTTER_ENGINE_DIR="<Flutter SDK>/bin/cache/artifacts/engine/windows-x64" `
+  -DERIKA_COMPAT_DLL="<released v0.1.7>/erika_capi.dll" `
+  -DERIKA_SOURCE_DLL="<this checkout>/target/debug/erika_capi.dll"
+cmake --build target/windows-plugin-tests --config Debug
+ctest --test-dir target/windows-plugin-tests -C Debug --output-on-failure
+```
+
+## 发布与验收边界
+
+- 当前 artifact manifest 仍固定 v0.1.7，该预编译库没有新 texture API，也没有上述线程退出修复。使用新能力需匹配的源码 runtime（仓库源码构建可设置 `ERIKA_FORCE_SOURCE_BUILD=1`）；正式发布前需构建并更新匹配的 artifact 和校验值。没有虚构或修改成尚不存在的版本。
+- 尚未执行 HDR 显示器上的实际视频播放、NipaPlay 集成和真实 DWM Composition 压力测试。无窗口 GPU/API 测试不等于这些场景已验收。
+- 合并前建议验证：普通 SDR/HDR10 的默认主组件播放与输出状态、暂停/seek/字幕/弹幕/超分、窗口缩放和跨显示器移动；透明扫描线 overlay；显式 texture 的暂停通知、裁剪/透明度、快速缩放及播放器切换/关闭。
+- 修改保存在独立 worktree，不改用户 main 工作区的已有修改；推送到原 PR 分支须经用户明确要求，不合并到 main。

--- a/packages/erika_flutter/README.md
+++ b/packages/erika_flutter/README.md
@@ -32,6 +32,19 @@ video stays outside Flutter's platform-view compositor.
 On Windows `ErikaWindowOverlayVideoView` hosts a window-level Direct3D 11
 swapchain as a sibling surface, following the same overlay model.
 
+Windows `ErikaVideoView` uses that native path too, including for default
+opaque `srcOver` playback. It preserves HDR10 negotiation outside Flutter's
+texture compositor. `ErikaTextureVideoView` is an explicit **SDR-only** option
+for content that needs Flutter opacity, clipping or color filters. Its default
+`srcOver` uses BGRA8 GPU snapshots; `overlay` uses native Windows Composition.
+Other Windows blend modes are rejected explicitly.
+
+Windows texture output requires a runtime built from the matching source
+revision (`ERIKA_FORCE_SOURCE_BUILD=1`); the pinned v0.1.7 prebuilt does not
+provide this new API. Native video/player creation remains compatible with
+that prebuilt. Publish matching binaries and update the artifact manifest
+before distributing the new texture capability in a release.
+
 Use `ErikaVideoView` when a standard Flutter platform view is required for a
 small embedder, compatibility path, or diagnostics.
 

--- a/packages/erika_flutter/lib/src/erika_player.dart
+++ b/packages/erika_flutter/lib/src/erika_player.dart
@@ -21,11 +21,11 @@ class ErikaMediaMetadata {
   final Uint8List? artwork;
 
   Map<String, Object> toMap() => <String, Object>{
-        'title': title,
-        if (artist != null) 'artist': artist!,
-        if (album != null) 'album': album!,
-        if (artwork != null) 'artwork': artwork!,
-      };
+    'title': title,
+    if (artist != null) 'artist': artist!,
+    if (album != null) 'album': album!,
+    if (artwork != null) 'artwork': artwork!,
+  };
 }
 
 /// Subtitle text colour Erika falls back to, as `0xRRGGBBAA`: opaque white.
@@ -48,7 +48,8 @@ const int kErikaSubtitleOverrideBorder = 1 << 6;
 const int kErikaSubtitleOverrideAlignment = 1 << 7;
 const int kErikaSubtitleOverrideMargins = 1 << 8;
 const int kErikaSubtitleOverrideBlur = 1 << 11;
-const int kErikaSubtitleOverrideAll = kErikaSubtitleOverrideFontSizeFields |
+const int kErikaSubtitleOverrideAll =
+    kErikaSubtitleOverrideFontSizeFields |
     kErikaSubtitleOverrideFontName |
     kErikaSubtitleOverrideColors |
     kErikaSubtitleOverrideAttributes |
@@ -273,9 +274,7 @@ class ErikaPresenterResourceStatus {
       danmakuVertexBufferBytes: value('danmakuVertexBufferBytes'),
       upscalerBytes: value('upscalerBytes'),
       rendererTrackedBytes: value('rendererTrackedBytes'),
-      presenterCpuDanmakuAtlasBytes: value(
-        'presenterCpuDanmakuAtlasBytes',
-      ),
+      presenterCpuDanmakuAtlasBytes: value('presenterCpuDanmakuAtlasBytes'),
       drawableCount: value('drawableCount'),
       outputModeSwitches: value('outputModeSwitches'),
     );
@@ -614,8 +613,9 @@ class _ErikaDanmakuConfigPatch {
     this.blockBottom,
     this.blockScroll,
     List<String>? blockWords,
-  }) : blockWords =
-            blockWords == null ? null : List<String>.unmodifiable(blockWords);
+  }) : blockWords = blockWords == null
+           ? null
+           : List<String>.unmodifiable(blockWords);
 
   final bool? enabled;
   final double? fontSize;
@@ -697,36 +697,39 @@ class _ErikaDanmakuConfigPatch {
       enabled: _changed(enabled, previous?.enabled) ? enabled : null,
       fontSize: _changed(fontSize, previous?.fontSize) ? fontSize : null,
       opacity: _changed(opacity, previous?.opacity) ? opacity : null,
-      displayArea:
-          _changed(displayArea, previous?.displayArea) ? displayArea : null,
+      displayArea: _changed(displayArea, previous?.displayArea)
+          ? displayArea
+          : null,
       scrollDurationSeconds:
           _changed(scrollDurationSeconds, previous?.scrollDurationSeconds)
-              ? scrollDurationSeconds
-              : null,
+          ? scrollDurationSeconds
+          : null,
       scrollSpeedFactor:
           _changed(scrollSpeedFactor, previous?.scrollSpeedFactor)
-              ? scrollSpeedFactor
-              : null,
+          ? scrollSpeedFactor
+          : null,
       trackGapRatio: _changed(trackGapRatio, previous?.trackGapRatio)
           ? trackGapRatio
           : null,
-      outlineWidth:
-          _changed(outlineWidth, previous?.outlineWidth) ? outlineWidth : null,
+      outlineWidth: _changed(outlineWidth, previous?.outlineWidth)
+          ? outlineWidth
+          : null,
       shadowOffsetX: _changed(shadowOffsetX, previous?.shadowOffsetX)
           ? shadowOffsetX
           : null,
       shadowOffsetY: _changed(shadowOffsetY, previous?.shadowOffsetY)
           ? shadowOffsetY
           : null,
-      shadowStyle:
-          _changed(shadowStyle, previous?.shadowStyle) ? shadowStyle : null,
+      shadowStyle: _changed(shadowStyle, previous?.shadowStyle)
+          ? shadowStyle
+          : null,
       customFontFamily: _changed(customFontFamily, previous?.customFontFamily)
           ? customFontFamily
           : null,
       customFontFilePath:
           _changed(customFontFilePath, previous?.customFontFilePath)
-              ? customFontFilePath
-              : null,
+          ? customFontFilePath
+          : null,
       mergeDuplicates: _changed(mergeDuplicates, previous?.mergeDuplicates)
           ? mergeDuplicates
           : null,
@@ -735,20 +738,24 @@ class _ErikaDanmakuConfigPatch {
           : null,
       allowScrollOverwrite:
           _changed(allowScrollOverwrite, previous?.allowScrollOverwrite)
-              ? allowScrollOverwrite
-              : null,
-      maxQuantity:
-          _changed(maxQuantity, previous?.maxQuantity) ? maxQuantity : null,
+          ? allowScrollOverwrite
+          : null,
+      maxQuantity: _changed(maxQuantity, previous?.maxQuantity)
+          ? maxQuantity
+          : null,
       maxLinesPerMode: _changed(maxLinesPerMode, previous?.maxLinesPerMode)
           ? maxLinesPerMode
           : null,
       blockTop: _changed(blockTop, previous?.blockTop) ? blockTop : null,
-      blockBottom:
-          _changed(blockBottom, previous?.blockBottom) ? blockBottom : null,
-      blockScroll:
-          _changed(blockScroll, previous?.blockScroll) ? blockScroll : null,
-      blockWords:
-          _changedList(blockWords, previous?.blockWords) ? blockWords : null,
+      blockBottom: _changed(blockBottom, previous?.blockBottom)
+          ? blockBottom
+          : null,
+      blockScroll: _changed(blockScroll, previous?.blockScroll)
+          ? blockScroll
+          : null,
+      blockWords: _changedList(blockWords, previous?.blockWords)
+          ? blockWords
+          : null,
     );
   }
 
@@ -1000,7 +1007,8 @@ class ErikaPlayer {
     );
     if (fontId == null) {
       throw StateError(
-          'Erika subtitle memory font registration returned null.');
+        'Erika subtitle memory font registration returned null.',
+      );
     }
     return fontId;
   }
@@ -1009,7 +1017,10 @@ class ErikaPlayer {
     final ids = List<int>.unmodifiable(fontIds);
     if (ids.any((id) => id <= 0) || ids.toSet().length != ids.length) {
       throw ArgumentError.value(
-          fontIds, 'fontIds', 'must contain unique positive IDs');
+        fontIds,
+        'fontIds',
+        'must contain unique positive IDs',
+      );
     }
     final playerId = await ensureCreated();
     await _invoke('selectSubtitleMemoryFonts', <String, Object?>{
@@ -1263,11 +1274,11 @@ class ErikaPlayer {
     final playerId = await ensureCreated();
     final trackId = await _channel
         .invokeMethod<int>('addDanmakuTrackFile', <String, Object?>{
-      'playerId': playerId,
-      'uri': uri,
-      if (name != null) 'name': name,
-      'offsetMicros': offset.inMicroseconds,
-    });
+          'playerId': playerId,
+          'uri': uri,
+          if (name != null) 'name': name,
+          'offsetMicros': offset.inMicroseconds,
+        });
     if (trackId == null || trackId <= 0) {
       throw StateError('Erika danmaku track add returned no track id.');
     }
@@ -1282,11 +1293,11 @@ class ErikaPlayer {
     final playerId = await ensureCreated();
     final trackId = await _channel
         .invokeMethod<int>('addDanmakuTrackJson', <String, Object?>{
-      'playerId': playerId,
-      'json': json,
-      if (name != null) 'name': name,
-      'offsetMicros': offset.inMicroseconds,
-    });
+          'playerId': playerId,
+          'json': json,
+          if (name != null) 'name': name,
+          'offsetMicros': offset.inMicroseconds,
+        });
     if (trackId == null || trackId <= 0) {
       throw StateError('Erika danmaku track add returned no track id.');
     }
@@ -1541,10 +1552,10 @@ class ErikaPlayer {
     });
   }
 
-  /// Allocates a Flutter texture backed by an OpenHarmony SurfaceProducer.
+  /// Allocates a native GPU surface exposed through a Flutter texture.
   ///
-  /// This is used by [ErikaVideoView] on HarmonyOS; other embedders normally
-  /// attach their platform view directly.
+  /// This is used on Windows, macOS, and HarmonyOS when the embedder supports
+  /// compositor-owned texture surfaces.
   Future<int> createTextureSurface({
     required int width,
     required int height,
@@ -1552,11 +1563,7 @@ class ErikaPlayer {
   }) async {
     final textureId = await _channel.invokeMethod<int>(
       'createTexture',
-      <String, Object?>{
-        'width': width,
-        'height': height,
-        'scale': scale,
-      },
+      <String, Object?>{'width': width, 'height': height, 'scale': scale},
     );
     if (textureId == null || textureId < 0) {
       throw StateError('Erika texture allocation failed.');
@@ -1579,9 +1586,7 @@ class ErikaPlayer {
   }
 
   Future<void> releaseTextureSurface(int textureId) {
-    return _invoke('releaseTexture', <String, Object?>{
-      'textureId': textureId,
-    });
+    return _invoke('releaseTexture', <String, Object?>{'textureId': textureId});
   }
 
   /// Attaches the shared native overlay to this player.
@@ -1595,16 +1600,14 @@ class ErikaPlayer {
     double opacity = 1.0,
   }) async {
     final playerId = await ensureCreated();
-    final viewId = await _channel.invokeMethod<int>(
-      'attachOverlay',
-      <String, Object?>{
-        'playerId': playerId,
-        if (flutterViewId != null) 'flutterViewId': flutterViewId,
-        'secondaryWindow': secondaryWindow,
-        if (blendMode != 'srcOver') 'blendMode': blendMode,
-        if (opacity != 1.0) 'opacity': opacity,
-      },
-    );
+    final viewId = await _channel
+        .invokeMethod<int>('attachOverlay', <String, Object?>{
+          'playerId': playerId,
+          if (flutterViewId != null) 'flutterViewId': flutterViewId,
+          'secondaryWindow': secondaryWindow,
+          if (blendMode != 'srcOver') 'blendMode': blendMode,
+          if (opacity != 1.0) 'opacity': opacity,
+        });
     return viewId ?? windowOverlayViewId;
   }
 
@@ -1692,7 +1695,8 @@ class ErikaPlayer {
   }
 
   Future<int> _create() async {
-    final requestedHeadroom = edrHeadroom ??
+    final requestedHeadroom =
+        edrHeadroom ??
         (outputMode == ErikaOutputMode.extendedLinear ? 4.0 : null);
     final arguments = <String, Object?>{
       if (outputMode case final mode?) 'outputMode': mode.nativeValue,

--- a/packages/erika_flutter/lib/src/erika_video_view.dart
+++ b/packages/erika_flutter/lib/src/erika_video_view.dart
@@ -26,7 +26,11 @@ bool get _supportsFlutterTextureVideoView =>
         defaultTargetPlatform == TargetPlatform.windows ||
         _usesOhosTextureView);
 
-/// Flutter platform-view video surface backed by AppKit/UIKit.
+/// Native video surface backed by AppKit/UIKit or a Windows HWND.
+///
+/// Windows keeps video outside Flutter's texture compositor so opaque playback
+/// can negotiate HDR10. Use [ErikaTextureVideoView] explicitly for SDR content
+/// that needs Flutter clipping or color filters.
 ///
 /// This is the compatibility surface. Full-player Apple hosts should usually
 /// prefer [ErikaWindowOverlayVideoView] so Erika owns the native Metal video
@@ -56,6 +60,8 @@ class ErikaVideoView extends StatefulWidget {
 /// On macOS this uses an IOSurface-backed Metal texture, and on Windows it uses
 /// a shareable D3D11 texture. Regular Flutter effects such as opacity, clipping
 /// and color filters therefore apply to the video on both desktop platforms.
+/// Windows textures are SDR; use [ErikaVideoView] for native HDR playback.
+/// Windows supports [BlendMode.srcOver] and native [BlendMode.overlay] only.
 class ErikaTextureVideoView extends StatelessWidget {
   const ErikaTextureVideoView({
     super.key,
@@ -87,7 +93,12 @@ class ErikaTextureVideoView extends StatelessWidget {
     }
     if (!kIsWeb &&
         defaultTargetPlatform == TargetPlatform.windows &&
-        blendMode == BlendMode.overlay) {
+        blendMode != BlendMode.srcOver) {
+      if (blendMode != BlendMode.overlay) {
+        throw UnsupportedError(
+          'Windows ErikaTextureVideoView supports only srcOver and overlay.',
+        );
+      }
       return ErikaWindowOverlayVideoView(
         player: player,
         debugLabel: debugLabel,
@@ -97,14 +108,11 @@ class ErikaTextureVideoView extends StatelessWidget {
       );
     }
     if (_supportsFlutterTextureVideoView) {
-      return _ErikaTextureBlendLayer(
-        blendMode: blendMode,
-        child: Opacity(
-          opacity: opacity,
-          child: _ErikaOhosVideoView(
-            player: player,
-            onPlatformViewIdChanged: onTextureIdChanged,
-          ),
+      return Opacity(
+        opacity: opacity,
+        child: _ErikaOhosVideoView(
+          player: player,
+          onPlatformViewIdChanged: onTextureIdChanged,
         ),
       );
     }
@@ -115,55 +123,6 @@ class ErikaTextureVideoView extends StatelessWidget {
       blendMode: blendMode,
       opacity: opacity,
     );
-  }
-}
-
-class _ErikaTextureBlendLayer extends SingleChildRenderObjectWidget {
-  const _ErikaTextureBlendLayer({
-    required this.blendMode,
-    required super.child,
-  });
-
-  final BlendMode blendMode;
-
-  @override
-  RenderObject createRenderObject(BuildContext context) =>
-      _RenderErikaTextureBlendLayer(blendMode);
-
-  @override
-  void updateRenderObject(
-    BuildContext context,
-    covariant _RenderErikaTextureBlendLayer renderObject,
-  ) {
-    renderObject.blendMode = blendMode;
-  }
-}
-
-class _RenderErikaTextureBlendLayer extends RenderProxyBox {
-  _RenderErikaTextureBlendLayer(this._blendMode);
-
-  BlendMode _blendMode;
-
-  set blendMode(BlendMode value) {
-    if (_blendMode == value) {
-      return;
-    }
-    _blendMode = value;
-    markNeedsPaint();
-  }
-
-  @override
-  void paint(PaintingContext context, Offset offset) {
-    if (child == null || size.isEmpty) {
-      return;
-    }
-    if (_blendMode == BlendMode.srcOver) {
-      super.paint(context, offset);
-      return;
-    }
-    context.canvas.saveLayer(offset & size, Paint()..blendMode = _blendMode);
-    super.paint(context, offset);
-    context.canvas.restore();
   }
 }
 
@@ -245,9 +204,12 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
           gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
         );
       case TargetPlatform.windows:
-        return _ErikaOhosVideoView(
+        return ErikaWindowOverlayVideoView(
           player: widget.player,
+          debugLabel: widget.debugLabel,
           onPlatformViewIdChanged: widget.onPlatformViewIdChanged,
+          blendMode: widget.blendMode,
+          opacity: widget.opacity,
         );
       case TargetPlatform.android:
         return _ErikaAndroidVideoView(
@@ -518,7 +480,7 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     }
     final surfaceConfigurationChanged =
         _surfaceConfigurationKey(oldWidget.player) !=
-        _surfaceConfigurationKey(widget.player);
+            _surfaceConfigurationKey(widget.player);
     if (surfaceConfigurationChanged) {
       // Invalidate callbacks from a PlatformView whose asynchronous create
       // has not completed yet; in that state _viewId is still null.
@@ -593,7 +555,7 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     int generation,
   ) async {
     Object? lastError;
-    for (var attempt = 0; ; attempt += 1) {
+    for (var attempt = 0;; attempt += 1) {
       if (!_attachmentIsCurrent(player, viewId, generation)) {
         return;
       }
@@ -664,11 +626,10 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
       surfaceFactory:
           (BuildContext context, PlatformViewController controller) =>
               AndroidViewSurface(
-                controller: controller as AndroidViewController,
-                hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-                gestureRecognizers:
-                    const <Factory<OneSequenceGestureRecognizer>>{},
-              ),
+        controller: controller as AndroidViewController,
+        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+      ),
       onCreatePlatformView: (PlatformViewCreationParams params) {
         final controller = PlatformViewsService.initExpensiveAndroidView(
           id: params.id,
@@ -719,8 +680,7 @@ class ErikaWindowOverlayVideoView extends StatefulWidget {
 }
 
 class _ErikaWindowOverlayVideoViewState
-    extends State<ErikaWindowOverlayVideoView>
-    with WidgetsBindingObserver {
+    extends State<ErikaWindowOverlayVideoView> with WidgetsBindingObserver {
   Timer? _retryTimer;
   Timer? _frameTimer;
   int _bindAttempts = 0;

--- a/packages/erika_flutter/lib/src/erika_video_view.dart
+++ b/packages/erika_flutter/lib/src/erika_video_view.dart
@@ -22,7 +22,9 @@ bool get _usesOhosTextureView =>
 
 bool get _supportsFlutterTextureVideoView =>
     !kIsWeb &&
-    (defaultTargetPlatform == TargetPlatform.macOS || _usesOhosTextureView);
+    (defaultTargetPlatform == TargetPlatform.macOS ||
+        defaultTargetPlatform == TargetPlatform.windows ||
+        _usesOhosTextureView);
 
 /// Flutter platform-view video surface backed by AppKit/UIKit.
 ///
@@ -51,9 +53,9 @@ class ErikaVideoView extends StatefulWidget {
 
 /// Video surface composited as a Flutter [Texture].
 ///
-/// On macOS this uses an IOSurface-backed Metal texture, so regular Flutter
-/// effects such as opacity, clipping and color filters apply to the video. On
-/// platforms without a native texture path it falls back to [ErikaVideoView].
+/// On macOS this uses an IOSurface-backed Metal texture, and on Windows it uses
+/// a shareable D3D11 texture. Regular Flutter effects such as opacity, clipping
+/// and color filters therefore apply to the video on both desktop platforms.
 class ErikaTextureVideoView extends StatelessWidget {
   const ErikaTextureVideoView({
     super.key,
@@ -83,12 +85,26 @@ class ErikaTextureVideoView extends StatelessWidget {
         opacity: opacity,
       );
     }
-    if (_supportsFlutterTextureVideoView) {
-      return Opacity(
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.windows &&
+        blendMode == BlendMode.overlay) {
+      return ErikaWindowOverlayVideoView(
+        player: player,
+        debugLabel: debugLabel,
+        onPlatformViewIdChanged: onTextureIdChanged,
+        blendMode: blendMode,
         opacity: opacity,
-        child: _ErikaOhosVideoView(
-          player: player,
-          onPlatformViewIdChanged: onTextureIdChanged,
+      );
+    }
+    if (_supportsFlutterTextureVideoView) {
+      return _ErikaTextureBlendLayer(
+        blendMode: blendMode,
+        child: Opacity(
+          opacity: opacity,
+          child: _ErikaOhosVideoView(
+            player: player,
+            onPlatformViewIdChanged: onTextureIdChanged,
+          ),
         ),
       );
     }
@@ -99,6 +115,55 @@ class ErikaTextureVideoView extends StatelessWidget {
       blendMode: blendMode,
       opacity: opacity,
     );
+  }
+}
+
+class _ErikaTextureBlendLayer extends SingleChildRenderObjectWidget {
+  const _ErikaTextureBlendLayer({
+    required this.blendMode,
+    required super.child,
+  });
+
+  final BlendMode blendMode;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderErikaTextureBlendLayer(blendMode);
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderErikaTextureBlendLayer renderObject,
+  ) {
+    renderObject.blendMode = blendMode;
+  }
+}
+
+class _RenderErikaTextureBlendLayer extends RenderProxyBox {
+  _RenderErikaTextureBlendLayer(this._blendMode);
+
+  BlendMode _blendMode;
+
+  set blendMode(BlendMode value) {
+    if (_blendMode == value) {
+      return;
+    }
+    _blendMode = value;
+    markNeedsPaint();
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null || size.isEmpty) {
+      return;
+    }
+    if (_blendMode == BlendMode.srcOver) {
+      super.paint(context, offset);
+      return;
+    }
+    context.canvas.saveLayer(offset & size, Paint()..blendMode = _blendMode);
+    super.paint(context, offset);
+    context.canvas.restore();
   }
 }
 
@@ -180,12 +245,9 @@ class _ErikaVideoViewState extends State<ErikaVideoView> {
           gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
         );
       case TargetPlatform.windows:
-        return ErikaWindowOverlayVideoView(
+        return _ErikaOhosVideoView(
           player: widget.player,
-          debugLabel: widget.debugLabel,
           onPlatformViewIdChanged: widget.onPlatformViewIdChanged,
-          blendMode: widget.blendMode,
-          opacity: widget.opacity,
         );
       case TargetPlatform.android:
         return _ErikaAndroidVideoView(
@@ -456,7 +518,7 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     }
     final surfaceConfigurationChanged =
         _surfaceConfigurationKey(oldWidget.player) !=
-            _surfaceConfigurationKey(widget.player);
+        _surfaceConfigurationKey(widget.player);
     if (surfaceConfigurationChanged) {
       // Invalidate callbacks from a PlatformView whose asynchronous create
       // has not completed yet; in that state _viewId is still null.
@@ -506,11 +568,7 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     unawaited(_attachWithRetry(widget.player, viewId, generation));
   }
 
-  bool _attachmentIsCurrent(
-    ErikaPlayer player,
-    int viewId,
-    int generation,
-  ) =>
+  bool _attachmentIsCurrent(ErikaPlayer player, int viewId, int generation) =>
       mounted &&
       generation == _attachmentGeneration &&
       identical(widget.player, player) &&
@@ -535,7 +593,7 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     int generation,
   ) async {
     Object? lastError;
-    for (var attempt = 0;; attempt += 1) {
+    for (var attempt = 0; ; attempt += 1) {
       if (!_attachmentIsCurrent(player, viewId, generation)) {
         return;
       }
@@ -603,15 +661,14 @@ class _ErikaAndroidVideoViewState extends State<_ErikaAndroidVideoView> {
     return PlatformViewLink(
       key: ValueKey<Object>(_surfaceConfigurationKey(widget.player)),
       viewType: 'erika_flutter/hdr_video_view',
-      surfaceFactory: (
-        BuildContext context,
-        PlatformViewController controller,
-      ) =>
-          AndroidViewSurface(
-        controller: controller as AndroidViewController,
-        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-        gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-      ),
+      surfaceFactory:
+          (BuildContext context, PlatformViewController controller) =>
+              AndroidViewSurface(
+                controller: controller as AndroidViewController,
+                hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+                gestureRecognizers:
+                    const <Factory<OneSequenceGestureRecognizer>>{},
+              ),
       onCreatePlatformView: (PlatformViewCreationParams params) {
         final controller = PlatformViewsService.initExpensiveAndroidView(
           id: params.id,
@@ -662,7 +719,8 @@ class ErikaWindowOverlayVideoView extends StatefulWidget {
 }
 
 class _ErikaWindowOverlayVideoViewState
-    extends State<ErikaWindowOverlayVideoView> with WidgetsBindingObserver {
+    extends State<ErikaWindowOverlayVideoView>
+    with WidgetsBindingObserver {
   Timer? _retryTimer;
   Timer? _frameTimer;
   int _bindAttempts = 0;
@@ -815,8 +873,10 @@ class _ErikaWindowOverlayVideoViewState
       if (!box.hasSize || box.size.isEmpty) {
         return;
       }
-      final origin = box.localToGlobal(Offset.zero);
-      rect = origin & box.size;
+      rect = MatrixUtils.transformRect(
+        box.getTransformTo(null),
+        Offset.zero & box.size,
+      );
     } else {
       rect = Rect.zero;
     }

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -752,6 +752,13 @@ ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
     ErikaPresenterHandle *handle,
     void **out_swapchain);
 
+/* Windows only. Returns an AddRef'd IUnknown for the renderer-owned,
+ * shareable D3D11 texture attached through WindowsTextureRegistrar. The
+ * caller owns the returned COM reference and must Release it. */
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_texture);
+
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/packages/erika_flutter/native/include/erika.h
+++ b/packages/erika_flutter/native/include/erika.h
@@ -752,9 +752,9 @@ ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
     ErikaPresenterHandle *handle,
     void **out_swapchain);
 
-/* Windows only. Returns an AddRef'd IUnknown for the renderer-owned,
- * shareable D3D11 texture attached through WindowsTextureRegistrar. The
- * caller owns the returned COM reference and must Release it. */
+/* Windows only. Returns an AddRef'd IUnknown for the latest completed,
+ * immutable SDR Flutter GPU frame. The caller owns the COM reference and
+ * must Release it. The texture remains unchanged for its entire lifetime. */
 ErikaStatus erika_presenter_windows_flutter_texture_iunknown(
     ErikaPresenterHandle *handle,
     void **out_texture);

--- a/packages/erika_flutter/test/erika_player_test.dart
+++ b/packages/erika_flutter/test/erika_player_test.dart
@@ -821,6 +821,49 @@ void main() {
     await player.dispose();
   });
 
+  testWidgets('window overlay reports its transformed FittedBox bounds', (
+    WidgetTester tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final player = ErikaPlayer();
+    try {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 640,
+              height: 360,
+              child: FittedBox(
+                fit: BoxFit.fill,
+                child: SizedBox(
+                  width: 320,
+                  height: 180,
+                  child: ErikaWindowOverlayVideoView(player: player),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+
+      final frameCalls = playerCalls
+          .where((MethodCall call) => call.method == 'setOverlayFrame')
+          .toList();
+      expect(frameCalls, isNotEmpty);
+      final arguments = frameCalls.last.arguments as Map<Object?, Object?>;
+      expect(arguments['width'], closeTo(640.0, 0.01));
+      expect(arguments['height'], closeTo(360.0, 0.01));
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await player.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
   testWidgets('window overlay uses the Android TextureView platform view', (
     WidgetTester tester,
   ) async {

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -3,6 +3,23 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('Windows texture APIs are optional for native runtime compatibility', () {
+    final plugin = File('windows/erika_flutter_plugin.cpp').readAsStringSync();
+    expect(plugin, contains('LoadOptional<AttachFlutterTextureFn>'));
+    expect(plugin, contains('LoadOptional<GetWindowsFlutterTextureFn>'));
+    expect(plugin, isNot(contains('LoadRequired<AttachFlutterTextureFn>')));
+    expect(plugin, isNot(contains('LoadRequired<GetWindowsFlutterTextureFn>')));
+  });
+
+  test('new Windows texture export is declared in both SDK headers', () {
+    const symbol = 'erika_presenter_windows_flutter_texture_iunknown';
+    expect(File('native/include/erika.h').readAsStringSync(), contains(symbol));
+    final publicHeader = File('../../crates/erika_capi/include/erika.h');
+    if (publicHeader.existsSync()) {
+      expect(publicHeader.readAsStringSync(), contains(symbol));
+    }
+  });
+
   test('macOS renders on CVDisplayLink without a per-frame GCD hop', () {
     final plugin = File(
       'macos/Classes/ErikaFlutterPlugin.swift',

--- a/packages/erika_flutter/test/render_scheduler_contract_test.dart
+++ b/packages/erika_flutter/test/render_scheduler_contract_test.dart
@@ -48,24 +48,27 @@ void main() {
     expect(plugin, isNot(contains('CVPixelBufferLockBaseAddress')));
   });
 
-  test('macOS transparent platform view applies native overlay compositing',
-      () {
-    final plugin = File(
-      'macos/Classes/ErikaFlutterPlugin.swift',
-    ).readAsStringSync();
+  test(
+    'macOS transparent platform view applies native overlay compositing',
+    () {
+      final plugin = File(
+        'macos/Classes/ErikaFlutterPlugin.swift',
+      ).readAsStringSync();
 
-    expect(plugin, contains('metalLayer.isOpaque = !alphaVideo'));
-    expect(plugin, contains('NSColor.clear.cgColor'));
-    expect(
-      plugin,
-      contains('metalLayer.compositingFilter = "overlayBlendMode"'),
-    );
-    expect(plugin, contains('metalLayer.opacity = Float('));
-  });
+      expect(plugin, contains('metalLayer.isOpaque = !alphaVideo'));
+      expect(plugin, contains('NSColor.clear.cgColor'));
+      expect(
+        plugin,
+        contains('metalLayer.compositingFilter = "overlayBlendMode"'),
+      );
+      expect(plugin, contains('metalLayer.opacity = Float('));
+    },
+  );
 
   test('Windows transparent video is composed into the Flutter HWND', () {
-    final plugin = File(
-      'windows/erika_flutter_plugin.cpp',
+    final plugin = File('windows/erika_flutter_plugin.cpp').readAsStringSync();
+    final blendEffect = File(
+      'windows/erika_composition_blend_effect.h',
     ).readAsStringSync();
     final rendererFile = File('../../crates/erika/src/renderer/d3d11.rs');
     if (!rendererFile.existsSync()) {
@@ -75,12 +78,20 @@ void main() {
 
     expect(plugin, contains('config.video_alpha_mode ='));
     expect(plugin, contains('capabilities.direct_composition = true'));
-    expect(plugin, contains('DCompositionCreateDevice2'));
-    expect(plugin, contains('CreateTargetForHwnd'));
-    expect(plugin, contains('CreateBlendEffect'));
+    expect(plugin, contains('QueryInterface(IDXGISwapChain)'));
+    expect(plugin, contains('CreateDispatcherQueueController'));
+    expect(plugin, contains('CreateDesktopWindowTarget'));
+    expect(plugin, contains('CreateCompositionSurfaceForSwapChain'));
+    expect(plugin, contains('CreateEffectFactory'));
+    expect(plugin, contains('CreateBackdropBrush'));
+    expect(plugin, contains('SetSourceParameter(\n        L"Backdrop"'));
+    expect(plugin, contains('SetSourceParameter(L"Video"'));
     expect(plugin, contains('D2D1_BLEND_MODE_OVERLAY'));
-    expect(plugin, contains('IDCompositionEffectGroup::SetOpacity'));
-    expect(plugin, contains('root_visual->SetEffect(effect)'));
+    expect(blendEffect, contains('GetSourceCount(UINT* count)'));
+    expect(blendEffect, contains('*count = 2'));
+    expect(plugin, isNot(contains('DCompositionCreateDevice3')));
+    expect(plugin, isNot(contains('CreateBlendEffect')));
+    expect(plugin, isNot(contains('root_visual->SetEffect(effect)')));
     expect(
       plugin,
       contains('erika_presenter_windows_composition_swapchain_iunknown'),
@@ -106,7 +117,9 @@ void main() {
 
       expect(plugin, contains('private let renderQueue: DispatchQueue'));
       expect(
-          plugin, contains('private let nativeCallLock = NSRecursiveLock()'));
+        plugin,
+        contains('private let nativeCallLock = NSRecursiveLock()'),
+      );
       expect(plugin, contains('renderQueue.async'));
       expect(plugin, contains('self?.$schedulerCall'));
       expect(plugin, contains('mainThread=\\(Thread.isMainThread)'));
@@ -114,10 +127,7 @@ void main() {
       expect(plugin, isNot(contains('self?.renderTick(sendEvent:')));
 
       final renderStart = plugin.indexOf('  func renderTick() {');
-      final pollStart = plugin.indexOf(
-        '  func pollEvents(',
-        renderStart,
-      );
+      final pollStart = plugin.indexOf('  func pollEvents(', renderStart);
       expect(renderStart, greaterThanOrEqualTo(0));
       expect(pollStart, greaterThan(renderStart));
       expect(
@@ -127,18 +137,20 @@ void main() {
     });
   }
 
-  test('iOS retries audio-session activation after an allowed interruption',
-      () {
-    final plugin = File(
-      'ios/Classes/ErikaFlutterPlugin.swift',
-    ).readAsStringSync();
+  test(
+    'iOS retries audio-session activation after an allowed interruption',
+    () {
+      final plugin = File(
+        'ios/Classes/ErikaFlutterPlugin.swift',
+      ).readAsStringSync();
 
-    expect(plugin, contains('AVAudioSession.interruptionNotification'));
-    expect(plugin, contains('try session.setActive(true)'));
-    expect(plugin, contains('private func resumeInterruptedPlayback'));
-    expect(plugin, contains('interruptionResumeWorkItem'));
-    expect(plugin, contains('guard attempt < maxAttempts else'));
-  });
+      expect(plugin, contains('AVAudioSession.interruptionNotification'));
+      expect(plugin, contains('try session.setActive(true)'));
+      expect(plugin, contains('private func resumeInterruptedPlayback'));
+      expect(plugin, contains('interruptionResumeWorkItem'));
+      expect(plugin, contains('guard attempt < maxAttempts else'));
+    },
+  );
 
   test('iOS drops a pending interruption resume on an explicit command', () {
     final plugin = File(
@@ -148,7 +160,8 @@ void main() {
     expect(
       plugin,
       contains(
-          'private func cancelPendingInterruptionResume(ifPlayer playerId: Int64)'),
+        'private func cancelPendingInterruptionResume(ifPlayer playerId: Int64)',
+      ),
     );
 
     // Every explicit pause/stop/close path must disarm the retry before it
@@ -165,14 +178,16 @@ void main() {
         plugin.indexOf(entry.$2, caseStart) + entry.$2.length,
       );
       expect(
-          body, contains('cancelPendingInterruptionResume(ifPlayer: host.id)'));
+        body,
+        contains('cancelPendingInterruptionResume(ifPlayer: host.id)'),
+      );
     }
 
-    final remoteStart = plugin.indexOf(
-      'private func performRemotePause()',
+    final remoteStart = plugin.indexOf('private func performRemotePause()');
+    final remoteEnd = plugin.indexOf(
+      'private func performRemoteToggle()',
+      remoteStart,
     );
-    final remoteEnd =
-        plugin.indexOf('private func performRemoteToggle()', remoteStart);
     expect(remoteStart, greaterThanOrEqualTo(0));
     expect(remoteEnd, greaterThan(remoteStart));
     expect(
@@ -181,30 +196,32 @@ void main() {
     );
   });
 
-  test('Android polls events on the presenter thread with adaptive scheduling',
-      () {
-    final plugin = File(
-      'android/src/main/kotlin/dev/aimesoft/erika_flutter/'
-      'ErikaFlutterPlugin.kt',
-    ).readAsStringSync();
+  test(
+    'Android polls events on the presenter thread with adaptive scheduling',
+    () {
+      final plugin = File(
+        'android/src/main/kotlin/dev/aimesoft/erika_flutter/'
+        'ErikaFlutterPlugin.kt',
+      ).readAsStringSync();
 
-    expect(plugin, contains('private val eventPollRunnable'));
-    expect(plugin, contains('private fun scheduleEventPoll()'));
-    expect(plugin, contains('presenterThread.post {'));
-    expect(plugin, contains('androidEventPollDelayMillis('));
+      expect(plugin, contains('private val eventPollRunnable'));
+      expect(plugin, contains('private fun scheduleEventPoll()'));
+      expect(plugin, contains('presenterThread.post {'));
+      expect(plugin, contains('androidEventPollDelayMillis('));
 
-    final frameStart = plugin.indexOf(
-      'private val frameCallback = Choreographer.FrameCallback',
-    );
-    final attachStart = plugin.indexOf(
-      'override fun onAttachedToEngine',
-      frameStart,
-    );
-    expect(frameStart, greaterThanOrEqualTo(0));
-    expect(attachStart, greaterThan(frameStart));
-    expect(
-      plugin.substring(frameStart, attachStart),
-      isNot(contains('drainEvents')),
-    );
-  });
+      final frameStart = plugin.indexOf(
+        'private val frameCallback = Choreographer.FrameCallback',
+      );
+      final attachStart = plugin.indexOf(
+        'override fun onAttachedToEngine',
+        frameStart,
+      );
+      expect(frameStart, greaterThanOrEqualTo(0));
+      expect(attachStart, greaterThan(frameStart));
+      expect(
+        plugin.substring(frameStart, attachStart),
+        isNot(contains('drainEvents')),
+      );
+    },
+  );
 }

--- a/packages/erika_flutter/test/windows_video_view_test.dart
+++ b/packages/erika_flutter/test/windows_video_view_test.dart
@@ -1,0 +1,143 @@
+import 'package:erika_flutter/erika_flutter.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('erika_flutter/player');
+  const events = MethodChannel('erika_flutter/events');
+  late List<MethodCall> calls;
+  var nextPlayer = 0;
+
+  setUp(() {
+    calls = [];
+    nextPlayer = 0;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return switch (call.method) {
+        'create' => ++nextPlayer,
+        'createTexture' => 13,
+        'attachOverlay' => -1,
+        _ => null,
+      };
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(events, (_) async => null);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(events, null);
+  });
+
+  Widget host(Widget child) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: SizedBox(width: 320, height: 180, child: child)),
+      );
+
+  for (final outputMode in [
+    null,
+    ErikaOutputMode.auto,
+    ErikaOutputMode.extendedLinear
+  ]) {
+    testWidgets('Windows default view preserves native output for $outputMode',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      final player = ErikaPlayer(outputMode: outputMode);
+      try {
+        await tester.pumpWidget(host(ErikaVideoView(player: player)));
+        await tester.pump();
+        await tester.pump();
+        expect(calls.map((c) => c.method), contains('attachOverlay'));
+        expect(calls.map((c) => c.method), isNot(contains('createTexture')));
+        expect(find.byType(Texture), findsNothing);
+      } finally {
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        await player.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  }
+
+  for (final texture in [false, true]) {
+    testWidgets(
+        'Windows overlay forwards blend/opacity (texture entry: $texture)',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      final player =
+          ErikaPlayer(videoAlphaMode: ErikaVideoAlphaMode.packedAlphaRight);
+      try {
+        await tester.pumpWidget(host(texture
+            ? ErikaTextureVideoView(
+                player: player, blendMode: BlendMode.overlay, opacity: 0.25)
+            : ErikaVideoView(
+                player: player, blendMode: BlendMode.overlay, opacity: 0.25)));
+        await tester.pump();
+        await tester.pump();
+        final attach = calls.firstWhere((c) => c.method == 'attachOverlay');
+        expect((attach.arguments as Map)['blendMode'], 'overlay');
+        expect((attach.arguments as Map)['opacity'], 0.25);
+        expect(find.byType(Texture), findsNothing);
+      } finally {
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        await player.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  }
+
+  testWidgets(
+      'explicit Windows texture applies opacity and rebinds after player disposal',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final oldPlayer = ErikaPlayer();
+    final newPlayer = ErikaPlayer();
+    try {
+      await tester.pumpWidget(
+          host(ErikaTextureVideoView(player: oldPlayer, opacity: 0.4)));
+      await tester.pump();
+      await tester.pump();
+      expect(find.byType(Texture), findsOneWidget);
+      expect(tester.widget<Opacity>(find.byType(Opacity)).opacity, 0.4);
+      await oldPlayer.dispose();
+      await tester.pumpWidget(
+          host(ErikaTextureVideoView(player: newPlayer, opacity: 0.4)));
+      await tester.pump();
+      expect(calls.where((c) => c.method == 'createTexture'), hasLength(1));
+      final attached =
+          calls.where((c) => c.method == 'attachView').last.arguments as Map;
+      expect(attached['playerId'], 2);
+      expect(attached['viewId'], 13);
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      await oldPlayer.dispose();
+      await newPlayer.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets(
+      'unsupported Windows blend modes fail explicitly before texture allocation',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final player = ErikaPlayer();
+    try {
+      await tester.pumpWidget(host(ErikaTextureVideoView(
+          player: player, blendMode: BlendMode.multiply)));
+      expect(tester.takeException(), isA<UnsupportedError>());
+      expect(calls, isEmpty);
+    } finally {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await player.dispose();
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/packages/erika_flutter/windows/CMakeLists.txt
+++ b/packages/erika_flutter/windows/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 list(APPEND PLUGIN_SOURCES
   "erika_composition_blend_effect.h"
+  "erika_texture_publication.h"
   "erika_flutter_plugin.cpp"
   "erika_flutter_plugin.h"
   "erika_windows_smtc.cpp"

--- a/packages/erika_flutter/windows/CMakeLists.txt
+++ b/packages/erika_flutter/windows/CMakeLists.txt
@@ -20,6 +20,7 @@ if(NOT EXISTS "${ERIKA_NATIVE_HEADER_DIR}/erika.h")
 endif()
 
 list(APPEND PLUGIN_SOURCES
+  "erika_composition_blend_effect.h"
   "erika_flutter_plugin.cpp"
   "erika_flutter_plugin.h"
   "erika_windows_smtc.cpp"
@@ -50,7 +51,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_include_directories(${PLUGIN_NAME} PRIVATE
   "${ERIKA_NATIVE_HEADER_DIR}")
 target_link_libraries(${PLUGIN_NAME} PRIVATE
-  flutter flutter_wrapper_plugin runtimeobject windowsapp dcomp shcore shlwapi)
+  flutter flutter_wrapper_plugin runtimeobject windowsapp CoreMessaging d3d11 dxgi shcore shlwapi)
 
 set(ERIKA_WINDOWS_ARCH "" CACHE STRING
   "Erika Windows architecture: x64, x86_64, arm64, or aarch64")

--- a/packages/erika_flutter/windows/erika_composition_blend_effect.h
+++ b/packages/erika_flutter/windows/erika_composition_blend_effect.h
@@ -1,0 +1,155 @@
+// Copyright (c) Aimes Soft and contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Windows.Foundation.h>
+#include <Windows.Graphics.Effects.h>
+#include <Windows.Graphics.Effects.Interop.h>
+#include <d2d1effects.h>
+#include <wrl.h>
+#include <wrl/wrappers/corewrappers.h>
+
+namespace erika_flutter {
+
+// Windows.UI.Composition consumes a Win2D-style effect description.  The SDK
+// does not ship a concrete C++ BlendEffect class, so keep the small descriptor
+// here rather than attaching IDCompositionBlendEffect directly to a visual.
+// The latter is a filter node whose two inputs must belong to an explicit
+// filter graph; treating the HWND target as an implicit input produces an
+// invalid D2D graph inside DWM.
+class ErikaCompositionBlendEffect final
+    : public Microsoft::WRL::RuntimeClass<
+          Microsoft::WRL::RuntimeClassFlags<
+              Microsoft::WRL::WinRtClassicComMix>,
+          ABI::Windows::Graphics::Effects::IGraphicsEffect,
+          ABI::Windows::Graphics::Effects::IGraphicsEffectSource,
+          ABI::Windows::Graphics::Effects::IGraphicsEffectD2D1Interop> {
+  InspectableClass(L"Erika.CompositionBlendEffect", BaseTrust);
+
+ public:
+  HRESULT RuntimeClassInitialize(
+      ABI::Windows::Graphics::Effects::IGraphicsEffectSource* background,
+      ABI::Windows::Graphics::Effects::IGraphicsEffectSource* foreground,
+      D2D1_BLEND_MODE mode) noexcept {
+    if (background == nullptr || foreground == nullptr) {
+      return E_INVALIDARG;
+    }
+    background_ = background;
+    foreground_ = foreground;
+    mode_ = mode;
+    return S_OK;
+  }
+
+  IFACEMETHODIMP get_Name(HSTRING* value) override {
+    if (value == nullptr) {
+      return E_POINTER;
+    }
+    return name_.CopyTo(value);
+  }
+
+  IFACEMETHODIMP put_Name(HSTRING value) override {
+    return name_.Set(value);
+  }
+
+  IFACEMETHODIMP GetEffectId(GUID* value) override {
+    if (value == nullptr) {
+      return E_POINTER;
+    }
+    // CLSID_D2D1Blend, spelled out to keep this descriptor independent from
+    // the SDK's external GUID-definition library.
+    static constexpr GUID kBlendEffectId{
+        0x81C5B77B,
+        0x13F8,
+        0x4CDD,
+        {0xAD, 0x20, 0xC8, 0x90, 0x54, 0x7A, 0xC6, 0x5D}};
+    *value = kBlendEffectId;
+    return S_OK;
+  }
+
+  IFACEMETHODIMP GetNamedPropertyMapping(
+      LPCWSTR name,
+      UINT* index,
+      ABI::Windows::Graphics::Effects::GRAPHICS_EFFECT_PROPERTY_MAPPING*
+          mapping) override {
+    if (name == nullptr || index == nullptr || mapping == nullptr) {
+      return E_POINTER;
+    }
+    if (_wcsicmp(name, L"Mode") != 0) {
+      return E_INVALIDARG;
+    }
+    *index = D2D1_BLEND_PROP_MODE;
+    *mapping = ABI::Windows::Graphics::Effects::
+        GRAPHICS_EFFECT_PROPERTY_MAPPING_DIRECT;
+    return S_OK;
+  }
+
+  IFACEMETHODIMP GetPropertyCount(UINT* count) override {
+    if (count == nullptr) {
+      return E_POINTER;
+    }
+    *count = 1;
+    return S_OK;
+  }
+
+  IFACEMETHODIMP GetProperty(
+      UINT index,
+      ABI::Windows::Foundation::IPropertyValue** value) override {
+    if (value == nullptr) {
+      return E_POINTER;
+    }
+    *value = nullptr;
+    if (index != D2D1_BLEND_PROP_MODE) {
+      return E_INVALIDARG;
+    }
+
+    Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IPropertyValueStatics>
+        property_value_factory;
+    Microsoft::WRL::Wrappers::HStringReference class_name(
+        RuntimeClass_Windows_Foundation_PropertyValue);
+    HRESULT result = GetActivationFactory(class_name.Get(),
+                                          &property_value_factory);
+    if (FAILED(result)) {
+      return result;
+    }
+    return property_value_factory->CreateUInt32(
+        static_cast<UINT32>(mode_),
+        reinterpret_cast<IInspectable**>(value));
+  }
+
+  IFACEMETHODIMP GetSource(
+      UINT index,
+      ABI::Windows::Graphics::Effects::IGraphicsEffectSource** value) override {
+    if (value == nullptr) {
+      return E_POINTER;
+    }
+    if (index == 0) {
+      return background_.CopyTo(value);
+    }
+    if (index == 1) {
+      return foreground_.CopyTo(value);
+    }
+    *value = nullptr;
+    return E_INVALIDARG;
+  }
+
+  IFACEMETHODIMP GetSourceCount(UINT* count) override {
+    if (count == nullptr) {
+      return E_POINTER;
+    }
+    *count = 2;
+    return S_OK;
+  }
+
+ private:
+  Microsoft::WRL::Wrappers::HString name_;
+  Microsoft::WRL::ComPtr<
+      ABI::Windows::Graphics::Effects::IGraphicsEffectSource>
+      background_;
+  Microsoft::WRL::ComPtr<
+      ABI::Windows::Graphics::Effects::IGraphicsEffectSource>
+      foreground_;
+  D2D1_BLEND_MODE mode_ = D2D1_BLEND_MODE_OVERLAY;
+};
+
+}  // namespace erika_flutter

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -1,5 +1,6 @@
 #include "erika_flutter_plugin.h"
 #include "erika_composition_blend_effect.h"
+#include "erika_texture_publication.h"
 
 #include <flutter/event_channel.h>
 #include <flutter/method_channel.h>
@@ -1037,9 +1038,9 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         "erika_danmaku_track_info_free");
     attach_windows_hwnd =
         LoadRequired<AttachWindowsHwndFn>("erika_presenter_attach_windows_hwnd");
-    attach_flutter_texture = LoadRequired<AttachFlutterTextureFn>(
+    attach_flutter_texture = LoadOptional<AttachFlutterTextureFn>(
         "erika_presenter_attach_flutter_texture");
-    windows_flutter_texture = LoadRequired<GetWindowsFlutterTextureFn>(
+    windows_flutter_texture = LoadOptional<GetWindowsFlutterTextureFn>(
         "erika_presenter_windows_flutter_texture_iunknown");
     attach_wgpu_surface_with_output_capabilities =
         LoadRequired<AttachWgpuSurfaceWithOutputCapabilitiesFn>(
@@ -1496,89 +1497,31 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
 };
 
 struct ErikaFlutterPlugin::ErikaFlutterTexture {
-  struct Snapshot {
-    Snapshot(Microsoft::WRL::ComPtr<ID3D11Texture2D> source,
-             HANDLE shared_handle,
-             uint32_t pixel_width,
-             uint32_t pixel_height)
-        : texture(std::move(source)) {
-      descriptor.struct_size = sizeof(FlutterDesktopGpuSurfaceDescriptor);
-      descriptor.handle = shared_handle;
-      descriptor.width = pixel_width;
-      descriptor.height = pixel_height;
-      descriptor.visible_width = pixel_width;
-      descriptor.visible_height = pixel_height;
-      descriptor.format = kFlutterDesktopPixelFormatBGRA8888;
-      descriptor.release_callback = [](void* context) {
-        static_cast<Snapshot*>(context)->opened.store(
-            true, std::memory_order_release);
-      };
-      descriptor.release_context = this;
-    }
-
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
-    FlutterDesktopGpuSurfaceDescriptor descriptor{};
-    std::atomic<bool> opened{false};
-    uint64_t retire_after_frame = 0;
-  };
-
-  ErikaFlutterTexture(flutter::PluginRegistrarWindows* plugin_registrar,
+  ErikaFlutterTexture(flutter::TextureRegistrar* texture_registrar,
                       uint32_t pixel_width,
                       uint32_t pixel_height,
                       double backing_scale)
-      : registrar(plugin_registrar),
+      : registrar(texture_registrar),
         width(pixel_width),
         height(pixel_height),
         scale(backing_scale),
         texture_variant(std::make_unique<flutter::TextureVariant>(
             flutter::GpuSurfaceTexture(
                 kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
-                [this](size_t requested_width, size_t requested_height) {
-                  const auto* snapshot =
-                      current.load(std::memory_order_acquire);
-                  return snapshot == nullptr ? nullptr : &snapshot->descriptor;
+                [this](size_t, size_t) {
+                  return publication.AcquireDescriptor();
                 }))) {
-    texture_id =
-        registrar->texture_registrar()->RegisterTexture(texture_variant.get());
+    texture_id = registrar->RegisterTexture(texture_variant.get());
     if (texture_id < 0) {
       throw PluginError("Flutter failed to register the Erika GPU texture.");
     }
   }
 
   bool UpdateNativeTexture(void* raw_texture) {
-    if (raw_texture == nullptr) {
-      return false;
-    }
-
-    Microsoft::WRL::ComPtr<IUnknown> unknown;
-    unknown.Attach(static_cast<IUnknown*>(raw_texture));
-    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
-    CheckHResult(unknown.As(&texture),
-                 "QueryInterface(ID3D11Texture2D)");
-
-    auto* previous = current.load(std::memory_order_acquire);
-    if (previous != nullptr && previous->texture.Get() == texture.Get()) {
-      return false;
-    }
-
-    Microsoft::WRL::ComPtr<IDXGIResource> resource;
-    CheckHResult(texture.As(&resource), "QueryInterface(IDXGIResource)");
-    HANDLE shared_handle = nullptr;
-    CheckHResult(resource->GetSharedHandle(&shared_handle),
-                 "IDXGIResource::GetSharedHandle");
-    if (shared_handle == nullptr) {
-      throw PluginError("Erika returned a D3D11 texture without a shared handle.");
-    }
-
-    if (previous != nullptr) {
-      previous->retire_after_frame = frame_sequence + 4;
-    }
-    auto snapshot =
-        std::make_unique<Snapshot>(std::move(texture), shared_handle, width, height);
-    auto* published = snapshot.get();
-    snapshots.push_back(std::move(snapshot));
-    current.store(published, std::memory_order_release);
-    return true;
+    bool changed = false;
+    CheckHResult(publication.Update(raw_texture, changed),
+                 "Publish completed Flutter GPU texture");
+    return changed;
   }
 
   void Resize(uint32_t pixel_width,
@@ -1590,30 +1533,22 @@ struct ErikaFlutterPlugin::ErikaFlutterTexture {
   }
 
   void MarkFrameAvailable() {
-    registrar->texture_registrar()->MarkTextureFrameAvailable(texture_id);
-    ++frame_sequence;
-    const auto* active = current.load(std::memory_order_acquire);
-    snapshots.erase(
-        std::remove_if(
-            snapshots.begin(), snapshots.end(),
-            [active, this](const std::unique_ptr<Snapshot>& snapshot) {
-              return snapshot.get() != active &&
-                     snapshot->opened.load(std::memory_order_acquire) &&
-                     frame_sequence >= snapshot->retire_after_frame;
-            }),
-        snapshots.end());
+    registrar->MarkTextureFrameAvailable(texture_id);
   }
 
-  flutter::PluginRegistrarWindows* registrar = nullptr;
+  void Clear() {
+    publication.Clear();
+    MarkFrameAvailable();
+  }
+
+  flutter::TextureRegistrar* registrar = nullptr;
   uint32_t width = 1;
   uint32_t height = 1;
   double scale = 1.0;
   int64_t texture_id = -1;
   int64_t owner_player_id = 0;
+  ErikaTexturePublication publication;
   std::unique_ptr<flutter::TextureVariant> texture_variant;
-  std::vector<std::unique_ptr<Snapshot>> snapshots;
-  std::atomic<Snapshot*> current{nullptr};
-  uint64_t frame_sequence = 0;
 };
 
 struct ErikaFlutterPlugin::PlayerHost {
@@ -1639,7 +1574,7 @@ struct ErikaFlutterPlugin::PlayerHost {
 
   ~PlayerHost() {
     if (handle != nullptr) {
-      library->detach_surface(handle);
+      Detach(std::nullopt);
       library->destroy(handle);
       handle = nullptr;
     }
@@ -2286,6 +2221,16 @@ struct ErikaFlutterPlugin::PlayerHost {
   }
 
   void AttachFlutterTexture(ErikaFlutterTexture& texture) {
+    // Optional features must not prevent native HWND/HDR playback with an
+    // older bundled runtime. Check before disturbing an existing attachment.
+    if (library->attach_flutter_texture == nullptr ||
+        library->windows_flutter_texture == nullptr) {
+      throw PluginError(
+          "Windows Flutter textures require a matching Erika native runtime. "
+          "Build with ERIKA_FORCE_SOURCE_BUILD=1 from this checkout, or install "
+          "a runtime providing erika_presenter_windows_flutter_texture_iunknown. "
+          "ErikaVideoView remains available for native HDR playback.");
+    }
     if (texture.owner_player_id != 0 && texture.owner_player_id != id) {
       throw PluginError("Erika Flutter texture " +
                         std::to_string(texture.texture_id) +
@@ -2339,8 +2284,9 @@ struct ErikaFlutterPlugin::PlayerHost {
         library->windows_flutter_texture(handle, &raw_texture);
     Check(status, "windows_flutter_texture_iunknown",
           status == ErikaStatus_Ok ? std::string{} : library->TakeLastError());
-    attached_texture->UpdateNativeTexture(raw_texture);
-    attached_texture->MarkFrameAvailable();
+    if (attached_texture->UpdateNativeTexture(raw_texture)) {
+      attached_texture->MarkFrameAvailable();
+    }
   }
 
   void ResizeOverlay(ErikaOverlayWindow& overlay) {
@@ -2403,6 +2349,7 @@ struct ErikaFlutterPlugin::PlayerHost {
     attached_overlay = nullptr;
     if (attached_texture != nullptr && attached_texture->owner_player_id == id) {
       attached_texture->owner_player_id = 0;
+      attached_texture->Clear();
     }
     attached_texture = nullptr;
     composition_surface = false;
@@ -3065,13 +3012,20 @@ ErikaFlutterPlugin::ErikaOverlayWindow& ErikaFlutterPlugin::EnsureOverlayWindow(
     const std::string blend_mode =
         overlay_window_ ? overlay_window_->blend_mode : "srcOver";
     const double opacity = overlay_window_ ? overlay_window_->opacity : 1.0;
+    std::vector<PlayerHost*> reattach;
+    for (auto& entry : players_) {
+      if (entry.second->attached_view_id == kWindowOverlayViewId) {
+        reattach.push_back(entry.second.get());
+        // Clear composition references while the old overlay is still alive.
+        entry.second->Detach(std::nullopt);
+      }
+    }
     overlay_window_ = std::make_unique<ErikaOverlayWindow>(parent);
     overlay_window_->ConfigureComposition(blend_mode, opacity);
     StartFrameTimer();
-    for (auto& entry : players_) {
-      if (entry.second->attached_view_id == kWindowOverlayViewId) {
-        entry.second->AttachOverlay(*overlay_window_);
-      }
+    for (auto* player : reattach) {
+      player->AttachOverlay(*overlay_window_);
+      overlay_window_->owner_player_id = player->id;
     }
   }
   return *overlay_window_;
@@ -3109,7 +3063,7 @@ int64_t ErikaFlutterPlugin::CreateTexture(const EncodableMap& args) {
     throw PluginError("Flutter texture metrics must be finite and positive.");
   }
   auto texture = std::make_shared<ErikaFlutterTexture>(
-      registrar_, static_cast<uint32_t>(requested_width),
+      registrar_->texture_registrar(), static_cast<uint32_t>(requested_width),
       static_cast<uint32_t>(requested_height), scale);
   const int64_t texture_id = texture->texture_id;
   textures_.emplace(texture_id, std::move(texture));

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -3009,26 +3009,71 @@ ErikaFlutterPlugin::ErikaOverlayWindow& ErikaFlutterPlugin::EnsureOverlayWindow(
                           : "No Flutter HWND is available for Erika overlay.");
   }
   if (!overlay_window_ || overlay_window_->flutter != parent) {
-    const std::string blend_mode =
-        overlay_window_ ? overlay_window_->blend_mode : "srcOver";
-    const double opacity = overlay_window_ ? overlay_window_->opacity : 1.0;
-    std::vector<PlayerHost*> reattach;
-    for (auto& entry : players_) {
-      if (entry.second->attached_view_id == kWindowOverlayViewId) {
-        reattach.push_back(entry.second.get());
-        // Clear composition references while the old overlay is still alive.
-        entry.second->Detach(std::nullopt);
-      }
-    }
-    overlay_window_ = std::make_unique<ErikaOverlayWindow>(parent);
-    overlay_window_->ConfigureComposition(blend_mode, opacity);
+    RecreateOverlayWindow(players_, overlay_window_, parent);
     StartFrameTimer();
-    for (auto* player : reattach) {
-      player->AttachOverlay(*overlay_window_);
-      overlay_window_->owner_player_id = player->id;
-    }
   }
   return *overlay_window_;
+}
+
+void ErikaFlutterPlugin::RecreateOverlayWindow(
+    const PlayerMap& players,
+    std::unique_ptr<ErikaOverlayWindow>& overlay,
+    HWND parent) {
+  const int64_t owner_id = overlay ? overlay->owner_player_id : 0;
+  auto next = std::make_unique<ErikaOverlayWindow>(parent);
+  next->ConfigureComposition(overlay ? overlay->blend_mode : "srcOver",
+                             overlay ? overlay->opacity : 1.0);
+  PlayerHost* owner = nullptr;
+  for (const auto& entry : players) {
+    auto& player = *entry.second;
+    if (player.attached_view_id == kWindowOverlayViewId) {
+      if (player.id == owner_id && player.surface_attached) {
+        owner = &player;
+      }
+      // Clear references while the old HWND/composition target is still alive.
+      player.Detach(std::nullopt);
+    }
+  }
+  overlay = std::move(next);
+  // Rebind only the owner chosen by Flutter, never the last map entry.
+  if (owner != nullptr) {
+    AttachOverlayPlayer(players, *owner, *overlay);
+  }
+}
+
+void ErikaFlutterPlugin::AttachOverlayPlayer(const PlayerMap& players,
+                                            PlayerHost& host,
+                                            ErikaOverlayWindow& overlay) {
+  // A shared overlay has one producer. Old widgets can still send late frame
+  // or detach messages, but must not keep rendering into the new owner's HWND.
+  for (const auto& entry : players) {
+    if (entry.second.get() != &host &&
+        entry.second->attached_view_id == kWindowOverlayViewId) {
+      entry.second->Detach(std::nullopt);
+    }
+  }
+  try {
+    host.AttachOverlay(overlay);
+    overlay.owner_player_id = host.id;
+  } catch (...) {
+    overlay.owner_player_id = 0;
+    throw;
+  }
+}
+
+bool ErikaFlutterPlugin::DetachOverlayPlayer(
+    PlayerHost& host,
+    ErikaOverlayWindow* overlay,
+    std::optional<int64_t> generation) {
+  if (generation && overlay && *generation != overlay->active_generation) {
+    return false;
+  }
+  host.Detach(kWindowOverlayViewId);
+  if (overlay && overlay->owner_player_id == host.id) {
+    overlay->SetFrame(0.0, 0.0, 0.0, 0.0, false, generation, std::nullopt);
+    overlay->owner_player_id = 0;
+  }
+  return true;
 }
 
 ErikaFlutterPlugin::PlayerHost& ErikaFlutterPlugin::PlayerFromArgs(
@@ -3546,8 +3591,7 @@ void ErikaFlutterPlugin::HandleMethodCall(
       overlay.ConfigureComposition(
           StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
           DoubleValue(FindArg(args, "opacity")).value_or(1.0));
-      host.AttachOverlay(overlay);
-      overlay.owner_player_id = host.id;
+      AttachOverlayPlayer(players_, host, overlay);
       OnFrameTimer();
       result->Success();
     } else if (method == "detachView") {
@@ -3561,27 +3605,17 @@ void ErikaFlutterPlugin::HandleMethodCall(
       overlay.ConfigureComposition(
           StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
           DoubleValue(FindArg(args, "opacity")).value_or(1.0));
-      host.AttachOverlay(overlay);
-      overlay.owner_player_id = host.id;
+      AttachOverlayPlayer(players_, host, overlay);
       OnFrameTimer();
       result->Success(EncodableValue(kWindowOverlayViewId));
     } else if (method == "detachOverlay") {
       auto& host = PlayerFromArgs(args);
       const auto generation = Int64Value(FindArg(args, "generation"));
-      if (generation && overlay_window_ &&
-          *generation != overlay_window_->active_generation) {
+      if (!DetachOverlayPlayer(host, overlay_window_.get(), generation)) {
         result->Success();
         return;
       }
-      host.Detach(kWindowOverlayViewId);
       OnFrameTimer();
-      if (overlay_window_) {
-        overlay_window_->SetFrame(0.0, 0.0, 0.0, 0.0, false, generation,
-                                  std::nullopt);
-        if (overlay_window_->owner_player_id == host.id) {
-          overlay_window_->owner_player_id = 0;
-        }
-      }
       result->Success();
     } else if (method == "setOverlayFrame") {
       const bool visible =
@@ -3592,25 +3626,30 @@ void ErikaFlutterPlugin::HandleMethodCall(
         result->Success();
         return;
       }
-      UpdateOverlayTarget(args);
-      auto& overlay = EnsureOverlayWindow();
       const int64_t player_id = RequiredInt64(args, "playerId");
       auto& host = PlayerFromArgs(args);
-      if (!visible && overlay.owner_player_id != 0 &&
-          overlay.owner_player_id != player_id) {
+      // Reject stale hides before they can switch the shared HWND target.
+      if (!visible && overlay_window_ &&
+          overlay_window_->owner_player_id != 0 &&
+          overlay_window_->owner_player_id != player_id) {
         result->Success();
         return;
       }
-      if (visible) {
-        overlay.owner_player_id = player_id;
-      }
+      UpdateOverlayTarget(args);
+      auto& overlay = EnsureOverlayWindow();
       overlay.ConfigureComposition(
           StringValue(FindArg(args, "blendMode")).value_or("srcOver"),
           DoubleValue(FindArg(args, "opacity")).value_or(1.0));
-      if (host.surface_attached &&
-          host.attached_view_id == kWindowOverlayViewId &&
-          host.composition_surface != host.RequiresComposition(overlay)) {
-        host.AttachOverlay(overlay);
+      const bool attached_to_overlay = host.surface_attached &&
+          host.attached_view_id == kWindowOverlayViewId;
+      if ((visible && !attached_to_overlay) ||
+          (attached_to_overlay &&
+           host.composition_surface != host.RequiresComposition(overlay))) {
+        AttachOverlayPlayer(players_, host, overlay);
+      }
+      if (visible) {
+        // Showing the same bound player again must not recreate its swapchain.
+        overlay.owner_player_id = player_id;
       }
       overlay.SetFrame(DoubleValue(FindArg(args, "x")).value_or(0.0),
                        DoubleValue(FindArg(args, "y")).value_or(0.0),

--- a/packages/erika_flutter/windows/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.cpp
@@ -1,12 +1,22 @@
 #include "erika_flutter_plugin.h"
+#include "erika_composition_blend_effect.h"
 
 #include <flutter/event_channel.h>
 #include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
+#include <flutter/texture_registrar.h>
 
 #include <d2d1effects.h>
-#include <dcomp.h>
+#include <d3d11.h>
+#include <DispatcherQueue.h>
+#include <dxgi.h>
+#include <windows.ui.composition.interop.h>
 #include <wrl/client.h>
+
+#include <winrt/Windows.Graphics.Effects.h>
+#include <winrt/Windows.System.h>
+#include <winrt/Windows.UI.Composition.Desktop.h>
+#include <winrt/Windows.UI.Composition.h>
 
 #include <algorithm>
 #include <chrono>
@@ -45,9 +55,17 @@ using flutter::EncodableList;
 using flutter::EncodableMap;
 using flutter::EncodableValue;
 
+void DebugLog(const std::string& message);
+
 class PluginError : public std::runtime_error {
  public:
-  explicit PluginError(const std::string& message) : std::runtime_error(message) {}
+  explicit PluginError(std::string message)
+      : std::runtime_error("Erika plugin error"), message_(std::move(message)) {}
+
+  const char* what() const noexcept override { return message_.c_str(); }
+
+ private:
+  std::string message_;
 };
 
 void CheckHResult(HRESULT result, const char* operation) {
@@ -57,7 +75,9 @@ void CheckHResult(HRESULT result, const char* operation) {
   std::ostringstream message;
   message << operation << " failed (HRESULT=0x" << std::hex << std::uppercase
           << static_cast<uint32_t>(result) << ")";
-  throw PluginError(message.str());
+  const auto detail = message.str();
+  DebugLog(detail);
+  throw PluginError(detail);
 }
 
 std::string LastErrorMessage() {
@@ -791,6 +811,11 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   using AttachWindowsHwndFn =
       ErikaStatus (*)(ErikaPresenterHandle*, uint64_t, uint64_t, uint32_t,
                       uint32_t, double);
+  using AttachFlutterTextureFn = ErikaStatus (*)(
+      ErikaPresenterHandle*, ErikaFlutterTextureKind, int64_t, uint32_t,
+      uint32_t, double);
+  using GetWindowsFlutterTextureFn =
+      ErikaStatus (*)(ErikaPresenterHandle*, void**);
   using AttachWgpuSurfaceWithOutputCapabilitiesFn = ErikaStatus (*)(
       ErikaPresenterHandle*, ErikaWgpuSurfaceKind, uint64_t, uint64_t,
       uint32_t, uint32_t, double, ErikaSurfaceOutputCapabilities);
@@ -905,6 +930,8 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
   TrackInfoFreeFn free_track_info = nullptr;
   DanmakuTrackInfoFreeFn free_danmaku_track_info = nullptr;
   AttachWindowsHwndFn attach_windows_hwnd = nullptr;
+  AttachFlutterTextureFn attach_flutter_texture = nullptr;
+  GetWindowsFlutterTextureFn windows_flutter_texture = nullptr;
   AttachWgpuSurfaceWithOutputCapabilitiesFn
       attach_wgpu_surface_with_output_capabilities = nullptr;
   GetWindowsCompositionSwapchainFn windows_composition_swapchain = nullptr;
@@ -1010,6 +1037,10 @@ struct ErikaFlutterPlugin::ErikaNativeLibrary {
         "erika_danmaku_track_info_free");
     attach_windows_hwnd =
         LoadRequired<AttachWindowsHwndFn>("erika_presenter_attach_windows_hwnd");
+    attach_flutter_texture = LoadRequired<AttachFlutterTextureFn>(
+        "erika_presenter_attach_flutter_texture");
+    windows_flutter_texture = LoadRequired<GetWindowsFlutterTextureFn>(
+        "erika_presenter_windows_flutter_texture_iunknown");
     attach_wgpu_surface_with_output_capabilities =
         LoadRequired<AttachWgpuSurfaceWithOutputCapabilitiesFn>(
             "erika_presenter_attach_wgpu_surface_with_output_capabilities");
@@ -1113,15 +1144,14 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     }
     blend_mode = std::move(requested_blend_mode);
     opacity = std::clamp(requested_opacity, 0.0, 1.0);
-    if (composition_mode && composition_device) {
+    if (composition_mode && compositor) {
       ApplyCompositionState();
     }
   }
 
   void SetCompositionMode(bool enabled) {
     if (composition_mode == enabled) {
-      if (enabled) {
-        EnsureComposition();
+      if (enabled && compositor) {
         ApplyCompositionState();
       }
       return;
@@ -1129,8 +1159,9 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     composition_mode = enabled;
     if (enabled) {
       ShowWindow(hwnd, SW_HIDE);
-      EnsureComposition();
-      ApplyCompositionState();
+      if (compositor) {
+        ApplyCompositionState();
+      }
       return;
     }
     ClearCompositionContent();
@@ -1142,28 +1173,42 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     }
     Microsoft::WRL::ComPtr<IUnknown> next_content;
     next_content.Attach(static_cast<IUnknown*>(raw_content));
+    Microsoft::WRL::ComPtr<IDXGISwapChain> swapchain;
+    CheckHResult(next_content.As(&swapchain),
+                  "QueryInterface(IDXGISwapChain)");
     EnsureComposition();
     if (composition_content.Get() == next_content.Get()) {
       return;
     }
-    CheckHResult(content_visual->SetContent(next_content.Get()),
-                 "IDCompositionVisual::SetContent");
+
+    winrt::Windows::UI::Composition::ICompositionSurface next_surface{
+        nullptr};
+    auto interop = compositor.as<
+        ABI::Windows::UI::Composition::ICompositorInterop>();
+    CheckHResult(
+        interop->CreateCompositionSurfaceForSwapChain(
+            swapchain.Get(),
+            reinterpret_cast<
+                ABI::Windows::UI::Composition::ICompositionSurface**>(
+                winrt::put_abi(next_surface))),
+        "ICompositorInterop::CreateCompositionSurfaceForSwapChain");
+
+    composition_surface = std::move(next_surface);
+    surface_brush.Surface(composition_surface);
     composition_content = std::move(next_content);
     ApplyCompositionState();
   }
 
   void ClearCompositionContent() {
-    if (!composition_device || !content_visual) {
+    if (!compositor) {
       composition_content.Reset();
       return;
     }
-    CheckHResult(content_visual->SetContent(nullptr),
-                 "IDCompositionVisual::SetContent(null)");
+    composition_surface = nullptr;
+    surface_brush.Surface(composition_surface);
     composition_content.Reset();
-    CheckHResult(composition_target->SetRoot(nullptr),
-                 "IDCompositionTarget::SetRoot(null)");
-    CheckHResult(composition_device->Commit(),
-                 "IDCompositionDevice::Commit(clear)");
+    composition_target.Root(
+        winrt::Windows::UI::Composition::Visual{nullptr});
   }
 
   void SetFrame(double x,
@@ -1194,8 +1239,9 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
 
     if (composition_mode) {
       ShowWindow(hwnd, SW_HIDE);
-      EnsureComposition();
-      ApplyCompositionState();
+      if (compositor) {
+        ApplyCompositionState();
+      }
       return;
     }
 
@@ -1276,90 +1322,150 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
     }
   }
 
-  void EnsureComposition() {
-    if (composition_device) {
+  void EnsureDispatcherQueue() {
+    using winrt::Windows::System::DispatcherQueue;
+    using winrt::Windows::System::DispatcherQueueController;
+
+    // A DispatcherQueue belongs to the UI thread, not to one overlay target.
+    // Keep the controller alive if the Flutter HWND changes and the overlay
+    // object is replaced; shutting down the queue underneath the new
+    // Compositor can otherwise invalidate its target asynchronously.
+    static thread_local DispatcherQueueController queue_controller{nullptr};
+    if (DispatcherQueue::GetForCurrentThread()) {
       return;
     }
-    if (flutter == nullptr) {
-      throw PluginError("No Flutter HWND is available for DirectComposition.");
-    }
 
+    DispatcherQueueOptions options{
+        sizeof(DispatcherQueueOptions),
+        DQTYPE_THREAD_CURRENT,
+        DQTAT_COM_STA,
+    };
+    DispatcherQueueController next_controller{nullptr};
     CheckHResult(
-        DCompositionCreateDevice2(
-            nullptr, __uuidof(IDCompositionDesktopDevice),
-            reinterpret_cast<void**>(desktop_device.ReleaseAndGetAddressOf())),
-        "DCompositionCreateDevice2");
-    CheckHResult(desktop_device.As(&composition_device),
-                 "QueryInterface(IDCompositionDevice3)");
-    CheckHResult(composition_device->CreateVisual(
-                     root_visual.ReleaseAndGetAddressOf()),
-                 "IDCompositionDevice::CreateVisual(root)");
-    CheckHResult(composition_device->CreateVisual(
-                     content_visual.ReleaseAndGetAddressOf()),
-                 "IDCompositionDevice::CreateVisual(content)");
-    CheckHResult(root_visual->AddVisual(content_visual.Get(), FALSE, nullptr),
-                 "IDCompositionVisual::AddVisual");
-    CheckHResult(composition_device->CreateEffectGroup(
-                     opacity_effect.ReleaseAndGetAddressOf()),
-                 "IDCompositionDevice::CreateEffectGroup");
-    CheckHResult(content_visual->SetEffect(opacity_effect.Get()),
-                 "IDCompositionVisual::SetEffect(opacity)");
-    CheckHResult(composition_device->CreateBlendEffect(
-                     overlay_blend_effect.ReleaseAndGetAddressOf()),
-                 "IDCompositionDevice3::CreateBlendEffect");
-    CheckHResult(overlay_blend_effect->SetMode(D2D1_BLEND_MODE_OVERLAY),
-                 "IDCompositionBlendEffect::SetMode");
+        CreateDispatcherQueueController(
+            options,
+            reinterpret_cast<ABI::Windows::System::
+                                 IDispatcherQueueController**>(
+                winrt::put_abi(next_controller))),
+        "CreateDispatcherQueueController");
+    queue_controller = std::move(next_controller);
+  }
 
-    HRESULT target_result = desktop_device->CreateTargetForHwnd(
-        flutter, TRUE, composition_target.ReleaseAndGetAddressOf());
-    if (FAILED(target_result)) {
-      target_result = desktop_device->CreateTargetForHwnd(
-          flutter, FALSE, composition_target.ReleaseAndGetAddressOf());
+  void EnsureComposition() {
+    if (flutter == nullptr) {
+      throw PluginError("No Flutter HWND is available for Windows Composition.");
     }
-    CheckHResult(target_result,
-                 "IDCompositionDesktopDevice::CreateTargetForHwnd");
+    if (compositor) {
+      return;
+    }
+
+    EnsureDispatcherQueue();
+
+    using winrt::Windows::Graphics::Effects::IGraphicsEffect;
+    using winrt::Windows::Graphics::Effects::IGraphicsEffectSource;
+    using winrt::Windows::UI::Composition::CompositionEffectBrush;
+    using winrt::Windows::UI::Composition::CompositionEffectSourceParameter;
+    using winrt::Windows::UI::Composition::CompositionStretch;
+    using winrt::Windows::UI::Composition::CompositionSurfaceBrush;
+    using winrt::Windows::UI::Composition::Compositor;
+    using winrt::Windows::UI::Composition::SpriteVisual;
+    using winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget;
+
+    Compositor next_compositor;
+    DesktopWindowTarget next_target{nullptr};
+    auto desktop_interop = next_compositor.as<
+        ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
+    CheckHResult(
+        desktop_interop->CreateDesktopWindowTarget(
+            flutter, TRUE,
+            reinterpret_cast<ABI::Windows::UI::Composition::Desktop::
+                                 IDesktopWindowTarget**>(
+                winrt::put_abi(next_target))),
+        "ICompositorDesktopInterop::CreateDesktopWindowTarget");
+
+    CompositionSurfaceBrush next_surface_brush =
+        next_compositor.CreateSurfaceBrush();
+    next_surface_brush.Stretch(CompositionStretch::Fill);
+
+    CompositionEffectSourceParameter background_parameter(L"Backdrop");
+    CompositionEffectSourceParameter foreground_parameter(L"Video");
+    auto background_source =
+        background_parameter.as<IGraphicsEffectSource>();
+    auto foreground_source =
+        foreground_parameter.as<IGraphicsEffectSource>();
+
+    Microsoft::WRL::ComPtr<ErikaCompositionBlendEffect> blend_descriptor;
+    CheckHResult(
+        Microsoft::WRL::MakeAndInitialize<ErikaCompositionBlendEffect>(
+            blend_descriptor.GetAddressOf(),
+            reinterpret_cast<ABI::Windows::Graphics::Effects::
+                                 IGraphicsEffectSource*>(
+                winrt::get_abi(background_source)),
+            reinterpret_cast<ABI::Windows::Graphics::Effects::
+                                 IGraphicsEffectSource*>(
+                winrt::get_abi(foreground_source)),
+            D2D1_BLEND_MODE_OVERLAY),
+        "Create Windows Composition overlay effect description");
+
+    Microsoft::WRL::ComPtr<
+        ABI::Windows::Graphics::Effects::IGraphicsEffect>
+        abi_blend_effect;
+    CheckHResult(blend_descriptor.As(&abi_blend_effect),
+                 "QueryInterface(IGraphicsEffect)");
+    IGraphicsEffect blend_effect{nullptr};
+    winrt::copy_from_abi(blend_effect, abi_blend_effect.Get());
+
+    CompositionEffectBrush next_overlay_brush =
+        next_compositor.CreateEffectFactory(blend_effect).CreateBrush();
+    next_overlay_brush.SetSourceParameter(
+        L"Backdrop", next_compositor.CreateBackdropBrush());
+    next_overlay_brush.SetSourceParameter(L"Video", next_surface_brush);
+
+    SpriteVisual next_content_visual = next_compositor.CreateSpriteVisual();
+    next_content_visual.Brush(next_surface_brush);
+
+    compositor = std::move(next_compositor);
+    composition_target = std::move(next_target);
+    surface_brush = std::move(next_surface_brush);
+    overlay_brush = std::move(next_overlay_brush);
+    content_visual = std::move(next_content_visual);
   }
 
   void ApplyCompositionState() {
-    if (!composition_device) {
+    if (!compositor) {
       return;
     }
-    IDCompositionEffect* effect = blend_mode == "overlay"
-                                     ? overlay_blend_effect.Get()
-                                     : nullptr;
-    CheckHResult(root_visual->SetEffect(effect),
-                 "IDCompositionVisual::SetEffect");
-    CheckHResult(opacity_effect->SetOpacity(static_cast<float>(opacity)),
-                 "IDCompositionEffectGroup::SetOpacity");
-    CheckHResult(content_visual->SetOffsetX(static_cast<float>(
-                     LogicalToPhysical(flutter, logical_x))),
-                 "IDCompositionVisual::SetOffsetX");
-    CheckHResult(content_visual->SetOffsetY(static_cast<float>(
-                     LogicalToPhysical(flutter, logical_y))),
-                 "IDCompositionVisual::SetOffsetY");
-    CheckHResult(
-        composition_target->SetRoot(
-            composition_mode && visible && composition_content
-                ? root_visual.Get()
-                : nullptr),
-        "IDCompositionTarget::SetRoot");
-    CheckHResult(composition_device->Commit(),
-                 "IDCompositionDevice::Commit");
+    if (blend_mode == "overlay") {
+      content_visual.Brush(overlay_brush);
+    } else {
+      content_visual.Brush(surface_brush);
+    }
+    content_visual.Opacity(static_cast<float>(opacity));
+    content_visual.Offset(
+        {static_cast<float>(LogicalToPhysical(flutter, logical_x)),
+         static_cast<float>(LogicalToPhysical(flutter, logical_y)), 0.0f});
+    content_visual.Size({static_cast<float>(PixelWidth()),
+                         static_cast<float>(PixelHeight())});
+    if (composition_mode && visible && composition_content) {
+      composition_target.Root(content_visual);
+    } else {
+      composition_target.Root(
+          winrt::Windows::UI::Composition::Visual{nullptr});
+    }
   }
 
   void ShutdownComposition() {
-    if (composition_target && composition_device) {
-      composition_target->SetRoot(nullptr);
-      composition_device->Commit();
+    if (composition_target) {
+      composition_target.Root(
+          winrt::Windows::UI::Composition::Visual{nullptr});
     }
     composition_content.Reset();
-    overlay_blend_effect.Reset();
-    opacity_effect.Reset();
-    content_visual.Reset();
-    root_visual.Reset();
-    composition_target.Reset();
-    composition_device.Reset();
-    desktop_device.Reset();
+    composition_surface = nullptr;
+    content_visual = nullptr;
+    overlay_brush = nullptr;
+    surface_brush = nullptr;
+    composition_target = nullptr;
+    compositor = nullptr;
   }
 
   HWND flutter = nullptr;
@@ -1376,14 +1482,138 @@ struct ErikaFlutterPlugin::ErikaOverlayWindow {
   double opacity = 1.0;
   int64_t active_generation = 0;
   int64_t owner_player_id = 0;
-  Microsoft::WRL::ComPtr<IDCompositionDesktopDevice> desktop_device;
-  Microsoft::WRL::ComPtr<IDCompositionDevice3> composition_device;
-  Microsoft::WRL::ComPtr<IDCompositionTarget> composition_target;
-  Microsoft::WRL::ComPtr<IDCompositionVisual2> root_visual;
-  Microsoft::WRL::ComPtr<IDCompositionVisual2> content_visual;
-  Microsoft::WRL::ComPtr<IDCompositionEffectGroup> opacity_effect;
-  Microsoft::WRL::ComPtr<IDCompositionBlendEffect> overlay_blend_effect;
+  winrt::Windows::UI::Composition::Compositor compositor{nullptr};
+  winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget
+      composition_target{nullptr};
+  winrt::Windows::UI::Composition::SpriteVisual content_visual{nullptr};
+  winrt::Windows::UI::Composition::CompositionSurfaceBrush surface_brush{
+      nullptr};
+  winrt::Windows::UI::Composition::CompositionEffectBrush overlay_brush{
+      nullptr};
+  winrt::Windows::UI::Composition::ICompositionSurface composition_surface{
+      nullptr};
   Microsoft::WRL::ComPtr<IUnknown> composition_content;
+};
+
+struct ErikaFlutterPlugin::ErikaFlutterTexture {
+  struct Snapshot {
+    Snapshot(Microsoft::WRL::ComPtr<ID3D11Texture2D> source,
+             HANDLE shared_handle,
+             uint32_t pixel_width,
+             uint32_t pixel_height)
+        : texture(std::move(source)) {
+      descriptor.struct_size = sizeof(FlutterDesktopGpuSurfaceDescriptor);
+      descriptor.handle = shared_handle;
+      descriptor.width = pixel_width;
+      descriptor.height = pixel_height;
+      descriptor.visible_width = pixel_width;
+      descriptor.visible_height = pixel_height;
+      descriptor.format = kFlutterDesktopPixelFormatBGRA8888;
+      descriptor.release_callback = [](void* context) {
+        static_cast<Snapshot*>(context)->opened.store(
+            true, std::memory_order_release);
+      };
+      descriptor.release_context = this;
+    }
+
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    FlutterDesktopGpuSurfaceDescriptor descriptor{};
+    std::atomic<bool> opened{false};
+    uint64_t retire_after_frame = 0;
+  };
+
+  ErikaFlutterTexture(flutter::PluginRegistrarWindows* plugin_registrar,
+                      uint32_t pixel_width,
+                      uint32_t pixel_height,
+                      double backing_scale)
+      : registrar(plugin_registrar),
+        width(pixel_width),
+        height(pixel_height),
+        scale(backing_scale),
+        texture_variant(std::make_unique<flutter::TextureVariant>(
+            flutter::GpuSurfaceTexture(
+                kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
+                [this](size_t requested_width, size_t requested_height) {
+                  const auto* snapshot =
+                      current.load(std::memory_order_acquire);
+                  return snapshot == nullptr ? nullptr : &snapshot->descriptor;
+                }))) {
+    texture_id =
+        registrar->texture_registrar()->RegisterTexture(texture_variant.get());
+    if (texture_id < 0) {
+      throw PluginError("Flutter failed to register the Erika GPU texture.");
+    }
+  }
+
+  bool UpdateNativeTexture(void* raw_texture) {
+    if (raw_texture == nullptr) {
+      return false;
+    }
+
+    Microsoft::WRL::ComPtr<IUnknown> unknown;
+    unknown.Attach(static_cast<IUnknown*>(raw_texture));
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    CheckHResult(unknown.As(&texture),
+                 "QueryInterface(ID3D11Texture2D)");
+
+    auto* previous = current.load(std::memory_order_acquire);
+    if (previous != nullptr && previous->texture.Get() == texture.Get()) {
+      return false;
+    }
+
+    Microsoft::WRL::ComPtr<IDXGIResource> resource;
+    CheckHResult(texture.As(&resource), "QueryInterface(IDXGIResource)");
+    HANDLE shared_handle = nullptr;
+    CheckHResult(resource->GetSharedHandle(&shared_handle),
+                 "IDXGIResource::GetSharedHandle");
+    if (shared_handle == nullptr) {
+      throw PluginError("Erika returned a D3D11 texture without a shared handle.");
+    }
+
+    if (previous != nullptr) {
+      previous->retire_after_frame = frame_sequence + 4;
+    }
+    auto snapshot =
+        std::make_unique<Snapshot>(std::move(texture), shared_handle, width, height);
+    auto* published = snapshot.get();
+    snapshots.push_back(std::move(snapshot));
+    current.store(published, std::memory_order_release);
+    return true;
+  }
+
+  void Resize(uint32_t pixel_width,
+              uint32_t pixel_height,
+              double backing_scale) {
+    width = pixel_width;
+    height = pixel_height;
+    scale = backing_scale;
+  }
+
+  void MarkFrameAvailable() {
+    registrar->texture_registrar()->MarkTextureFrameAvailable(texture_id);
+    ++frame_sequence;
+    const auto* active = current.load(std::memory_order_acquire);
+    snapshots.erase(
+        std::remove_if(
+            snapshots.begin(), snapshots.end(),
+            [active, this](const std::unique_ptr<Snapshot>& snapshot) {
+              return snapshot.get() != active &&
+                     snapshot->opened.load(std::memory_order_acquire) &&
+                     frame_sequence >= snapshot->retire_after_frame;
+            }),
+        snapshots.end());
+  }
+
+  flutter::PluginRegistrarWindows* registrar = nullptr;
+  uint32_t width = 1;
+  uint32_t height = 1;
+  double scale = 1.0;
+  int64_t texture_id = -1;
+  int64_t owner_player_id = 0;
+  std::unique_ptr<flutter::TextureVariant> texture_variant;
+  std::vector<std::unique_ptr<Snapshot>> snapshots;
+  std::atomic<Snapshot*> current{nullptr};
+  uint64_t frame_sequence = 0;
 };
 
 struct ErikaFlutterPlugin::PlayerHost {
@@ -1413,6 +1643,12 @@ struct ErikaFlutterPlugin::PlayerHost {
       library->destroy(handle);
       handle = nullptr;
     }
+  }
+
+  void CheckNative(ErikaStatus status, const char* operation) const {
+    Check(status, operation,
+          status == ErikaStatus_Ok ? std::string{}
+                                   : library->TakeLastError());
   }
 
   void Open(const std::string& uri, const EncodableMap& args) {
@@ -1559,23 +1795,23 @@ struct ErikaFlutterPlugin::PlayerHost {
   }
 
   void Play() {
-    Check(library->play(handle), "play", library->TakeLastError());
+    CheckNative(library->play(handle), "play");
     smtc_state.playing = true;
     smtc_state.stopped = false;
   }
   void Pause() {
-    Check(library->pause(handle), "pause", library->TakeLastError());
+    CheckNative(library->pause(handle), "pause");
     smtc_state.playing = false;
     smtc_state.stopped = false;
   }
   void Stop() {
-    Check(library->stop(handle), "stop", library->TakeLastError());
+    CheckNative(library->stop(handle), "stop");
     smtc_state.playing = false;
     smtc_state.stopped = true;
     smtc_state.position_micros = 0;
   }
   void Close() {
-    Check(library->close(handle), "close", library->TakeLastError());
+    CheckNative(library->close(handle), "close");
     smtc_state.playing = false;
     smtc_state.stopped = true;
     smtc_state.duration_micros = 0;
@@ -1583,8 +1819,7 @@ struct ErikaFlutterPlugin::PlayerHost {
   }
 
   void Seek(uint64_t position_micros) {
-    Check(library->seek(handle, position_micros), "seek",
-          library->TakeLastError());
+    CheckNative(library->seek(handle, position_micros), "seek");
     smtc_state.position_micros = position_micros;
   }
 
@@ -1592,8 +1827,7 @@ struct ErikaFlutterPlugin::PlayerHost {
     if (library->set_playback_rate == nullptr) {
       throw PluginError("Missing Erika C ABI symbol: erika_presenter_set_playback_rate");
     }
-    Check(library->set_playback_rate(handle, rate), "set_playback_rate",
-          library->TakeLastError());
+    CheckNative(library->set_playback_rate(handle, rate), "set_playback_rate");
     smtc_state.playback_rate = rate;
   }
 
@@ -1602,16 +1836,14 @@ struct ErikaFlutterPlugin::PlayerHost {
       throw PluginError("Missing Erika C ABI symbol: erika_presenter_set_volume");
     }
     const double clamped = std::isfinite(volume) ? std::clamp(volume, 0.0, 1.0) : 1.0;
-    Check(library->set_volume(handle, clamped), "set_volume",
-          library->TakeLastError());
+    CheckNative(library->set_volume(handle, clamped), "set_volume");
   }
 
   void SetUpscaler(int32_t mode) {
     if (library->set_upscaler == nullptr) {
       throw PluginError("Missing Erika C ABI symbol: erika_presenter_set_upscaler");
     }
-    Check(library->set_upscaler(handle, mode), "set_upscaler",
-          library->TakeLastError());
+    CheckNative(library->set_upscaler(handle, mode), "set_upscaler");
   }
 
   void SetSubtitleScale(double scale) {
@@ -1991,33 +2223,59 @@ struct ErikaFlutterPlugin::PlayerHost {
   }
 
   void AttachOverlay(ErikaOverlayWindow& overlay) {
+    if (surface_attached) {
+      Detach(std::nullopt);
+    }
     const uint32_t width = overlay.PixelWidth();
     const uint32_t height = overlay.PixelHeight();
     const double scale = overlay.scale;
     const uint64_t hinstance = reinterpret_cast<uint64_t>(GetModuleHandleW(nullptr));
     composition_surface = RequiresComposition(overlay);
-    overlay.SetCompositionMode(composition_surface);
-    if (composition_surface) {
-      overlay.ClearCompositionContent();
-      ErikaSurfaceOutputCapabilities capabilities{};
-      capabilities.direct_composition = true;
-      capabilities.fallback_reason = ErikaOutputFallbackReason_None;
-      Check(library->attach_wgpu_surface_with_output_capabilities(
-                handle, ErikaWgpuSurfaceKind_WindowsHwnd,
-                reinterpret_cast<uint64_t>(overlay.flutter), hinstance, width,
-                height, scale, capabilities),
-            "attach_wgpu_surface_with_output_capabilities",
-            library->TakeLastError());
-      attached_hwnd = overlay.flutter;
-      attached_overlay = &overlay;
-      RefreshCompositionContent();
-    } else {
-      Check(library->attach_windows_hwnd(
-                handle, reinterpret_cast<uint64_t>(overlay.hwnd), hinstance,
-                width, height, scale),
-            "attach_windows_hwnd", library->TakeLastError());
-      attached_hwnd = overlay.hwnd;
+    try {
+      overlay.SetCompositionMode(composition_surface);
+      if (composition_surface) {
+        overlay.ClearCompositionContent();
+        ErikaSurfaceOutputCapabilities capabilities{};
+        capabilities.direct_composition = true;
+        capabilities.fallback_reason = ErikaOutputFallbackReason_None;
+        CheckNative(library->attach_wgpu_surface_with_output_capabilities(
+                        handle, ErikaWgpuSurfaceKind_WindowsHwnd,
+                        reinterpret_cast<uint64_t>(overlay.flutter), hinstance,
+                        width, height, scale, capabilities),
+                    "attach_wgpu_surface_with_output_capabilities");
+        attached_hwnd = overlay.flutter;
+        attached_overlay = &overlay;
+        RefreshCompositionContent();
+      } else {
+        CheckNative(library->attach_windows_hwnd(
+                        handle, reinterpret_cast<uint64_t>(overlay.hwnd),
+                        hinstance, width, height, scale),
+                    "attach_windows_hwnd");
+        attached_hwnd = overlay.hwnd;
+        attached_overlay = nullptr;
+      }
+    } catch (...) {
+      if (composition_surface) {
+        try {
+          overlay.ClearCompositionContent();
+        } catch (const std::exception& error) {
+          DebugLog(std::string("DirectComposition attach rollback failed: ") +
+                   error.what());
+        }
+      }
+      library->detach_surface(handle);
+      attached_hwnd = nullptr;
       attached_overlay = nullptr;
+      attached_view_id = 0;
+      surface_attached = false;
+      composition_surface = false;
+      attached_surface_width = 0;
+      attached_surface_height = 0;
+      attached_surface_scale = 0.0;
+      if (overlay.owner_player_id == id) {
+        overlay.owner_player_id = 0;
+      }
+      throw;
     }
     attached_view_id = kWindowOverlayViewId;
     surface_attached = true;
@@ -2025,6 +2283,64 @@ struct ErikaFlutterPlugin::PlayerHost {
     attached_surface_height = height;
     attached_surface_scale = scale;
     start_time_seconds = NowSeconds();
+  }
+
+  void AttachFlutterTexture(ErikaFlutterTexture& texture) {
+    if (texture.owner_player_id != 0 && texture.owner_player_id != id) {
+      throw PluginError("Erika Flutter texture " +
+                        std::to_string(texture.texture_id) +
+                        " is already attached to another player.");
+    }
+    if (surface_attached) {
+      Detach(std::nullopt);
+    }
+    const auto status = library->attach_flutter_texture(
+        handle, ErikaFlutterTextureKind_WindowsTextureRegistrar,
+        texture.texture_id, texture.width, texture.height, texture.scale);
+    Check(status, "attach_flutter_texture",
+          status == ErikaStatus_Ok ? std::string{} : library->TakeLastError());
+    texture.owner_player_id = id;
+    attached_texture = &texture;
+    attached_view_id = texture.texture_id;
+    surface_attached = true;
+    composition_surface = false;
+    attached_surface_width = texture.width;
+    attached_surface_height = texture.height;
+    attached_surface_scale = texture.scale;
+    start_time_seconds = NowSeconds();
+  }
+
+  void ResizeFlutterTexture(ErikaFlutterTexture& texture,
+                            uint32_t width,
+                            uint32_t height,
+                            double scale) {
+    texture.Resize(width, height, scale);
+    if (!surface_attached || attached_texture != &texture) {
+      return;
+    }
+    if (width == attached_surface_width && height == attached_surface_height &&
+        std::abs(scale - attached_surface_scale) < 0.0001) {
+      return;
+    }
+    const auto status = library->resize_surface(handle, width, height, scale);
+    Check(status, "resize_surface",
+          status == ErikaStatus_Ok ? std::string{} : library->TakeLastError());
+    attached_surface_width = width;
+    attached_surface_height = height;
+    attached_surface_scale = scale;
+  }
+
+  void RefreshFlutterTexture() {
+    if (attached_texture == nullptr) {
+      return;
+    }
+    void* raw_texture = nullptr;
+    const auto status =
+        library->windows_flutter_texture(handle, &raw_texture);
+    Check(status, "windows_flutter_texture_iunknown",
+          status == ErikaStatus_Ok ? std::string{} : library->TakeLastError());
+    attached_texture->UpdateNativeTexture(raw_texture);
+    attached_texture->MarkFrameAvailable();
   }
 
   void ResizeOverlay(ErikaOverlayWindow& overlay) {
@@ -2040,8 +2356,8 @@ struct ErikaFlutterPlugin::PlayerHost {
         std::abs(scale - attached_surface_scale) < 0.0001) {
       return;
     }
-    Check(library->resize_surface(handle, width, height, scale),
-          "resize_surface", library->TakeLastError());
+    CheckNative(library->resize_surface(handle, width, height, scale),
+                "resize_surface");
     attached_surface_width = width;
     attached_surface_height = height;
     attached_surface_scale = scale;
@@ -2065,9 +2381,8 @@ struct ErikaFlutterPlugin::PlayerHost {
           "swap chain. Update the bundled Erika runtime.");
     }
     void* swapchain = nullptr;
-    Check(library->windows_composition_swapchain(handle, &swapchain),
-          "windows_composition_swapchain_iunknown",
-          library->TakeLastError());
+    CheckNative(library->windows_composition_swapchain(handle, &swapchain),
+                "windows_composition_swapchain_iunknown");
     attached_overlay->SetCompositionContent(swapchain);
   }
 
@@ -2086,6 +2401,10 @@ struct ErikaFlutterPlugin::PlayerHost {
     }
     attached_hwnd = nullptr;
     attached_overlay = nullptr;
+    if (attached_texture != nullptr && attached_texture->owner_player_id == id) {
+      attached_texture->owner_player_id = 0;
+    }
+    attached_texture = nullptr;
     composition_surface = false;
     attached_view_id = 0;
     surface_attached = false;
@@ -2106,7 +2425,14 @@ struct ErikaFlutterPlugin::PlayerHost {
                  library->TakeLastError());
       } else {
         latest_presenter_stats = stats;
-        if (composition_surface) {
+        if (attached_texture != nullptr) {
+          try {
+            RefreshFlutterTexture();
+          } catch (const std::exception& error) {
+            DebugLog(std::string("Flutter texture publication failed: ") +
+                     error.what());
+          }
+        } else if (composition_surface) {
           try {
             RefreshCompositionContent();
           } catch (const std::exception& error) {
@@ -2285,6 +2611,7 @@ struct ErikaFlutterPlugin::PlayerHost {
   ErikaPresenterHandle* handle = nullptr;
   HWND attached_hwnd = nullptr;
   ErikaOverlayWindow* attached_overlay = nullptr;
+  ErikaFlutterTexture* attached_texture = nullptr;
   int64_t attached_view_id = 0;
   bool surface_attached = false;
   bool composition_surface = false;
@@ -2357,6 +2684,9 @@ ErikaFlutterPlugin::~ErikaFlutterPlugin() {
   }
   if (event_channel_) {
     event_channel_->SetStreamHandler(nullptr);
+  }
+  while (!textures_.empty()) {
+    ReleaseTexture(textures_.begin()->first);
   }
   players_.clear();
   overlay_window_.reset();
@@ -2758,6 +3088,57 @@ ErikaFlutterPlugin::PlayerHost& ErikaFlutterPlugin::PlayerFromArgs(
   return *it->second;
 }
 
+ErikaFlutterPlugin::ErikaFlutterTexture& ErikaFlutterPlugin::TextureFromArgs(
+    const EncodableMap& args) {
+  const int64_t texture_id = RequiredInt64(args, "textureId");
+  const auto it = textures_.find(texture_id);
+  if (it == textures_.end()) {
+    throw PluginError("Erika Flutter texture " + std::to_string(texture_id) +
+                      " was not found.");
+  }
+  return *it->second;
+}
+
+int64_t ErikaFlutterPlugin::CreateTexture(const EncodableMap& args) {
+  const int64_t requested_width = RequiredInt64(args, "width");
+  const int64_t requested_height = RequiredInt64(args, "height");
+  const double scale = DoubleValue(FindArg(args, "scale")).value_or(1.0);
+  if (requested_width <= 0 || requested_width > UINT32_MAX ||
+      requested_height <= 0 || requested_height > UINT32_MAX ||
+      !std::isfinite(scale) || scale <= 0.0) {
+    throw PluginError("Flutter texture metrics must be finite and positive.");
+  }
+  auto texture = std::make_shared<ErikaFlutterTexture>(
+      registrar_, static_cast<uint32_t>(requested_width),
+      static_cast<uint32_t>(requested_height), scale);
+  const int64_t texture_id = texture->texture_id;
+  textures_.emplace(texture_id, std::move(texture));
+  DebugLog("registered Flutter GPU texture id=" +
+           std::to_string(texture_id));
+  return texture_id;
+}
+
+void ErikaFlutterPlugin::ReleaseTexture(int64_t texture_id) {
+  const auto it = textures_.find(texture_id);
+  if (it == textures_.end()) {
+    return;
+  }
+  auto texture = it->second;
+  if (texture->owner_player_id != 0) {
+    const auto player = players_.find(texture->owner_player_id);
+    if (player != players_.end()) {
+      player->second->Detach(texture_id);
+    }
+  }
+  textures_.erase(it);
+  registrar_->texture_registrar()->UnregisterTexture(
+      texture_id, [texture = std::move(texture)]() mutable {
+        texture.reset();
+      });
+  DebugLog("unregistered Flutter GPU texture id=" +
+           std::to_string(texture_id));
+}
+
 void ErikaFlutterPlugin::ResizeAttachedOverlay() {
   if (!overlay_window_) {
     return;
@@ -2928,6 +3309,31 @@ void ErikaFlutterPlugin::HandleMethodCall(
     if (method == "dispose") {
       RemovePlayer(RequiredInt64(args, "playerId"));
       OnFrameTimer();
+      result->Success();
+    } else if (method == "createTexture") {
+      result->Success(EncodableValue(CreateTexture(args)));
+    } else if (method == "resizeTexture") {
+      auto& texture = TextureFromArgs(args);
+      const int64_t width = RequiredInt64(args, "width");
+      const int64_t height = RequiredInt64(args, "height");
+      const double scale = DoubleValue(FindArg(args, "scale")).value_or(1.0);
+      if (width <= 0 || width > UINT32_MAX || height <= 0 ||
+          height > UINT32_MAX || !std::isfinite(scale) || scale <= 0.0) {
+        throw PluginError("Flutter texture metrics must be finite and positive.");
+      }
+      const auto player = players_.find(texture.owner_player_id);
+      if (player != players_.end()) {
+        player->second->ResizeFlutterTexture(
+            texture, static_cast<uint32_t>(width),
+            static_cast<uint32_t>(height), scale);
+      } else {
+        texture.Resize(static_cast<uint32_t>(width),
+                       static_cast<uint32_t>(height), scale);
+      }
+      OnFrameTimer();
+      result->Success();
+    } else if (method == "releaseTexture") {
+      ReleaseTexture(RequiredInt64(args, "textureId"));
       result->Success();
     } else if (method == "open") {
       auto& player = PlayerFromArgs(args);
@@ -3172,8 +3578,15 @@ void ErikaFlutterPlugin::HandleMethodCall(
       auto& host = PlayerFromArgs(args);
       const int64_t view_id = RequiredInt64(args, "viewId");
       if (view_id != kWindowOverlayViewId) {
-        throw PluginError("Erika video view " + std::to_string(view_id) +
-                          " was not found.");
+        const auto texture = textures_.find(view_id);
+        if (texture == textures_.end()) {
+          throw PluginError("Erika video view " + std::to_string(view_id) +
+                            " was not found.");
+        }
+        host.AttachFlutterTexture(*texture->second);
+        OnFrameTimer();
+        result->Success();
+        return;
       }
       auto& overlay = EnsureOverlayWindow();
       overlay.ConfigureComposition(

--- a/packages/erika_flutter/windows/erika_flutter_plugin.h
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.h
@@ -67,6 +67,7 @@ class ErikaFlutterPlugin : public flutter::Plugin {
  private:
   struct ErikaNativeLibrary;
   struct ErikaOverlayWindow;
+  struct ErikaFlutterTexture;
   struct PlayerHost;
 
   friend class ErikaEventStreamHandler;
@@ -97,6 +98,9 @@ class ErikaFlutterPlugin : public flutter::Plugin {
   HWND RequestedOverlayFlutterWindow() const;
   void UpdateOverlayTarget(const flutter::EncodableMap& args);
   PlayerHost& PlayerFromArgs(const flutter::EncodableMap& args);
+  ErikaFlutterTexture& TextureFromArgs(const flutter::EncodableMap& args);
+  int64_t CreateTexture(const flutter::EncodableMap& args);
+  void ReleaseTexture(int64_t texture_id);
   void ResizeAttachedOverlay();
   int64_t CreatePlayer(const flutter::EncodableValue* arguments);
   void RemovePlayer(int64_t player_id);
@@ -111,6 +115,7 @@ class ErikaFlutterPlugin : public flutter::Plugin {
       event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
   std::unordered_map<int64_t, std::unique_ptr<PlayerHost>> players_;
+  std::unordered_map<int64_t, std::shared_ptr<ErikaFlutterTexture>> textures_;
   std::unique_ptr<ErikaOverlayWindow> overlay_window_;
   std::unique_ptr<ErikaWindowsSmtc> smtc_;
   int64_t active_player_id_ = 0;

--- a/packages/erika_flutter/windows/erika_flutter_plugin.h
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.h
@@ -71,6 +71,7 @@ class ErikaFlutterPlugin : public flutter::Plugin {
   struct PlayerHost;
 
   friend class ErikaEventStreamHandler;
+  friend class ErikaFlutterPluginTestPeer;
 
   HWND FlutterWindow() const;
   double BackingScale() const;

--- a/packages/erika_flutter/windows/erika_flutter_plugin.h
+++ b/packages/erika_flutter/windows/erika_flutter_plugin.h
@@ -69,6 +69,7 @@ class ErikaFlutterPlugin : public flutter::Plugin {
   struct ErikaOverlayWindow;
   struct ErikaFlutterTexture;
   struct PlayerHost;
+  using PlayerMap = std::unordered_map<int64_t, std::unique_ptr<PlayerHost>>;
 
   friend class ErikaEventStreamHandler;
   friend class ErikaFlutterPluginTestPeer;
@@ -96,6 +97,16 @@ class ErikaFlutterPlugin : public flutter::Plugin {
                                               LPARAM lparam);
 
   ErikaOverlayWindow& EnsureOverlayWindow();
+  static void RecreateOverlayWindow(
+      const PlayerMap& players,
+      std::unique_ptr<ErikaOverlayWindow>& overlay,
+      HWND parent);
+  static void AttachOverlayPlayer(const PlayerMap& players,
+                                  PlayerHost& host,
+                                  ErikaOverlayWindow& overlay);
+  static bool DetachOverlayPlayer(PlayerHost& host,
+                                  ErikaOverlayWindow* overlay,
+                                  std::optional<int64_t> generation);
   HWND RequestedOverlayFlutterWindow() const;
   void UpdateOverlayTarget(const flutter::EncodableMap& args);
   PlayerHost& PlayerFromArgs(const flutter::EncodableMap& args);
@@ -115,7 +126,7 @@ class ErikaFlutterPlugin : public flutter::Plugin {
   std::unique_ptr<flutter::EventChannel<flutter::EncodableValue>>
       event_channel_;
   std::unique_ptr<flutter::EventSink<flutter::EncodableValue>> event_sink_;
-  std::unordered_map<int64_t, std::unique_ptr<PlayerHost>> players_;
+  PlayerMap players_;
   std::unordered_map<int64_t, std::shared_ptr<ErikaFlutterTexture>> textures_;
   std::unique_ptr<ErikaOverlayWindow> overlay_window_;
   std::unique_ptr<ErikaWindowsSmtc> smtc_;

--- a/packages/erika_flutter/windows/erika_texture_publication.h
+++ b/packages/erika_flutter/windows/erika_texture_publication.h
@@ -1,0 +1,88 @@
+// Copyright (c) Aimes Soft and contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <d3d11.h>
+#include <dxgi.h>
+#include <flutter_texture_registrar.h>
+#include <wrl/client.h>
+
+#include <memory>
+#include <mutex>
+#include <utility>
+
+namespace erika_flutter {
+
+// Publish only completed, immutable GPU textures. The UI thread owns latest_,
+// while Flutter's raster callback pins sampled_ until its next invocation.
+// The descriptor therefore also survives the engine's reads AFTER opening the
+// handle. No frame-count timeout or release_callback is a lifetime guarantee.
+// Destroy this object only after UnregisterTexture's completion callback.
+class ErikaTexturePublication {
+ public:
+  HRESULT Update(void* raw_texture, bool& changed) {
+    changed = false;
+    Microsoft::WRL::ComPtr<IUnknown> unknown;
+    unknown.Attach(static_cast<IUnknown*>(raw_texture));
+    if (!unknown) {
+      return E_POINTER;
+    }
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    HRESULT status = unknown.As(&texture);
+    if (FAILED(status)) {
+      return status;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (latest_ && latest_->texture.Get() == texture.Get()) {
+      return S_OK;
+    }
+    Microsoft::WRL::ComPtr<IDXGIResource> resource;
+    status = texture.As(&resource);
+    if (FAILED(status)) {
+      return status;
+    }
+    HANDLE handle = nullptr;
+    status = resource->GetSharedHandle(&handle);
+    if (FAILED(status) || handle == nullptr) {
+      return FAILED(status) ? status : E_HANDLE;
+    }
+    auto next = std::make_shared<Snapshot>();
+    D3D11_TEXTURE2D_DESC desc{};
+    texture->GetDesc(&desc);
+    next->texture = std::move(texture);
+    next->descriptor.struct_size = sizeof(FlutterDesktopGpuSurfaceDescriptor);
+    next->descriptor.handle = handle;
+    next->descriptor.width = desc.Width;
+    next->descriptor.height = desc.Height;
+    next->descriptor.visible_width = desc.Width;
+    next->descriptor.visible_height = desc.Height;
+    next->descriptor.format = kFlutterDesktopPixelFormatBGRA8888;
+    latest_ = std::move(next);
+    changed = true;
+    return S_OK;
+  }
+
+  // Called serially on Flutter's raster thread. UI publication never mutates
+  // sampled_ or its descriptor, including while Flutter is opening a handle.
+  const FlutterDesktopGpuSurfaceDescriptor* AcquireDescriptor() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    sampled_ = latest_;
+    return sampled_ ? &sampled_->descriptor : nullptr;
+  }
+
+  void Clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_.reset();
+  }
+
+ private:
+  struct Snapshot {
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    FlutterDesktopGpuSurfaceDescriptor descriptor{};
+  };
+  std::mutex mutex_;
+  std::shared_ptr<Snapshot> latest_;
+  std::shared_ptr<Snapshot> sampled_;
+};
+
+}  // namespace erika_flutter

--- a/packages/erika_flutter/windows/tests/CMakeLists.txt
+++ b/packages/erika_flutter/windows/tests/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.14)
+project(erika_windows_tests LANGUAGES CXX)
+
+if(NOT EXISTS "${FLUTTER_ENGINE_DIR}/flutter_texture_registrar.h")
+  message(FATAL_ERROR "Set FLUTTER_ENGINE_DIR to Flutter's cached Windows engine directory")
+endif()
+enable_testing()
+add_executable(texture_publication_test texture_publication_test.cpp)
+target_compile_features(texture_publication_test PRIVATE cxx_std_17)
+target_compile_definitions(texture_publication_test PRIVATE NOMINMAX)
+target_include_directories(texture_publication_test PRIVATE "${FLUTTER_ENGINE_DIR}")
+target_link_libraries(texture_publication_test PRIVATE d3d11 dxgi)
+add_test(NAME texture_publication COMMAND texture_publication_test)
+
+# Compile/link the real plugin as well, without needing to create a Flutter
+# window or run the Composition graph during these headless native checks.
+add_library(plugin_build_check SHARED
+  ../erika_flutter_plugin.cpp
+  ../erika_flutter_plugin_c_api.cpp
+  ../erika_windows_smtc.cpp
+  "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/core_implementations.cc"
+  "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/plugin_registrar.cc"
+  "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/standard_codec.cc")
+target_compile_features(plugin_build_check PRIVATE cxx_std_17)
+target_compile_options(plugin_build_check PRIVATE /W4 /WX /wd4100 /EHsc /utf-8)
+target_compile_definitions(plugin_build_check PRIVATE
+  FLUTTER_PLUGIN_IMPL _HAS_EXCEPTIONS=0 _WIN32_WINNT=0x0A00 WINVER=0x0A00
+  _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+target_include_directories(plugin_build_check PRIVATE
+  .. ../../native/include "${FLUTTER_ENGINE_DIR}"
+  "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/include")
+target_link_libraries(plugin_build_check PRIVATE
+  "${FLUTTER_ENGINE_DIR}/flutter_windows.dll.lib"
+  runtimeobject windowsapp CoreMessaging d3d11 dxgi shcore shlwapi)
+
+if(ERIKA_COMPAT_DLL OR ERIKA_SOURCE_DLL)
+  add_executable(player_lifecycle_test player_lifecycle_test.cpp
+    ../erika_windows_smtc.cpp
+    "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/core_implementations.cc"
+    "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/plugin_registrar.cc"
+    "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/standard_codec.cc")
+  target_compile_features(player_lifecycle_test PRIVATE cxx_std_17)
+  target_compile_options(player_lifecycle_test PRIVATE /EHsc /utf-8)
+  target_compile_definitions(player_lifecycle_test PRIVATE
+    FLUTTER_PLUGIN_IMPL _HAS_EXCEPTIONS=0 _WIN32_WINNT=0x0A00 WINVER=0x0A00
+    _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+  target_include_directories(player_lifecycle_test PRIVATE
+    .. ../../native/include "${FLUTTER_ENGINE_DIR}"
+    "${FLUTTER_ENGINE_DIR}/cpp_client_wrapper/include")
+  target_link_libraries(player_lifecycle_test PRIVATE
+    "${FLUTTER_ENGINE_DIR}/flutter_windows.dll.lib"
+    runtimeobject windowsapp CoreMessaging d3d11 dxgi shcore shlwapi)
+  add_custom_command(TARGET player_lifecycle_test POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${FLUTTER_ENGINE_DIR}/flutter_windows.dll" "$<TARGET_FILE_DIR:player_lifecycle_test>")
+  if(ERIKA_COMPAT_DLL)
+    # The released v0.1.7 DLL predates the danmaku-worker join fix. This fixture
+    # tests API compatibility, not hot-unloading that unpatched binary.
+    add_test(NAME released_runtime_compatibility COMMAND player_lifecycle_test
+      "${ERIKA_COMPAT_DLL}" --keep-runtime-loaded)
+  endif()
+  if(ERIKA_SOURCE_DLL)
+    add_test(NAME source_texture_lifecycle COMMAND player_lifecycle_test "${ERIKA_SOURCE_DLL}")
+  endif()
+endif()

--- a/packages/erika_flutter/windows/tests/player_lifecycle_test.cpp
+++ b/packages/erika_flutter/windows/tests/player_lifecycle_test.cpp
@@ -1,0 +1,110 @@
+// Include the implementation so the test peer exercises the actual internal
+// PlayerHost and native-library loader, without starting a Flutter/DWM window.
+#include "../erika_flutter_plugin.cpp"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace erika_flutter {
+
+class ErikaFlutterPluginTestPeer {
+ public:
+  static void Require(bool value) { if (!value) std::abort(); }
+
+  class Registrar : public flutter::TextureRegistrar {
+   public:
+    int marked_frames = 0;
+    int64_t RegisterTexture(flutter::TextureVariant*) override { return 13; }
+    bool MarkTextureFrameAvailable(int64_t) override {
+      ++marked_frames;
+      return true;
+    }
+    void UnregisterTexture(int64_t, std::function<void()> callback) override {
+      if (callback) callback();
+    }
+    bool UnregisterTexture(int64_t) override { return true; }
+  };
+
+  static void Run() {
+    auto library = ErikaFlutterPlugin::ErikaNativeLibrary::Shared();
+    ErikaPresenterConfig config{};
+    Registrar registrar;
+    ErikaFlutterPlugin::ErikaFlutterTexture texture(&registrar, 4, 4, 1.0);
+    if (library->attach_flutter_texture && library->windows_flutter_texture) {
+      // When run against a source-built DLL, exercise the actual bridge all
+      // the way to D3D11 too; no replacement function pointers in this block.
+      {
+        ErikaFlutterPlugin::PlayerHost player(4, library, config);
+        player.AttachFlutterTexture(texture);
+        player.RenderTick(nullptr);
+        Require(registrar.marked_frames == 1);
+        const auto* first = texture.publication.AcquireDescriptor();
+        Require(first && first->width == 4 && first->height == 4);
+        for (int i = 0; i < 10; ++i) player.RenderTick(nullptr);
+        Require(registrar.marked_frames == 1);
+        player.ResizeFlutterTexture(texture, 8, 6, 1.0);
+        player.RenderTick(nullptr);
+        Require(registrar.marked_frames == 2);
+        Require(first->width == 4 && first->height == 4);
+        const auto* resized = texture.publication.AcquireDescriptor();
+        Require(resized && resized->width == 8 && resized->height == 6);
+      }
+      Require(texture.owner_player_id == 0);
+      Require(texture.publication.AcquireDescriptor() == nullptr);
+      std::cout << "source runtime texture attach, idle, resize and disposal passed\n";
+    }
+    // Load the bundled runtime (including v0.1.7 without texture symbols).
+    // Also exercise absence when a future bundled runtime provides them.
+    library->attach_flutter_texture = nullptr;
+    library->windows_flutter_texture = nullptr;
+    {
+      ErikaFlutterPlugin::PlayerHost player(1, library, config);
+      Require(player.handle != nullptr);
+      player.surface_attached = true;
+      bool rejected = false;
+      try {
+        player.AttachFlutterTexture(texture);
+      } catch (const std::exception&) { rejected = true; }
+      Require(rejected && player.surface_attached); // Failed opt-in is atomic.
+      player.surface_attached = false;
+    }
+
+    // Supply only the new attachment capability; player creation/destruction
+    // still use the real released DLL. This isolates the plugin ownership bug.
+    library->attach_flutter_texture = [](ErikaPresenterHandle*, ErikaFlutterTextureKind,
+        int64_t, uint32_t, uint32_t, double) { return ErikaStatus_Ok; };
+    library->windows_flutter_texture = [](ErikaPresenterHandle*, void**) {
+      return ErikaStatus_PlayerError;
+    };
+    {
+      ErikaFlutterPlugin::PlayerHost player(2, library, config);
+      player.AttachFlutterTexture(texture);
+      Require(texture.owner_player_id == 2);
+    }
+    Require(texture.owner_player_id == 0);
+    {
+      ErikaFlutterPlugin::PlayerHost replacement(3, library, config);
+      replacement.AttachFlutterTexture(texture);
+      Require(texture.owner_player_id == 3);
+    }
+    Require(texture.owner_player_id == 0);
+  }
+};
+}  // namespace erika_flutter
+
+int wmain(int argc, wchar_t** argv) {
+  if (argc != 2 && argc != 3) return 1;
+  const bool keep_loaded = argc == 3 && wcscmp(argv[2], L"--keep-runtime-loaded") == 0;
+  if (argc == 3 && !keep_loaded) return 1;
+  if (!SetEnvironmentVariableW(L"ERIKA_CAPI_DLL", argv[1])) return 1;
+  // Compatibility-only fixture for released binaries with the pre-existing
+  // unjoined danmaku worker. Source-runtime tests MUST exercise real unloading.
+  if (keep_loaded && !LoadLibraryW(argv[1])) return 1;
+  erika_flutter::ErikaFlutterPluginTestPeer::Run();
+  if (!keep_loaded) {
+    erika_flutter::ErikaFlutterPluginTestPeer::Require(
+        GetModuleHandleW(argv[1]) == nullptr);
+    std::cout << "source runtime DLL unload passed\n";
+  }
+  std::cout << "runtime create/dispose, optional capability guard and texture owner cleanup passed\n";
+}

--- a/packages/erika_flutter/windows/tests/player_lifecycle_test.cpp
+++ b/packages/erika_flutter/windows/tests/player_lifecycle_test.cpp
@@ -25,8 +25,98 @@ class ErikaFlutterPluginTestPeer {
     bool UnregisterTexture(int64_t) override { return true; }
   };
 
+  inline static std::vector<ErikaPresenterHandle*> hwnd_attachments;
+  inline static bool fail_hwnd_attach = false;
+
+  static void RunOverlayOwnership(
+      const std::shared_ptr<ErikaFlutterPlugin::ErikaNativeLibrary>& library) {
+    const auto attach = library->attach_windows_hwnd;
+    const auto detach = library->detach_surface;
+    library->attach_windows_hwnd = [](ErikaPresenterHandle* player,
+        uint64_t, uint64_t, uint32_t, uint32_t, double) {
+      hwnd_attachments.push_back(player);
+      return fail_hwnd_attach ? ErikaStatus_PlayerError : ErikaStatus_Ok;
+    };
+    library->detach_surface = [](ErikaPresenterHandle*) { return ErikaStatus_Ok; };
+    // Hidden Win32 parents are sufficient to test actual overlay ownership
+    // logic. Only the native surface attachment is stubbed, not the owner map.
+    struct HiddenWindow {
+      HWND hwnd = CreateWindowExW(0, L"STATIC", L"Erika ownership test",
+          WS_POPUP, 0, 0, 1, 1, nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+      ~HiddenWindow() { if (hwnd) DestroyWindow(hwnd); }
+    };
+    {
+      HiddenWindow first_parent, second_parent;
+      Require(first_parent.hwnd && second_parent.hwnd);
+      auto overlay = std::make_unique<ErikaFlutterPlugin::ErikaOverlayWindow>(
+          first_parent.hwnd);
+      ErikaFlutterPlugin::PlayerMap players;
+      for (int64_t id : {11, 22, 33}) {
+        players.emplace(id, std::make_unique<ErikaFlutterPlugin::PlayerHost>(
+            id, library, ErikaPresenterConfig{}));
+      }
+      auto& original = *players.begin()->second; // Deliberately not the last entry.
+      for (const auto& entry : players) {
+        entry.second->attached_view_id = kWindowOverlayViewId;
+        entry.second->surface_attached = true;
+        entry.second->attached_hwnd = overlay->hwnd;
+      }
+      overlay->owner_player_id = original.id;
+      hwnd_attachments.clear();
+      ErikaFlutterPlugin::RecreateOverlayWindow(players, overlay, second_parent.hwnd);
+      Require(overlay->owner_player_id == original.id);
+      Require(hwnd_attachments.size() == 1 && hwnd_attachments[0] == original.handle);
+      Require(original.attached_hwnd == overlay->hwnd);
+      ErikaFlutterPlugin::PlayerHost* replacement = nullptr;
+      for (const auto& entry : players) {
+        if (entry.second.get() != &original) {
+          Require(!entry.second->surface_attached && entry.second->attached_view_id == 0);
+          replacement = entry.second.get();
+        }
+      }
+      Require(replacement != nullptr);
+      ErikaFlutterPlugin::AttachOverlayPlayer(players, *replacement, *overlay);
+      Require(!original.surface_attached && replacement->surface_attached);
+      Require(overlay->owner_player_id == replacement->id);
+      overlay->visible = true; // Test state without showing any window.
+      overlay->active_generation = 77;
+      Require(ErikaFlutterPlugin::DetachOverlayPlayer(original, overlay.get(), std::nullopt));
+      Require(overlay->visible && overlay->owner_player_id == replacement->id);
+      Require(!ErikaFlutterPlugin::DetachOverlayPlayer(*replacement, overlay.get(), 76));
+      Require(replacement->surface_attached && overlay->visible);
+      Require(ErikaFlutterPlugin::DetachOverlayPlayer(*replacement, overlay.get(), 77));
+      Require(!replacement->surface_attached && !overlay->visible && overlay->owner_player_id == 0);
+
+      // Hidden/unowned overlays must not acquire an arbitrary stale producer.
+      original.attached_view_id = kWindowOverlayViewId;
+      original.surface_attached = true;
+      hwnd_attachments.clear();
+      ErikaFlutterPlugin::RecreateOverlayWindow(players, overlay, first_parent.hwnd);
+      Require(hwnd_attachments.empty() && overlay->owner_player_id == 0);
+      Require(!original.surface_attached);
+      overlay->owner_player_id = original.id; // Stale ID without an attachment.
+      ErikaFlutterPlugin::RecreateOverlayWindow(players, overlay, second_parent.hwnd);
+      Require(hwnd_attachments.empty() && overlay->owner_player_id == 0);
+
+      // A failed takeover must not retain the previous player's ownership.
+      ErikaFlutterPlugin::AttachOverlayPlayer(players, original, *overlay);
+      fail_hwnd_attach = true;
+      bool rejected = false;
+      try {
+        ErikaFlutterPlugin::AttachOverlayPlayer(players, *replacement, *overlay);
+      } catch (const std::exception&) { rejected = true; }
+      fail_hwnd_attach = false;
+      Require(rejected && overlay->owner_player_id == 0);
+      Require(!original.surface_attached && !replacement->surface_attached);
+    }
+    library->attach_windows_hwnd = attach;
+    library->detach_surface = detach;
+    std::cout << "overlay owner preservation, exclusive takeover and stale detach protection passed\n";
+  }
+
   static void Run() {
     auto library = ErikaFlutterPlugin::ErikaNativeLibrary::Shared();
+    RunOverlayOwnership(library);
     ErikaPresenterConfig config{};
     Registrar registrar;
     ErikaFlutterPlugin::ErikaFlutterTexture texture(&registrar, 4, 4, 1.0);

--- a/packages/erika_flutter/windows/tests/texture_publication_test.cpp
+++ b/packages/erika_flutter/windows/tests/texture_publication_test.cpp
@@ -1,0 +1,101 @@
+#include "../erika_texture_publication.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using Microsoft::WRL::ComPtr;
+using erika_flutter::ErikaTexturePublication;
+
+void Require(bool condition) {
+  if (!condition) {
+    std::cerr << "texture publication assertion failed\n";
+    std::abort();
+  }
+}
+
+ComPtr<ID3D11Texture2D> Texture(ID3D11Device* device, UINT width) {
+  D3D11_TEXTURE2D_DESC desc{};
+  desc.Width = width;
+  desc.Height = 4;
+  desc.MipLevels = desc.ArraySize = desc.SampleDesc.Count = 1;
+  desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+  desc.Usage = D3D11_USAGE_DEFAULT;
+  desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+  desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+  ComPtr<ID3D11Texture2D> texture;
+  Require(SUCCEEDED(device->CreateTexture2D(&desc, nullptr, &texture)));
+  return texture;
+}
+
+bool Publish(ErikaTexturePublication& publication, ID3D11Texture2D* texture) {
+  texture->AddRef(); // Same owned-reference contract as the Rust C API.
+  bool changed = false;
+  Require(SUCCEEDED(publication.Update(texture, changed)));
+  return changed;
+}
+
+ULONG RefCount(ID3D11Texture2D* texture) {
+  texture->AddRef();
+  return texture->Release();
+}
+
+int main() {
+  ComPtr<ID3D11Device> device;
+  Require(SUCCEEDED(D3D11CreateDevice(
+      nullptr, D3D_DRIVER_TYPE_WARP, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+      nullptr, 0, D3D11_SDK_VERSION, &device, nullptr, nullptr)));
+  ErikaTexturePublication publication;
+  auto first = Texture(device.Get(), 4);
+  const auto baseline = RefCount(first.Get());
+  Require(Publish(publication, first.Get()));
+  Require(!Publish(publication, first.Get())); // Paused: no new notification.
+  const auto* descriptor = publication.AcquireDescriptor();
+  Require(descriptor && descriptor->width == 4);
+  const auto first_handle = descriptor->handle;
+
+  // Flutter may still be reading the first descriptor while arbitrarily many
+  // intermediate resize publications are replaced without ever being opened.
+  std::vector<ComPtr<ID3D11Texture2D>> skipped;
+  for (UINT i = 0; i < 100; ++i) {
+    auto texture = Texture(device.Get(), 8 + i);
+    Require(Publish(publication, texture.Get()));
+    skipped.push_back(std::move(texture));
+  }
+  Require(descriptor->width == 4 && descriptor->handle == first_handle);
+  for (size_t i = 0; i + 1 < skipped.size(); ++i) {
+    Require(RefCount(skipped[i].Get()) == baseline);
+  }
+  Require(RefCount(first.Get()) > baseline);
+  Require(publication.AcquireDescriptor()->width == 107);
+  Require(RefCount(first.Get()) == baseline);
+  publication.Clear();
+  Require(publication.AcquireDescriptor() == nullptr);
+  Require(RefCount(skipped.back().Get()) == baseline);
+
+  auto a = Texture(device.Get(), 8);
+  auto b = Texture(device.Get(), 16);
+  std::atomic<bool> done{false};
+  std::thread raster([&] {
+    while (!done.load()) {
+      const auto* frame = publication.AcquireDescriptor();
+      if (frame) {
+        const auto width = frame->width;
+        std::this_thread::yield();
+        Require((width == 8 || width == 16) && frame->width == width);
+      }
+    }
+  });
+  for (int i = 0; i < 10000; ++i) {
+    Publish(publication, (i % 2 == 0 ? a : b).Get());
+    if (i % 5 == 0) publication.Clear();
+  }
+  done.store(true);
+  raster.join();
+  publication.Clear();
+  publication.AcquireDescriptor();
+  Require(RefCount(a.Get()) == baseline && RefCount(b.Get()) == baseline);
+  std::cout << "publication lifetime, skipped resize reclamation, idle and concurrent access passed\n";
+}


### PR DESCRIPTION
## 问题

Windows 扫描线视频的 `overlay` 路径此前把一个没有连接两个有效输入的 `IDCompositionBlendEffect` 直接挂到根 visual。该图由 DWM 异步解析，插件侧提交可能成功，但系统事件日志会连续出现：

- `dwm.exe` 在 `dwmcore.dll` 崩溃；
- `0x8899001e (D2DERR_INVALID_GRAPH_CONFIGURATION)`；
- `0x88990016 (D2DERR_PUSH_POP_UNBALANCED)`。

DWM 反复重启会造成整屏闪烁、DPI/缩放异常、窗口退化、SakiEngine 白屏和游戏无响应。`IDCompositionBlendEffect` 是双输入 filter 节点，并不会自动把 Flutter HWND 后面的内容作为 Overlay 背景，原实现的 effect graph 本身不合法。

Windows 视频链路还同时存在 D3D11VA 帧过早归还以及普通 Flutter 视频纹理发布问题。

## 修改

- 保留 GPU/DWM 原生合成，不使用软件、CPU 或子窗口回退。
- 用 Windows Composition 的 `CompositionBackdropBrush` 显式取得 Flutter 背景。
- 将 backdrop 与 Erika 视频 swapchain surface 作为 D2D Overlay effect 的两个明确输入；effect factory 在应用进程内校验图，不再向 DWM 提交未接线的 `IDCompositionBlendEffect`。
- 继续通过桌面 composition target 绑定 Flutter HWND，扫描线视频仍由 DWM/GPU 合成。
- DispatcherQueue 按 Flutter UI 线程持有，避免 overlay/HWND 替换时关闭旧队列并使新 Compositor 异步失效。
- 隐藏、解绑和销毁时先移除 composition root，再释放 surface、brush、target 与 compositor。
- 使用完整 RenderBox 变换矩阵计算原生 overlay 矩形，确保 `FittedBox` 的缩放同时作用于位置和宽高，扫描线视频能铺满目标区域。
- 将 D3D11VA 表面池的额外帧预算严格限制在 Windows 条件编译范围内，避免破坏 Android、macOS 与 OpenHarmony 构建。
- 保留原修复：使用 D3D11 EVENT query 持有 GPU 尚未消费完的 AVFrame、扩充 D3D11VA 表面池，并为普通 Windows 视频注册 DXGI `GpuSurfaceTexture`。

## 验证

- Windows SDK 错误码静态核对完成，崩溃签名与非法 effect graph 一致。
- Windows Flutter 插件 Debug 配置已完成纯编译和链接，`erika_flutter_plugin.dll` 成功生成。
- Windows 合成源码契约测试通过（10/10），并新增反向断言，禁止裸 `IDCompositionBlendEffect` 路径回归。
- mocked Flutter widget 测试验证 320×180 overlay 经 `FittedBox` 放大后向 native 发送 640×360，`erika_player_test.dart` 全部 55 项通过。
- `cargo fmt --all -- --check` 与 `git diff --check` 通过。
- 未启动 SakiEngine、少女蕾或任何合成窗口；未进行可能触发死机的运行时测试。


