### PR TITLE
refactor(presenter): decouple audio delivery from rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 ### Playback
 
+- Audio output now has a dedicated owner for PCM delivery, clock observations,
+  device recovery and playback-rate commits. Rendering stalls no longer stop
+  audio feeding. Acknowledged control boundaries preserve pause, seek, track
+  changes, EOF/replay and shutdown ordering with the existing 250 ms rate bridge.
 - Host-provided Metal layers explicitly retain the finite drawable timeout
   (up to one second before returning nil); skipped presents are counted with
   throttled diagnostics.

--- a/crates/erika/src/audio.rs
+++ b/crates/erika/src/audio.rs
@@ -11,7 +11,7 @@ use crate::trace;
 pub(crate) mod spsc;
 
 // Keep enough old-rate PCM to cover SoundTouch startup and one normal output
-// prefill. The presenter commits the media clock at the end of this bridge.
+// prefill. The audio owner commits the media clock at the end of this bridge.
 pub(crate) const AUDIO_OUTPUT_QUEUE_HIGH_WATER: Duration = Duration::from_millis(250);
 const RATE_CHANGE_AUDIO_BRIDGE: Duration = AUDIO_OUTPUT_QUEUE_HIGH_WATER;
 const SOUNDTOUCH_SEQUENCE_MS: i32 = 25;
@@ -778,7 +778,7 @@ pub trait AudioOutputBackend {
     fn volume(&self) -> f32;
     fn set_playback_rate(&mut self, _rate: f64) {}
     /// Returns false while the output owns enough queued PCM to preserve the
-    /// bounded playback-rate transition latency. The presenter leaves decoded
+    /// bounded playback-rate transition latency. The audio owner leaves decoded
     /// frames in the worker channel, which applies backpressure safely.
     fn can_accept_audio_frame(&self) -> bool {
         true

--- a/crates/erika/src/presenter.rs
+++ b/crates/erika/src/presenter.rs
@@ -11,28 +11,12 @@ use std::{
 
 use crossbeam_channel::{Receiver, Sender};
 
-#[cfg(target_os = "android")]
-use crate::android::aaudio::{AAudioOutput, AAudioOutputConfig};
-#[cfg(target_os = "macos")]
-use crate::apple::coreaudio::{CoreAudioOutput, CoreAudioOutputConfig};
-#[cfg(any(target_os = "ios", target_os = "tvos"))]
-use crate::apple::iosaudio::{IosAudioQueueOutput, IosAudioQueueOutputConfig};
-#[cfg(not(any(
-    target_os = "android",
-    target_os = "macos",
-    any(target_os = "ios", target_os = "tvos"),
-    target_os = "windows",
-    target_env = "ohos"
-)))]
-use crate::audio::BufferedAudioOutput;
-use crate::audio::{
-    AudioClockSnapshot, AudioOutputBackend, AudioOutputRuntimeStats, AudioRingBufferConfig,
-};
+use crate::audio::{AudioOutputRuntimeStats, AudioRingBufferConfig};
 use crate::core::{
-    AudioOutputEvent, MediaRequest, PlatformSurface, PlaybackSnapshot, Player, PlayerAudioFrame,
-    PlayerConfig, PlayerSubtitleFrame, PlayerVideoFrame, RenderFrameContext, RendererBackend,
-    RendererBackendPreference, RendererRuntimeStats, SurfaceMetrics, TrackInfo, TrackSelection,
-    VideoDecoderEvent, VideoFrameImportFailure,
+    MediaRequest, PlatformSurface, PlaybackSnapshot, Player, PlayerConfig, PlayerSubtitleFrame,
+    PlayerVideoFrame, RenderFrameContext, RendererBackend, RendererBackendPreference,
+    RendererRuntimeStats, SurfaceMetrics, TrackInfo, TrackSelection, VideoDecoderEvent,
+    VideoFrameImportFailure,
 };
 use crate::danmaku::{
     DANMAKU_DEBUG_BUCKETS, DanmakuConfigChange, DanmakuDebugBucket, DanmakuFontSelection,
@@ -42,8 +26,6 @@ use crate::danmaku::{
 };
 use crate::debug_hud::{DebugHud, DebugHudSnapshot};
 use crate::ffmpeg::DecoderBackend;
-#[cfg(target_env = "ohos")]
-use crate::ohos::ohaudio::{OHAudioOutput, OHAudioOutputConfig};
 use crate::overlay::{OverlayFrame, OverlayTimeline, OverlayViewport};
 #[cfg(any(target_os = "windows", target_os = "android"))]
 use crate::playback::VideoDecodePreference;
@@ -62,19 +44,24 @@ use crate::subtitle::{
     SubtitleTrackConfig, SubtitleViewport, decoded_subtitle_frames_to_timeline,
 };
 use crate::trace;
-#[cfg(target_os = "windows")]
-use crate::windows::wasapi::{WasapiAudioOutput, WasapiAudioOutputConfig};
 use crate::{PlayerError, Result};
 
-const AUDIO_START_BUFFER: Duration = Duration::from_millis(250);
-const AUDIO_PUMP_FRAME_LIMIT: usize = 16;
-const AUDIO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
-// The audio transform currently runs on the display-driven presenter path.
-// Keep a rate-change refill bounded to one normal audio-pump slice so it
-// cannot consume an entire render frame while SoundTouch is warming up.
-const AUDIO_FAST_RATE_PUMP_FRAME_LIMIT: usize = 24;
-const AUDIO_FAST_RATE_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
-const PLAYBACK_RATE_EPSILON: f64 = 0.001;
+#[cfg(target_os = "android")]
+use crate::android::aaudio::AAudioOutputConfig;
+#[cfg(target_os = "macos")]
+use crate::apple::coreaudio::CoreAudioOutputConfig;
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+use crate::apple::iosaudio::IosAudioQueueOutputConfig;
+#[cfg(target_env = "ohos")]
+use crate::ohos::ohaudio::OHAudioOutputConfig;
+#[cfg(target_os = "windows")]
+use crate::windows::wasapi::WasapiAudioOutputConfig;
+
+mod audio;
+#[cfg(all(test, feature = "wgpu"))]
+mod audio_integration;
+use audio::{AudioCommand, AudioService};
+
 const VIDEO_PUMP_FRAME_LIMIT: usize = 8;
 const VIDEO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
 // A foreground resume that keeps failing must not retry once per display
@@ -286,16 +273,11 @@ pub struct PresenterRuntime {
     player: Player,
     renderer: Box<dyn RendererBackend>,
     video_frames: Receiver<PlayerVideoFrame>,
-    audio_frames: Receiver<PlayerAudioFrame>,
     subtitle_frames: Receiver<PlayerSubtitleFrame>,
     player_events: Receiver<crate::core::PlayerEvent>,
-    audio_output: Box<dyn AudioOutputBackend>,
-    audio_configured: bool,
-    audio_started: bool,
-    last_audio_clock_report: Option<AudioClockReportState>,
-    last_audio_runtime_stats: AudioOutputRuntimeStats,
-    playback_rate: f64,
-    pending_playback_rate: Option<PendingPlaybackRate>,
+    audio: AudioService,
+    uploaded_video_generation: Option<u64>,
+    audio_ready_generation: Option<u64>,
     audio_only_tick_active: bool,
     resume_pending: bool,
     video_decode_resume_attempts: u32,
@@ -360,20 +342,6 @@ fn should_reject_video_import(
 
 fn should_report_video_frame_backpressure(drop_count: u64) -> bool {
     drop_count == 1 || drop_count.is_power_of_two()
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct AudioClockReportState {
-    media_time: Duration,
-    queued_frames: usize,
-    read_frames: u64,
-    underflow_frames: u64,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct PendingPlaybackRate {
-    rate: f64,
-    commit_at: Instant,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -680,20 +648,16 @@ impl PresenterRuntime {
         let danmaku = DfmLayoutEngine::new(danmaku_timeline.clone(), danmaku_config.clone());
         let danmaku_planner =
             AsyncDanmakuPlanner::new(danmaku.clone(), danmaku_timeline, danmaku_config);
+        let audio = AudioService::new(player.clone(), audio_frames, config.audio)?;
         Ok(Self {
             player,
             renderer,
             video_frames,
-            audio_frames,
             subtitle_frames,
             player_events,
-            audio_output: build_audio_output(config.audio),
-            audio_configured: false,
-            audio_started: false,
-            last_audio_clock_report: None,
-            last_audio_runtime_stats: AudioOutputRuntimeStats::default(),
-            playback_rate: 1.0,
-            pending_playback_rate: None,
+            audio,
+            uploaded_video_generation: None,
+            audio_ready_generation: None,
             audio_only_tick_active: false,
             resume_pending: false,
             video_decode_resume_attempts: 0,
@@ -817,61 +781,50 @@ impl PresenterRuntime {
                 self.danmaku_trace.last_surface_resize_log_at = Some(now);
             }
         }
-        self.last_audio_clock_report = None;
         Ok(())
     }
 
     pub fn open(&mut self, media: MediaRequest) -> Result<()> {
         self.quiesce_frame_output("open")?;
         self.reset_video_decode_resume_state();
-        self.reset_audio_output_with_committed_rate();
+        self.reset_audio_output_with_committed_rate()?;
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
-        self.drain_pending_player_frames();
+        self.drain_pending_player_frames()?;
         self.current_generation = self.current_generation.saturating_add(1).max(1);
         self.latest_video_decoder = None;
         let result = self.player.open(media);
-        let rate_result = if result.is_ok() && !playback_rate_matches(self.playback_rate, 1.0) {
-            self.player.set_playback_rate(self.playback_rate)
-        } else {
-            Ok(())
-        };
+        let rate_result =
+            if result.is_ok() && (self.audio.snapshot().playback_rate - 1.0).abs() > 0.001 {
+                self.player
+                    .set_playback_rate(self.audio.snapshot().playback_rate)
+            } else {
+                Ok(())
+            };
         // Player::open joins the previous producer before returning, so this
         // second drain deterministically removes anything it emitted between
         // the first drain and shutdown. The new engine is still paused.
-        self.drain_pending_player_frames();
-        result.and(rate_result)
+        self.drain_pending_player_frames()?;
+        result.and(rate_result)?;
+        self.audio.command(AudioCommand::Resume)
     }
 
     pub fn play(&mut self) -> Result<()> {
         if self.player.is_stopped_at_end() {
+            self.audio.command(AudioCommand::Quiesce)?;
             self.cancel_pending_video_decode_resume();
-            self.reset_audio_output_with_committed_rate();
-            self.drain_pending_player_frames();
+            self.reset_audio_output_with_committed_rate()?;
+            self.drain_pending_player_frames()?;
             self.bump_danmaku_generation();
             self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
         }
-        self.player.play()
+        self.player.play()?;
+        self.audio.command(AudioCommand::Resume)
     }
 
     pub fn pause(&mut self) -> Result<()> {
         let result = self.player.pause();
-        if self.pending_playback_rate.is_some() {
-            // A pending transition is measured against wall time while the
-            // output is running. Pausing that output would otherwise leave the
-            // old-rate bridge queued but allow the stale deadline to commit on
-            // the next play. Flush the bridge and commit the requested rate
-            // while the clock is parked.
-            self.reset_audio_output();
-            let rate_result = self.commit_pending_playback_rate_now();
-            return result.and(rate_result);
-        }
-        if let Err(error) = self.audio_output.pause() {
-            self.stats.audio_failures += 1;
-            eprintln!("Erika presenter audio pause failed: {error}");
-        }
-        self.audio_started = false;
-        self.last_audio_clock_report = None;
-        result
+        let audio_result = self.audio.command(AudioCommand::Pause);
+        result.and(audio_result)
     }
 
     pub fn is_playing(&self) -> bool {
@@ -890,7 +843,7 @@ impl PresenterRuntime {
         let quiesced = self.quiesce_frame_output("stop")?;
         let result = self.player.stop();
         self.cancel_pending_video_decode_resume();
-        self.reset_audio_output_with_committed_rate();
+        self.reset_audio_output_with_committed_rate()?;
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
         let transition = self.finish_frame_output_transition("stop", quiesced, true);
@@ -900,14 +853,14 @@ impl PresenterRuntime {
     pub fn close(&mut self) -> Result<()> {
         self.quiesce_frame_output("close")?;
         self.reset_video_decode_resume_state();
-        self.reset_audio_output_with_committed_rate();
+        self.reset_audio_output_with_committed_rate()?;
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(Duration::ZERO, TransitionFramePolicy::Clear);
-        self.drain_pending_player_frames();
+        self.drain_pending_player_frames()?;
         self.latest_video_decoder = None;
         let result = self.player.close();
         // Shutdown is joined at this point; no producer can refill a receiver.
-        self.drain_pending_player_frames();
+        self.drain_pending_player_frames()?;
         result
     }
 
@@ -915,7 +868,7 @@ impl PresenterRuntime {
         let quiesced = self.quiesce_frame_output("seek")?;
         let result = self.player.seek(position);
         let rate_result = self.commit_pending_playback_rate_now();
-        self.reset_audio_output();
+        self.reset_audio_output()?;
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(position, TransitionFramePolicy::PreserveRendererSnapshot);
         let transition = self.finish_frame_output_transition("seek", quiesced, true);
@@ -923,53 +876,17 @@ impl PresenterRuntime {
     }
 
     pub fn set_playback_rate(&mut self, rate: f64) -> Result<()> {
-        let next_rate = normalize_playback_rate(rate);
-        if playback_rate_request_is_idempotent(
-            self.playback_rate,
-            self.pending_playback_rate,
-            next_rate,
-        ) {
-            return Ok(());
-        }
-        self.player.invalidate_audio_clock();
-        self.audio_output.set_playback_rate(next_rate);
-        self.last_audio_clock_report = None;
-
-        let bridge = audio_transition_bridge(
-            self.audio_output.clock_snapshot(),
-            self.audio_output.queued_output_duration(),
-        );
-        if self.is_playing()
-            && let Some(bridge) = bridge
-        {
-            self.pending_playback_rate = Some(PendingPlaybackRate {
-                rate: next_rate,
-                commit_at: Instant::now() + bridge,
-            });
-            return Ok(());
-        }
-
-        // A paused output keeps its queued PCM. Discard it before committing a
-        // new rate so a later resume cannot play old-rate samples while the
-        // player clock is already running at the new rate.
-        if !self.is_playing() && bridge.is_some() {
-            self.reset_audio_output();
-        }
-        if let Err(error) = self.player.set_playback_rate(next_rate) {
-            self.audio_output.set_playback_rate(self.playback_rate);
-            return Err(error);
-        }
-        self.playback_rate = next_rate;
-        self.pending_playback_rate = None;
-        Ok(())
+        self.audio.command(AudioCommand::SetRate(rate))
     }
 
     pub fn set_volume(&mut self, volume: f64) {
-        self.audio_output.set_volume(volume as f32);
+        if let Err(error) = self.audio.command(AudioCommand::SetVolume(volume as f32)) {
+            trace::diagnostic(format!("audio volume command failed: {error}"));
+        }
     }
 
     pub fn volume(&self) -> f64 {
-        self.audio_output.volume() as f64
+        self.audio.snapshot().volume as f64
     }
 
     pub fn set_debug_hud_enabled(&mut self, enabled: bool) {
@@ -1320,7 +1237,7 @@ impl PresenterRuntime {
         let quiesced = self.quiesce_frame_output("select_audio_track")?;
         let result = self.player.select_audio_track(track_id);
         let rate_result = self.commit_pending_playback_rate_now();
-        self.reset_audio_output();
+        self.reset_audio_output()?;
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(
             self.current_media_time,
@@ -1334,7 +1251,7 @@ impl PresenterRuntime {
         let quiesced = self.quiesce_frame_output("select_subtitle_track")?;
         let result = self.player.select_subtitle_track(track_id);
         let rate_result = self.commit_pending_playback_rate_now();
-        self.reset_audio_output();
+        self.reset_audio_output()?;
         self.bump_danmaku_generation();
         self.clear_playback_visual_state(
             self.current_media_time,
@@ -1380,7 +1297,6 @@ impl PresenterRuntime {
             self.video_decode_resume_attempts = 0;
         }
         let tick_started = Instant::now();
-        self.commit_pending_playback_rate()?;
         let pump_started = Instant::now();
         self.refresh_video_decoder_status();
 
@@ -1392,13 +1308,7 @@ impl PresenterRuntime {
         self.pump_video();
         self.last_video_pump_duration = video_started.elapsed();
 
-        let audio_started = Instant::now();
-        // Publish a callback-observed disconnection before clock/push recovery
-        // advances the backend to recovering or stable during this tick.
-        self.report_audio_output_runtime_stats();
-        self.pump_audio();
-        self.report_audio_output_runtime_stats();
-        self.last_audio_pump_duration = audio_started.elapsed();
+        self.refresh_audio_stats();
 
         let sync_started = Instant::now();
         let _snapshot = self.sync_media_time_from_player();
@@ -1483,7 +1393,7 @@ impl PresenterRuntime {
             self.last_render_current_duration = Duration::ZERO;
             self.last_render_test_duration = Duration::ZERO;
             self.last_tick_duration = tick_started.elapsed();
-            return Ok(self.stats);
+            return Ok(self.stats());
         }
         let render_started = Instant::now();
         let render_result = self.renderer.render_current_frame(context);
@@ -1491,7 +1401,16 @@ impl PresenterRuntime {
         self.last_render_duration = self.last_render_current_duration;
         self.last_render_test_duration = Duration::ZERO;
         match render_result {
-            Ok(true) => self.stats.rendered_video_frames += 1,
+            Ok(true) => {
+                self.stats.rendered_video_frames += 1;
+                if let Some(generation) = self.uploaded_video_generation
+                    && self.audio_ready_generation != Some(generation)
+                {
+                    self.audio
+                        .command(AudioCommand::VideoPresented(generation))?;
+                    self.audio_ready_generation = Some(generation);
+                }
+            }
             Ok(false) => {
                 if self.render_test_pattern_when_idle {
                     let render_started = Instant::now();
@@ -1533,17 +1452,20 @@ impl PresenterRuntime {
                 renderer.rendered_frames,
                 renderer.offscreen_frames,
                 renderer.last_gpu_duration.as_secs_f64() * 1000.0,
-                self.audio_output
-                    .clock_snapshot()
+                self.audio
+                    .snapshot()
+                    .clock
                     .map(|snapshot| snapshot.queued_frames)
                     .unwrap_or(0),
-                self.audio_output
-                    .clock_snapshot()
+                self.audio
+                    .snapshot()
+                    .clock
                     .and_then(|snapshot| snapshot.queued_duration)
                     .map(|duration| duration.as_secs_f64() * 1000.0)
                     .unwrap_or(0.0),
-                self.audio_output
-                    .clock_snapshot()
+                self.audio
+                    .snapshot()
+                    .clock
                     .map(|snapshot| snapshot.underflow_frames)
                     .unwrap_or(0),
                 self.current_surface_metrics
@@ -1555,12 +1477,11 @@ impl PresenterRuntime {
                     .map_or(0, |plan| plan.items.len()),
             ));
         }
-        Ok(self.stats)
+        Ok(self.stats())
     }
 
     pub fn audio_only_tick(&mut self) -> Result<PresenterStats> {
         let tick_started = Instant::now();
-        self.commit_pending_playback_rate()?;
         // A background tick starts a new foreground-resume window. If a
         // previous foreground attempt failed, do not carry its pending flag or
         // its spent attempt budget into the next foreground frame.
@@ -1574,11 +1495,7 @@ impl PresenterRuntime {
         let pump_started = Instant::now();
         self.last_subtitle_pump_duration = Duration::ZERO;
         self.last_video_pump_duration = Duration::ZERO;
-        self.report_audio_output_runtime_stats();
-        let audio_started = Instant::now();
-        self.pump_audio();
-        self.report_audio_output_runtime_stats();
-        self.last_audio_pump_duration = audio_started.elapsed();
+        self.refresh_audio_stats();
         let sync_started = Instant::now();
         self.sync_media_time_from_player();
         self.last_clock_sync_duration = sync_started.elapsed();
@@ -1588,7 +1505,7 @@ impl PresenterRuntime {
         self.last_render_test_duration = Duration::ZERO;
         self.last_pump_duration = pump_started.elapsed();
         self.last_tick_duration = tick_started.elapsed();
-        Ok(self.stats)
+        Ok(self.stats())
     }
 
     fn discard_pending_video_frames(&self) {
@@ -1702,9 +1619,9 @@ impl PresenterRuntime {
             .audio
             .and_then(|selected| tracks.iter().find(|track| track.id == selected));
         let renderer = self.renderer.runtime_stats();
-        let clock = self.audio_output.clock_snapshot();
+        let clock = self.audio.snapshot().clock;
         let output = self.renderer.output_status();
-        let audio_runtime = self.audio_output.runtime_stats();
+        let audio_runtime = self.audio.snapshot().runtime;
         let surface = self.current_surface_metrics;
         let decoder = self.latest_video_decoder.as_ref();
         DebugHudSnapshot {
@@ -1735,7 +1652,7 @@ impl PresenterRuntime {
             player_state: format!("{:?}", self.player.state()).to_lowercase(),
             media_time: self.current_media_time,
             duration: self.player.duration(),
-            playback_rate: self.playback_rate,
+            playback_rate: self.audio.snapshot().playback_rate,
             surface_width: surface.map_or(0, |metrics| metrics.physical_extent.width),
             surface_height: surface.map_or(0, |metrics| metrics.physical_extent.height),
             decoded_video_frames: self.stats.decoded_video_frames,
@@ -1844,7 +1761,12 @@ impl PresenterRuntime {
     }
 
     pub fn stats(&self) -> PresenterStats {
-        self.stats
+        let audio = self.audio.snapshot();
+        PresenterStats {
+            pushed_audio_frames: audio.pushed_audio_frames,
+            audio_failures: audio.audio_failures,
+            ..self.stats
+        }
     }
 
     pub fn runtime_snapshot(&self) -> PresenterRuntimeSnapshot {
@@ -1864,9 +1786,9 @@ impl PresenterRuntime {
             .current_danmaku
             .as_ref()
             .map_or(Default::default(), |plan| plan.frame_stats);
-        let audio_snapshot = self.audio_output.clock_snapshot();
+        let audio_snapshot = self.audio.snapshot().clock;
         PresenterRuntimeSnapshot {
-            stats: self.stats,
+            stats: self.stats(),
             renderer,
             resources,
             output,
@@ -1878,7 +1800,7 @@ impl PresenterRuntime {
                 .map_or(0, |snapshot| snapshot.written_frames),
             audio_output_underflow_frames: audio_snapshot
                 .map_or(0, |snapshot| snapshot.underflow_frames),
-            audio_output_runtime_stats: self.audio_output.runtime_stats(),
+            audio_output_runtime_stats: self.audio.snapshot().runtime,
             media_time: self.current_media_time,
             generation: self.current_generation,
             playing: self.is_playing(),
@@ -1943,6 +1865,7 @@ impl PresenterRuntime {
                     self.stats.decoded_video_frames += 1;
                     match self.renderer.upload_player_frame(&frame) {
                         Ok(()) => {
+                            self.uploaded_video_generation = Some(frame.generation);
                             if self.rejected_video_import_route.is_some() {
                                 self.rejected_video_import_route = None;
                             }
@@ -2712,12 +2635,13 @@ impl PresenterRuntime {
         media_time: Duration,
         frame_policy: TransitionFramePolicy,
     ) {
+        self.uploaded_video_generation = None;
+        self.audio_ready_generation = None;
         self.rejected_video_import_route = None;
         self.current_overlay = None;
         self.subtitles.clear();
         self.clear_current_danmaku_state();
         self.current_media_time = media_time;
-        self.last_audio_clock_report = None;
         match frame_policy {
             TransitionFramePolicy::Clear => self.release_current_video_frame(),
             TransitionFramePolicy::PreserveRendererSnapshot => {
@@ -2769,6 +2693,10 @@ impl PresenterRuntime {
     }
 
     fn quiesce_frame_output(&mut self, operation: &'static str) -> Result<bool> {
+        // Stop the consumer first. Its ACK proves no in-flight push can outlive
+        // the producer barrier or refill an output that a transition clears.
+        // No presenter/renderer lock is shared with the audio owner.
+        self.audio.command(AudioCommand::Quiesce)?;
         let started = Instant::now();
         trace::diagnostic(
             serde_json::json!({
@@ -2816,11 +2744,11 @@ impl PresenterRuntime {
     ) -> Result<()> {
         if !active {
             if drain_all_streams {
-                self.drain_pending_player_frames();
+                self.drain_pending_player_frames()?;
             } else {
                 self.drain_pending_video_frames();
             }
-            return Ok(());
+            return self.audio.command(AudioCommand::Resume);
         }
         // A second quiesce command is a FIFO barrier behind the transition
         // command. Its ACK proves decoder replacement finished while output
@@ -2846,7 +2774,7 @@ impl PresenterRuntime {
                     .to_string(),
                 );
                 if drain_all_streams {
-                    self.drain_pending_player_frames();
+                    self.drain_pending_player_frames()?;
                 } else {
                     self.drain_pending_video_frames();
                 }
@@ -2893,7 +2821,7 @@ impl PresenterRuntime {
                 // output resumed, so the pending receivers are now safe to drain.
                 if barrier_error.is_some() {
                     if drain_all_streams {
-                        self.drain_pending_player_frames();
+                        self.drain_pending_player_frames()?;
                     } else {
                         self.drain_pending_video_frames();
                     }
@@ -2913,13 +2841,18 @@ impl PresenterRuntime {
             }
         }
 
+        let audio_result = if resume_result.is_ok() {
+            self.audio.command(AudioCommand::Resume)
+        } else {
+            Ok(())
+        };
         match (barrier_error, resume_result) {
             (None, result) => result.map(|_| ()),
             (Some(barrier_error), Ok(_)) => Err(barrier_error),
             (Some(barrier_error), Err(resume_error)) => Err(PlayerError::Playback(format!(
                 "frame output transition barrier failed: {barrier_error}; resume failed: {resume_error}",
             ))),
-        }
+        }.and(audio_result)
     }
 
     fn sync_danmaku_engine_timeline(&mut self) {
@@ -2957,253 +2890,34 @@ impl PresenterRuntime {
         }
     }
 
-    fn pump_audio(&mut self) {
-        let started = Instant::now();
-        let mut pumped = 0usize;
-        let (frame_limit, time_budget) = self.audio_pump_limits();
-        loop {
-            if pumped >= frame_limit || started.elapsed() >= time_budget {
-                break;
-            }
-            if !self.audio_output.can_accept_audio_frame() {
-                break;
-            }
-            match self.audio_frames.try_recv() {
-                Ok(frame) => {
-                    if frame.generation != self.player.playback_generation() {
-                        continue;
-                    }
-                    self.push_audio(frame);
-                    pumped += 1;
-                }
-                Err(crossbeam_channel::TryRecvError::Empty) => break,
-                Err(crossbeam_channel::TryRecvError::Disconnected) => break,
-            }
-        }
-        self.ensure_audio_started();
-        if self.audio_started {
-            self.report_audio_clock_snapshot();
-        }
+    fn reset_audio_output(&mut self) -> Result<()> {
+        self.audio.command(AudioCommand::Reset)
     }
 
-    fn audio_pump_limits(&self) -> (usize, Duration) {
-        let rate = self
-            .pending_playback_rate
-            .map_or(self.playback_rate, |pending| pending.rate);
-        audio_pump_limits_for_rate(rate)
-    }
-
-    fn report_audio_clock_snapshot(&mut self) {
-        // During a rate transition the audio ring already uses the requested
-        // rate while the player clock still uses the old one. Do not enqueue a
-        // mixed-rate clock sample; the first sample after commit is coherent.
-        if self.pending_playback_rate.is_some() {
-            return;
-        }
-        // configure/start/push can recover the device during this pump. Publish
-        // its new epoch before sampling, not only after feedback is enqueued.
-        self.report_audio_output_runtime_stats();
-        let Some(observation) = self
-            .player
-            .capture_audio_clock(|| self.audio_output.clock_snapshot())
-        else {
-            return;
-        };
-        let snapshot = observation.snapshot();
-        // Report queue/underflow movement even when the engine later rejects the clock for sync.
-        if !self.should_report_audio_clock(snapshot) {
-            return;
-        }
-        trace::log(format!(
-            "[erika-clock-trace] stage=presenter_audio_snapshot media={} queued={} queued_frames={} read={} written={} underflow={}",
-            trace::duration_label(snapshot.media_time),
-            trace::duration_label(snapshot.queued_duration),
-            snapshot.queued_frames,
-            snapshot.read_frames,
-            snapshot.written_frames,
-            snapshot.underflow_frames,
-        ));
-        let _ = self.player.update_audio_clock_observation(observation);
-    }
-
-    fn should_report_audio_clock(&mut self, snapshot: AudioClockSnapshot) -> bool {
-        let Some(media_time) = snapshot.media_time else {
-            return false;
-        };
-        let next = AudioClockReportState {
-            media_time,
-            queued_frames: snapshot.queued_frames,
-            read_frames: snapshot.read_frames,
-            underflow_frames: snapshot.underflow_frames,
-        };
-        let should_report = self.last_audio_clock_report.is_none_or(|previous| {
-            snapshot.read_frames > previous.read_frames
-                || snapshot.underflow_frames > previous.underflow_frames
-                || snapshot.queued_frames != previous.queued_frames
-                || media_time > previous.media_time
-        });
-        if should_report {
-            self.last_audio_clock_report = Some(next);
-        }
-        should_report
-    }
-
-    fn push_audio(&mut self, frame: PlayerAudioFrame) {
-        if !self.audio_configured {
-            self.player.invalidate_audio_clock();
-            if let Err(error) = self.audio_output.configure(frame.frame.format) {
-                self.stats.audio_failures += 1;
-                eprintln!("Erika presenter audio configure failed: {error}");
-                return;
-            }
-            self.audio_configured = true;
-            self.last_audio_clock_report = None;
-        }
-        match self.audio_output.push(frame.frame) {
-            Ok(_) => self.stats.pushed_audio_frames += 1,
-            Err(error) => {
-                self.stats.audio_failures += 1;
-                eprintln!("Erika presenter audio push failed: {error}");
-                return;
-            }
-        }
-
-        self.ensure_audio_started();
-    }
-
-    fn ensure_audio_started(&mut self) {
-        if !self.is_playing()
-            || self.audio_started
-            || !self.audio_output_ready_to_start()
-            || !self.audio_start_allowed()
-        {
-            return;
-        }
-        if let Err(error) = self.audio_output.start() {
-            self.stats.audio_failures += 1;
-            eprintln!("Erika presenter audio start failed: {error}");
-            return;
-        }
-        self.audio_started = true;
-        self.last_audio_clock_report = None;
-    }
-
-    fn audio_output_ready_to_start(&self) -> bool {
-        self.audio_output
-            .clock_snapshot()
-            .and_then(|snapshot| snapshot.queued_duration)
-            .is_some_and(|queued| queued >= AUDIO_START_BUFFER)
-    }
-
-    fn audio_start_allowed(&self) -> bool {
-        self.player.track_selection().video.is_none() || self.stats.rendered_video_frames > 0
-    }
-
-    fn reset_audio_output(&mut self) {
-        self.player.invalidate_audio_clock();
-        if let Err(error) = self.audio_output.stop() {
-            self.stats.audio_failures += 1;
-            eprintln!("Erika presenter audio reset failed: {error}");
-        }
-        self.audio_configured = false;
-        self.audio_started = false;
-        self.last_audio_clock_report = None;
-    }
-
-    fn reset_audio_output_with_committed_rate(&mut self) {
-        self.pending_playback_rate = None;
-        self.reset_audio_output();
-        self.audio_output.set_playback_rate(self.playback_rate);
-    }
-
-    fn commit_pending_playback_rate(&mut self) -> Result<()> {
-        let Some(pending) = self.pending_playback_rate else {
-            return Ok(());
-        };
-        if !self.is_playing() || Instant::now() < pending.commit_at {
-            return Ok(());
-        }
-        self.commit_pending_playback_rate_now()
+    fn reset_audio_output_with_committed_rate(&mut self) -> Result<()> {
+        self.audio.command(AudioCommand::ResetCommitted)
     }
 
     fn commit_pending_playback_rate_now(&mut self) -> Result<()> {
-        let Some(rate) = self.pending_playback_rate.map(|pending| pending.rate) else {
-            return Ok(());
-        };
-        if let Err(error) = self.player.set_playback_rate(rate) {
-            self.reset_audio_output_with_committed_rate();
-            return Err(error);
-        }
-        self.playback_rate = rate;
-        self.pending_playback_rate = None;
-        self.player.invalidate_audio_clock();
-        self.last_audio_clock_report = None;
-        Ok(())
+        self.audio.command(AudioCommand::CommitPendingRate)
     }
 
-    fn report_audio_output_runtime_stats(&mut self) {
-        let stats = self.audio_output.runtime_stats();
-        if stats.transition_sequence == self.last_audio_runtime_stats.transition_sequence {
-            return;
-        }
-        self.player.invalidate_audio_clock();
-        self.last_audio_clock_report = None;
-        self.last_audio_runtime_stats = stats;
-        let event = AudioOutputEvent { stats };
-        trace::diagnostic(event.structured_message());
-        self.player.report_audio_output_event(event);
+    fn refresh_audio_stats(&mut self) {
+        let audio = self.audio.snapshot();
+        self.stats.pushed_audio_frames = audio.pushed_audio_frames;
+        self.stats.audio_failures = audio.audio_failures;
+        self.last_audio_pump_duration = audio.pump_duration;
     }
 
-    fn drain_pending_player_frames(&mut self) {
+    fn drain_pending_player_frames(&mut self) -> Result<()> {
         self.drain_pending_video_frames();
-        while self.audio_frames.try_recv().is_ok() {}
+        self.audio.command(AudioCommand::Drain)?;
         while self.subtitle_frames.try_recv().is_ok() {}
+        Ok(())
     }
 
     fn drain_pending_video_frames(&mut self) {
         while self.video_frames.try_recv().is_ok() {}
-    }
-}
-
-fn normalize_playback_rate(rate: f64) -> f64 {
-    if rate.is_finite() && rate > 0.0 {
-        rate
-    } else {
-        1.0
-    }
-}
-
-fn playback_rate_matches(lhs: f64, rhs: f64) -> bool {
-    (lhs - rhs).abs() <= PLAYBACK_RATE_EPSILON
-}
-
-fn playback_rate_request_is_idempotent(
-    current_rate: f64,
-    pending: Option<PendingPlaybackRate>,
-    next_rate: f64,
-) -> bool {
-    pending.is_some_and(|pending| playback_rate_matches(pending.rate, next_rate))
-        || (pending.is_none() && playback_rate_matches(current_rate, next_rate))
-}
-
-fn audio_transition_bridge(
-    snapshot: Option<AudioClockSnapshot>,
-    queued_output_duration: Duration,
-) -> Option<Duration> {
-    snapshot
-        .and_then(|snapshot| snapshot.queued_duration)
-        .map(|duration| duration.saturating_add(queued_output_duration))
-        .filter(|duration| !duration.is_zero())
-}
-
-fn audio_pump_limits_for_rate(rate: f64) -> (usize, Duration) {
-    if (rate - 1.0).abs() > PLAYBACK_RATE_EPSILON {
-        (
-            AUDIO_FAST_RATE_PUMP_FRAME_LIMIT,
-            AUDIO_FAST_RATE_PUMP_TIME_BUDGET,
-        )
-    } else {
-        (AUDIO_PUMP_FRAME_LIMIT, AUDIO_PUMP_TIME_BUDGET)
     }
 }
 
@@ -3554,50 +3268,6 @@ fn resolve_presenter_player_config(
     _renderer_preference: RendererBackendPreference,
     _supports_mediacodec_surface: bool,
 ) {
-}
-
-fn build_audio_output(config: PresenterAudioConfig) -> Box<dyn AudioOutputBackend> {
-    #[cfg(target_os = "macos")]
-    {
-        Box::new(CoreAudioOutput::new(CoreAudioOutputConfig {
-            ring_buffer: config.ring_buffer,
-        }))
-    }
-    #[cfg(any(target_os = "ios", target_os = "tvos"))]
-    {
-        Box::new(IosAudioQueueOutput::new(IosAudioQueueOutputConfig {
-            ring_buffer: config.ring_buffer,
-        }))
-    }
-    #[cfg(target_os = "windows")]
-    {
-        Box::new(WasapiAudioOutput::new(WasapiAudioOutputConfig {
-            ring_buffer: config.ring_buffer,
-        }))
-    }
-
-    #[cfg(target_os = "android")]
-    {
-        Box::new(AAudioOutput::new(AAudioOutputConfig {
-            ring_buffer: config.ring_buffer,
-        }))
-    }
-    #[cfg(target_env = "ohos")]
-    {
-        Box::new(OHAudioOutput::new(OHAudioOutputConfig {
-            ring_buffer: config.ring_buffer,
-        }))
-    }
-    #[cfg(not(any(
-        target_os = "android",
-        target_os = "macos",
-        any(target_os = "ios", target_os = "tvos"),
-        target_os = "windows",
-        target_env = "ohos"
-    )))]
-    {
-        Box::new(BufferedAudioOutput::new(config.ring_buffer))
-    }
 }
 
 #[cfg(feature = "wgpu")]
@@ -4670,135 +4340,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
     }
 
     #[test]
-    fn repeated_playback_rate_request_keeps_pending_transition_deadline() {
-        let deadline = Instant::now() + Duration::from_millis(250);
-        let pending = PendingPlaybackRate {
-            rate: 2.0,
-            commit_at: deadline,
-        };
-
-        assert!(playback_rate_request_is_idempotent(1.0, Some(pending), 2.0));
-        assert_eq!(pending.commit_at, deadline);
-        assert!(playback_rate_request_is_idempotent(2.0, None, 2.0));
-        assert!(!playback_rate_request_is_idempotent(
-            1.0,
-            Some(pending),
-            1.5
-        ));
-    }
-
-    #[test]
-    fn audio_transition_bridge_includes_platform_output_duration() {
-        let snapshot = AudioClockSnapshot {
-            media_time: Some(Duration::from_secs(1)),
-            queued_duration: Some(Duration::from_millis(250)),
-            queued_frames: 12_000,
-            read_frames: 0,
-            written_frames: 12_000,
-            underflow_frames: 0,
-        };
-
-        assert_eq!(
-            audio_transition_bridge(Some(snapshot), Duration::from_millis(60)),
-            Some(Duration::from_millis(310))
-        );
-        assert_eq!(
-            audio_transition_bridge(
-                Some(AudioClockSnapshot {
-                    queued_duration: Some(Duration::ZERO),
-                    ..snapshot
-                }),
-                Duration::from_millis(60),
-            ),
-            Some(Duration::from_millis(60))
-        );
-    }
-
-    #[cfg(feature = "wgpu")]
-    #[test]
-    fn audio_reset_preserves_pending_rate_for_transition() {
-        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
-        presenter.pending_playback_rate = Some(PendingPlaybackRate {
-            rate: 2.0,
-            commit_at: Instant::now(),
-        });
-
-        presenter.reset_audio_output();
-        assert_eq!(
-            presenter.pending_playback_rate.map(|pending| pending.rate),
-            Some(2.0)
-        );
-    }
-
-    #[cfg(feature = "wgpu")]
-    #[test]
-    fn terminal_audio_reset_restores_committed_rate() {
-        use crate::audio::BufferedAudioOutput;
-        use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
-
-        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
-        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
-        output.set_playback_rate(2.0);
-        presenter.audio_output = Box::new(output);
-        presenter.playback_rate = 1.0;
-        presenter.pending_playback_rate = Some(PendingPlaybackRate {
-            rate: 2.0,
-            commit_at: Instant::now(),
-        });
-
-        presenter.reset_audio_output_with_committed_rate();
-        let format = PcmFormat::f32_interleaved(48_000, 2);
-        presenter
-            .audio_output
-            .push(PcmAudioFrame {
-                format,
-                pts: Some(Duration::ZERO),
-                frames: 24_000,
-                samples: vec![0.0; 48_000],
-            })
-            .unwrap();
-
-        assert_eq!(
-            presenter
-                .audio_output
-                .clock_snapshot()
-                .unwrap()
-                .queued_frames,
-            24_000
-        );
-        assert!(presenter.pending_playback_rate.is_none());
-    }
-
-    #[cfg(feature = "wgpu")]
-    #[test]
-    fn failed_pending_rate_commit_clears_transition_state() {
-        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
-        presenter.pending_playback_rate = Some(PendingPlaybackRate {
-            rate: 2.0,
-            commit_at: Instant::now(),
-        });
-
-        assert!(presenter.commit_pending_playback_rate_now().is_err());
-        assert!(presenter.pending_playback_rate.is_none());
-        assert_eq!(presenter.playback_rate, 1.0);
-    }
-
-    #[test]
-    fn playback_rate_uses_fast_audio_pump_limits() {
-        assert_eq!(
-            audio_pump_limits_for_rate(1.0),
-            (AUDIO_PUMP_FRAME_LIMIT, AUDIO_PUMP_TIME_BUDGET)
-        );
-        assert_eq!(
-            audio_pump_limits_for_rate(2.0),
-            (
-                AUDIO_FAST_RATE_PUMP_FRAME_LIMIT,
-                AUDIO_FAST_RATE_PUMP_TIME_BUDGET
-            )
-        );
-    }
-
-    #[test]
     #[cfg(feature = "wgpu")]
     fn layout_config_generation_does_not_disturb_the_playback_clock() {
         let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
@@ -5201,75 +4742,6 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             next.items[0].rect[0] < first_x,
             "the retained right-to-left comment must keep moving"
         );
-    }
-
-    #[test]
-    #[cfg(feature = "wgpu")]
-    fn audio_clock_report_tracks_queue_and_underflow_changes() {
-        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
-
-        let first = AudioClockSnapshot {
-            media_time: Some(Duration::from_secs(1)),
-            queued_duration: Some(Duration::from_millis(500)),
-            queued_frames: 24_000,
-            read_frames: 0,
-            written_frames: 24_000,
-            underflow_frames: 0,
-        };
-        assert!(presenter.should_report_audio_clock(first));
-        assert!(!presenter.should_report_audio_clock(first));
-        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
-            media_time: Some(Duration::from_secs(1)),
-            queued_duration: Some(Duration::from_millis(300)),
-            queued_frames: 14_400,
-            read_frames: 0,
-            written_frames: 19_200,
-            underflow_frames: 0,
-        }));
-        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
-            media_time: Some(Duration::from_millis(100)),
-            queued_duration: Some(Duration::ZERO),
-            queued_frames: 0,
-            read_frames: 0,
-            written_frames: 24_000,
-            underflow_frames: 512,
-        }));
-
-        presenter.playback_rate = 2.0;
-        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
-            media_time: Some(Duration::from_secs(1)),
-            queued_duration: Some(Duration::from_millis(300)),
-            queued_frames: 14_400,
-            read_frames: 14_400,
-            written_frames: 28_800,
-            underflow_frames: 0,
-        }));
-    }
-
-    #[test]
-    #[cfg(feature = "wgpu")]
-    fn audio_start_is_blocked_while_player_is_not_playing() {
-        use crate::audio::{AudioOutputState, BufferedAudioOutput};
-        use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
-
-        let mut presenter = PresenterRuntime::new(PresenterConfig::default()).unwrap();
-        let format = PcmFormat::f32_interleaved(48_000, 2);
-        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
-        output.configure(format).unwrap();
-        output
-            .push(PcmAudioFrame {
-                format,
-                pts: Some(Duration::ZERO),
-                frames: 12_000,
-                samples: vec![0.0; 24_000],
-            })
-            .unwrap();
-        presenter.audio_output = Box::new(output);
-
-        presenter.ensure_audio_started();
-
-        assert!(!presenter.audio_started);
-        assert_eq!(presenter.audio_output.state(), AudioOutputState::Stopped);
     }
 
     #[test]

--- a/crates/erika/src/presenter/audio.rs
+++ b/crates/erika/src/presenter/audio.rs
@@ -1,0 +1,1140 @@
+// SPDX-License-Identifier: MPL-2.0
+// The audio owner is independent of rendering. Only this thread creates,
+// calls and drops the backend; platform audio callbacks keep their own model.
+use super::PresenterAudioConfig;
+#[cfg(target_os = "android")]
+use crate::android::aaudio::{AAudioOutput, AAudioOutputConfig};
+#[cfg(target_os = "macos")]
+use crate::apple::coreaudio::{CoreAudioOutput, CoreAudioOutputConfig};
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+use crate::apple::iosaudio::{IosAudioQueueOutput, IosAudioQueueOutputConfig};
+#[cfg(test)]
+use crate::audio::AudioRingBufferConfig;
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "macos",
+    any(target_os = "ios", target_os = "tvos"),
+    target_os = "windows",
+    target_env = "ohos"
+)))]
+use crate::audio::BufferedAudioOutput;
+use crate::audio::{
+    AUDIO_OUTPUT_QUEUE_HIGH_WATER, AudioClockSnapshot, AudioOutputBackend, AudioOutputRuntimeStats,
+};
+use crate::core::{AudioOutputEvent, Player, PlayerAudioFrame, PlayerState};
+#[cfg(target_env = "ohos")]
+use crate::ohos::ohaudio::{OHAudioOutput, OHAudioOutputConfig};
+
+#[cfg(target_os = "windows")]
+use crate::windows::wasapi::{WasapiAudioOutput, WasapiAudioOutputConfig};
+use crate::{PlayerError, Result, trace};
+use crossbeam_channel::{Receiver, Sender, bounded};
+use std::{
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+const AUDIO_START_BUFFER: Duration = Duration::from_millis(250);
+const AUDIO_PUMP_FRAME_LIMIT: usize = 16;
+const AUDIO_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+// Bound each slice so device commands remain responsive during SoundTouch warmup.
+const AUDIO_FAST_RATE_PUMP_FRAME_LIMIT: usize = 24;
+const AUDIO_FAST_RATE_PUMP_TIME_BUDGET: Duration = Duration::from_millis(4);
+const PLAYBACK_RATE_EPSILON: f64 = 0.001;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AudioClockReportState {
+    media_time: Duration,
+    queued_frames: usize,
+    read_frames: u64,
+    underflow_frames: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingPlaybackRate {
+    rate: f64,
+    commit_at: Instant,
+}
+
+const AUDIO_POLL_INTERVAL: Duration = Duration::from_millis(2);
+const AUDIO_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct AudioServiceSnapshot {
+    pub clock: Option<AudioClockSnapshot>,
+    pub runtime: AudioOutputRuntimeStats,
+    pub playback_rate: f64,
+    pub volume: f32,
+    pub pushed_audio_frames: u64,
+    pub audio_failures: u64,
+    pub pump_duration: Duration,
+}
+
+#[derive(Debug)]
+pub(super) enum AudioCommand {
+    Quiesce,
+    Resume,
+    Drain,
+    Reset,
+    ResetCommitted,
+    CommitPendingRate,
+    Pause,
+    SetRate(f64),
+    SetVolume(f32),
+    VideoPresented(u64),
+    Shutdown,
+}
+
+struct Request {
+    command: AudioCommand,
+    reply: Sender<Result<()>>,
+    deadline: Instant,
+}
+
+pub(super) struct AudioService {
+    commands: Sender<Request>,
+    snapshot: Arc<Mutex<AudioServiceSnapshot>>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl AudioService {
+    pub fn new(
+        player: Player,
+        frames: Receiver<PlayerAudioFrame>,
+        config: PresenterAudioConfig,
+    ) -> Result<Self> {
+        Self::with_factory(player, frames, move || build_audio_output(config))
+    }
+
+    pub fn with_factory(
+        player: Player,
+        frames: Receiver<PlayerAudioFrame>,
+        factory: impl FnOnce() -> Box<dyn AudioOutputBackend> + Send + 'static,
+    ) -> Result<Self> {
+        let (commands, requests) = bounded::<Request>(16);
+        let (ready, initialized) = bounded(1);
+        let worker = thread::Builder::new()
+            .name("erika-audio".into())
+            .spawn(move || {
+                let mut pump = AudioPump::new(player, frames, factory());
+                let shared = Arc::new(Mutex::new(pump.snapshot()));
+                if ready.send(shared.clone()).is_err() {
+                    return;
+                }
+                loop {
+                    let request = if pump.quiesced {
+                        requests.recv().map_err(|_| crossbeam_channel::RecvTimeoutError::Disconnected)
+                    } else {
+                        let interval = if pump.is_playing() || pump.audio_started {
+                            AUDIO_POLL_INTERVAL
+                        } else {
+                            Duration::from_millis(100)
+                        };
+                        requests.recv_timeout(interval)
+                    };
+                    match request {
+                        Ok(request) => {
+                            let shutdown = matches!(request.command, AudioCommand::Shutdown);
+                            if !shutdown && Instant::now() >= request.deadline {
+                                let _ = request.reply.send(Err(PlayerError::Playback(
+                                    "audio command expired before execution".into(),
+                                )));
+                                continue;
+                            }
+                            let action = format!("{:?}", request.command);
+                            let result = pump.handle(request.command);
+                            let snapshot = pump.snapshot();
+                            *shared.lock().expect("audio snapshot mutex poisoned") = snapshot;
+                            trace::log(format!(
+                                "[erika-audio-owner] action={action} acknowledged={} generation={} quiesced={}",
+                                result.is_ok(), pump.player.playback_generation(), pump.quiesced,
+                            ));
+                            let _ = request.reply.send(result);
+                            if shutdown {
+                                break;
+                            }
+                        }
+                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                    }
+                    if !pump.quiesced {
+                        let started = Instant::now();
+                        if let Err(error) = pump.run_slice() {
+                            pump.stats.audio_failures += 1;
+                            pump.quiesced = true;
+                            trace::diagnostic(format!("audio owner suspended after failure: {error}"));
+                        }
+                        pump.stats.pump_duration = started.elapsed();
+                        let snapshot = pump.snapshot();
+                        *shared.lock().expect("audio snapshot mutex poisoned") = snapshot;
+                    }
+                }
+                // Device destruction stays on its creation thread, before join returns.
+                let _ = pump.reset_audio_output();
+            })
+            .map_err(|error| PlayerError::Playback(format!("cannot start audio owner: {error}")))?;
+        let snapshot = initialized
+            .recv()
+            .map_err(|_| PlayerError::Playback("audio owner failed to initialize".into()))?;
+        Ok(Self {
+            commands,
+            snapshot,
+            worker: Some(worker),
+        })
+    }
+
+    pub fn command(&self, command: AudioCommand) -> Result<()> {
+        let (reply, response) = bounded(1);
+        let deadline = Instant::now() + AUDIO_COMMAND_TIMEOUT;
+        self.commands
+            .send_timeout(
+                Request {
+                    command,
+                    reply,
+                    deadline,
+                },
+                AUDIO_COMMAND_TIMEOUT,
+            )
+            .map_err(|error| {
+                PlayerError::Playback(format!("audio command send failed: {error}"))
+            })?;
+        response
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .map_err(|error| {
+                PlayerError::Playback(format!("audio command acknowledgement failed: {error}"))
+            })?
+    }
+
+    pub fn snapshot(&self) -> AudioServiceSnapshot {
+        *self.snapshot.lock().expect("audio snapshot mutex poisoned")
+    }
+}
+
+impl Drop for AudioService {
+    fn drop(&mut self) {
+        let _ = self.command(AudioCommand::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Default)]
+struct AudioCounters {
+    pushed_audio_frames: u64,
+    audio_failures: u64,
+    pump_duration: Duration,
+}
+
+struct AudioPump {
+    player: Player,
+    audio_frames: Receiver<PlayerAudioFrame>,
+    audio_output: Box<dyn AudioOutputBackend>,
+    audio_configured: bool,
+    audio_started: bool,
+    last_audio_clock_report: Option<AudioClockReportState>,
+    last_audio_runtime_stats: AudioOutputRuntimeStats,
+    playback_rate: f64,
+    pending_playback_rate: Option<PendingPlaybackRate>,
+    video_ready_generation: Option<u64>,
+    quiesced: bool,
+    stats: AudioCounters,
+}
+
+impl AudioPump {
+    fn new(
+        player: Player,
+        audio_frames: Receiver<PlayerAudioFrame>,
+        audio_output: Box<dyn AudioOutputBackend>,
+    ) -> Self {
+        Self {
+            player,
+            audio_frames,
+            audio_output,
+            audio_configured: false,
+            audio_started: false,
+            last_audio_clock_report: None,
+            last_audio_runtime_stats: AudioOutputRuntimeStats::default(),
+            playback_rate: 1.0,
+            pending_playback_rate: None,
+            video_ready_generation: None,
+            quiesced: true,
+            stats: AudioCounters::default(),
+        }
+    }
+
+    fn snapshot(&self) -> AudioServiceSnapshot {
+        AudioServiceSnapshot {
+            clock: self.audio_output.clock_snapshot(),
+            runtime: self.audio_output.runtime_stats(),
+            playback_rate: self.playback_rate,
+            volume: self.audio_output.volume(),
+            pushed_audio_frames: self.stats.pushed_audio_frames,
+            audio_failures: self.stats.audio_failures,
+            pump_duration: self.stats.pump_duration,
+        }
+    }
+
+    fn is_playing(&self) -> bool {
+        self.player.state() == PlayerState::Playing
+    }
+
+    fn run_slice(&mut self) -> Result<()> {
+        match self.player.state() {
+            PlayerState::Closed | PlayerState::Error => {
+                self.quiesced = true;
+                return self.reset_audio_output_with_committed_rate();
+            }
+            PlayerState::Paused if self.audio_started => self.pause_output()?,
+            _ => {}
+        }
+        self.commit_pending_playback_rate()?;
+        self.report_audio_output_runtime_stats();
+        self.pump_audio();
+        self.report_audio_output_runtime_stats();
+        // The worker owns EOF publication. Once all PCM has reached the device,
+        // sleep until a replay/open/control command. Do not stop the backend
+        // here: an empty ring does not prove its hardware tail has played.
+        if self.player.is_stopped_at_end()
+            && self.audio_frames.is_empty()
+            && self
+                .audio_output
+                .clock_snapshot()
+                .is_none_or(|s| s.queued_frames == 0)
+        {
+            self.quiesced = true;
+        }
+        Ok(())
+    }
+
+    fn pause_output(&mut self) -> Result<()> {
+        if self.pending_playback_rate.is_some() {
+            self.reset_audio_output()?;
+            return self.commit_pending_playback_rate_now();
+        }
+        self.audio_output
+            .pause()
+            .map_err(|error| PlayerError::Playback(error.to_string()))?;
+        self.audio_started = false;
+        self.last_audio_clock_report = None;
+        Ok(())
+    }
+
+    fn handle(&mut self, command: AudioCommand) -> Result<()> {
+        match command {
+            AudioCommand::Quiesce => {
+                self.quiesced = true;
+                self.player.invalidate_audio_clock();
+            }
+            AudioCommand::Resume => self.quiesced = false,
+            AudioCommand::Drain => {
+                if !self.quiesced {
+                    return Err(PlayerError::Playback(
+                        "audio drain requires quiesce acknowledgement".into(),
+                    ));
+                }
+                while self.audio_frames.try_recv().is_ok() {}
+            }
+            AudioCommand::Reset => return self.reset_audio_output(),
+            AudioCommand::ResetCommitted => return self.reset_audio_output_with_committed_rate(),
+            AudioCommand::CommitPendingRate => return self.commit_pending_playback_rate_now(),
+            AudioCommand::Pause => return self.pause_output(),
+            AudioCommand::SetRate(rate) => return self.set_playback_rate(rate),
+            AudioCommand::SetVolume(volume) => self.set_volume(volume as f64),
+            AudioCommand::VideoPresented(generation) => {
+                self.video_ready_generation = Some(generation)
+            }
+            AudioCommand::Shutdown => {
+                self.quiesced = true;
+                return self.reset_audio_output_with_committed_rate();
+            }
+        }
+        Ok(())
+    }
+    fn pump_audio(&mut self) {
+        let started = Instant::now();
+        let mut pumped = 0usize;
+        let (frame_limit, time_budget) = self.audio_pump_limits();
+        loop {
+            if pumped >= frame_limit || started.elapsed() >= time_budget {
+                break;
+            }
+            if !self.audio_output.can_accept_audio_frame()
+                || self
+                    .audio_output
+                    .clock_snapshot()
+                    .and_then(|s| s.queued_duration)
+                    .is_some_and(|q| q >= AUDIO_OUTPUT_QUEUE_HIGH_WATER)
+            {
+                break;
+            }
+            match self.audio_frames.try_recv() {
+                Ok(frame) => {
+                    if frame.generation != self.player.playback_generation() {
+                        continue;
+                    }
+                    self.push_audio(frame);
+                    pumped += 1;
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => break,
+                Err(crossbeam_channel::TryRecvError::Disconnected) => break,
+            }
+        }
+        self.ensure_audio_started();
+        if self.audio_started {
+            self.report_audio_clock_snapshot();
+        }
+    }
+
+    fn audio_pump_limits(&self) -> (usize, Duration) {
+        let rate = self
+            .pending_playback_rate
+            .map_or(self.playback_rate, |pending| pending.rate);
+        audio_pump_limits_for_rate(rate)
+    }
+
+    fn report_audio_clock_snapshot(&mut self) {
+        // During a rate transition the audio ring already uses the requested
+        // rate while the player clock still uses the old one. Do not enqueue a
+        // mixed-rate clock sample; the first sample after commit is coherent.
+        if self.pending_playback_rate.is_some() {
+            return;
+        }
+        // configure/start/push can recover the device during this pump. Publish
+        // its new epoch before sampling, not only after feedback is enqueued.
+        self.report_audio_output_runtime_stats();
+        let Some(observation) = self
+            .player
+            .capture_audio_clock(|| self.audio_output.clock_snapshot())
+        else {
+            return;
+        };
+        let snapshot = observation.snapshot();
+        // Report queue/underflow movement even when the engine later rejects the clock for sync.
+        if !self.should_report_audio_clock(snapshot) {
+            return;
+        }
+        trace::log(format!(
+            "[erika-clock-trace] stage=presenter_audio_snapshot media={} queued={} queued_frames={} read={} written={} underflow={}",
+            trace::duration_label(snapshot.media_time),
+            trace::duration_label(snapshot.queued_duration),
+            snapshot.queued_frames,
+            snapshot.read_frames,
+            snapshot.written_frames,
+            snapshot.underflow_frames,
+        ));
+        let _ = self.player.update_audio_clock_observation(observation);
+    }
+
+    fn should_report_audio_clock(&mut self, snapshot: AudioClockSnapshot) -> bool {
+        let Some(media_time) = snapshot.media_time else {
+            return false;
+        };
+        let next = AudioClockReportState {
+            media_time,
+            queued_frames: snapshot.queued_frames,
+            read_frames: snapshot.read_frames,
+            underflow_frames: snapshot.underflow_frames,
+        };
+        let should_report = self.last_audio_clock_report.is_none_or(|previous| {
+            snapshot.read_frames > previous.read_frames
+                || snapshot.underflow_frames > previous.underflow_frames
+                || snapshot.queued_frames != previous.queued_frames
+                || media_time > previous.media_time
+        });
+        if should_report {
+            self.last_audio_clock_report = Some(next);
+        }
+        should_report
+    }
+
+    fn push_audio(&mut self, frame: PlayerAudioFrame) {
+        if !self.audio_configured {
+            self.player.invalidate_audio_clock();
+            if let Err(error) = self.audio_output.configure(frame.frame.format) {
+                self.stats.audio_failures += 1;
+                eprintln!("Erika presenter audio configure failed: {error}");
+                return;
+            }
+            self.audio_configured = true;
+            self.last_audio_clock_report = None;
+        }
+        match self.audio_output.push(frame.frame) {
+            Ok(_) => self.stats.pushed_audio_frames += 1,
+            Err(error) => {
+                self.stats.audio_failures += 1;
+                eprintln!("Erika presenter audio push failed: {error}");
+                return;
+            }
+        }
+
+        self.ensure_audio_started();
+    }
+
+    fn ensure_audio_started(&mut self) {
+        if !self.is_playing()
+            || self.audio_started
+            || !self.audio_output_ready_to_start()
+            || !self.audio_start_allowed()
+        {
+            return;
+        }
+        if let Err(error) = self.audio_output.start() {
+            self.stats.audio_failures += 1;
+            eprintln!("Erika presenter audio start failed: {error}");
+            return;
+        }
+        self.audio_started = true;
+        self.last_audio_clock_report = None;
+    }
+
+    fn audio_output_ready_to_start(&self) -> bool {
+        self.audio_output
+            .clock_snapshot()
+            .and_then(|snapshot| snapshot.queued_duration)
+            .is_some_and(|queued| queued >= AUDIO_START_BUFFER)
+    }
+
+    fn audio_start_allowed(&self) -> bool {
+        self.player.track_selection().video.is_none()
+            || self.video_ready_generation == Some(self.player.playback_generation())
+    }
+
+    fn reset_audio_output(&mut self) -> Result<()> {
+        self.player.invalidate_audio_clock();
+        if let Err(error) = self.audio_output.stop() {
+            self.stats.audio_failures += 1;
+            return Err(PlayerError::Playback(format!(
+                "audio reset failed: {error}"
+            )));
+        }
+        self.audio_configured = false;
+        self.audio_started = false;
+        self.last_audio_clock_report = None;
+        Ok(())
+    }
+
+    fn reset_audio_output_with_committed_rate(&mut self) -> Result<()> {
+        self.pending_playback_rate = None;
+        self.reset_audio_output()?;
+        self.audio_output.set_playback_rate(self.playback_rate);
+        Ok(())
+    }
+
+    fn commit_pending_playback_rate(&mut self) -> Result<()> {
+        let Some(pending) = self.pending_playback_rate else {
+            return Ok(());
+        };
+        if !self.is_playing() || Instant::now() < pending.commit_at {
+            return Ok(());
+        }
+        self.commit_pending_playback_rate_now()
+    }
+
+    fn commit_pending_playback_rate_now(&mut self) -> Result<()> {
+        let Some(rate) = self.pending_playback_rate.map(|pending| pending.rate) else {
+            return Ok(());
+        };
+        if let Err(error) = self.player.set_playback_rate(rate) {
+            self.reset_audio_output_with_committed_rate()?;
+            return Err(error);
+        }
+        self.playback_rate = rate;
+        self.pending_playback_rate = None;
+        self.player.invalidate_audio_clock();
+        self.last_audio_clock_report = None;
+        Ok(())
+    }
+
+    fn report_audio_output_runtime_stats(&mut self) {
+        let stats = self.audio_output.runtime_stats();
+        if stats.transition_sequence == self.last_audio_runtime_stats.transition_sequence {
+            return;
+        }
+        self.player.invalidate_audio_clock();
+        self.last_audio_clock_report = None;
+        self.last_audio_runtime_stats = stats;
+        let event = AudioOutputEvent { stats };
+        trace::diagnostic(event.structured_message());
+        self.player.report_audio_output_event(event);
+    }
+
+    pub fn set_playback_rate(&mut self, rate: f64) -> Result<()> {
+        let next_rate = normalize_playback_rate(rate);
+        if playback_rate_request_is_idempotent(
+            self.playback_rate,
+            self.pending_playback_rate,
+            next_rate,
+        ) {
+            return Ok(());
+        }
+        self.player.invalidate_audio_clock();
+        self.audio_output.set_playback_rate(next_rate);
+        self.last_audio_clock_report = None;
+
+        let bridge = audio_transition_bridge(
+            self.audio_output.clock_snapshot(),
+            self.audio_output.queued_output_duration(),
+        );
+        if self.is_playing()
+            && let Some(bridge) = bridge
+        {
+            self.pending_playback_rate = Some(PendingPlaybackRate {
+                rate: next_rate,
+                commit_at: Instant::now() + bridge,
+            });
+            return Ok(());
+        }
+
+        // A paused output keeps its queued PCM. Discard it before committing a
+        // new rate so a later resume cannot play old-rate samples while the
+        // player clock is already running at the new rate.
+        if !self.is_playing() && bridge.is_some() {
+            self.reset_audio_output()?;
+        }
+        if let Err(error) = self.player.set_playback_rate(next_rate) {
+            self.audio_output.set_playback_rate(self.playback_rate);
+            return Err(error);
+        }
+        self.playback_rate = next_rate;
+        self.pending_playback_rate = None;
+        Ok(())
+    }
+
+    pub fn set_volume(&mut self, volume: f64) {
+        self.audio_output.set_volume(volume as f32);
+    }
+}
+fn normalize_playback_rate(rate: f64) -> f64 {
+    if rate.is_finite() && rate > 0.0 {
+        rate
+    } else {
+        1.0
+    }
+}
+
+fn playback_rate_matches(lhs: f64, rhs: f64) -> bool {
+    (lhs - rhs).abs() <= PLAYBACK_RATE_EPSILON
+}
+
+fn playback_rate_request_is_idempotent(
+    current_rate: f64,
+    pending: Option<PendingPlaybackRate>,
+    next_rate: f64,
+) -> bool {
+    pending.is_some_and(|pending| playback_rate_matches(pending.rate, next_rate))
+        || (pending.is_none() && playback_rate_matches(current_rate, next_rate))
+}
+
+fn audio_transition_bridge(
+    snapshot: Option<AudioClockSnapshot>,
+    queued_output_duration: Duration,
+) -> Option<Duration> {
+    snapshot
+        .and_then(|snapshot| snapshot.queued_duration)
+        .map(|duration| duration.saturating_add(queued_output_duration))
+        .filter(|duration| !duration.is_zero())
+}
+
+fn audio_pump_limits_for_rate(rate: f64) -> (usize, Duration) {
+    if (rate - 1.0).abs() > PLAYBACK_RATE_EPSILON {
+        (
+            AUDIO_FAST_RATE_PUMP_FRAME_LIMIT,
+            AUDIO_FAST_RATE_PUMP_TIME_BUDGET,
+        )
+    } else {
+        (AUDIO_PUMP_FRAME_LIMIT, AUDIO_PUMP_TIME_BUDGET)
+    }
+}
+
+fn build_audio_output(config: PresenterAudioConfig) -> Box<dyn AudioOutputBackend> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(CoreAudioOutput::new(CoreAudioOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(any(target_os = "ios", target_os = "tvos"))]
+    {
+        Box::new(IosAudioQueueOutput::new(IosAudioQueueOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(WasapiAudioOutput::new(WasapiAudioOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        Box::new(AAudioOutput::new(AAudioOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(target_env = "ohos")]
+    {
+        Box::new(OHAudioOutput::new(OHAudioOutputConfig {
+            ring_buffer: config.ring_buffer,
+        }))
+    }
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "macos",
+        any(target_os = "ios", target_os = "tvos"),
+        target_os = "windows",
+        target_env = "ohos"
+    )))]
+    {
+        Box::new(BufferedAudioOutput::new(config.ring_buffer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PlayerConfig, audio::BufferedAudioOutput};
+    fn test_pump() -> AudioPump {
+        let player = Player::new(PlayerConfig::default());
+        let frames = player.subscribe_audio_frames();
+        AudioPump::new(
+            player,
+            frames,
+            Box::new(BufferedAudioOutput::new(AudioRingBufferConfig::default())),
+        )
+    }
+
+    struct BlockingOutput {
+        output: BufferedAudioOutput,
+        entered: Sender<()>,
+        release: Receiver<()>,
+        block_next: bool,
+        fail_stop: bool,
+        recover_on_push: bool,
+    }
+
+    impl AudioOutputBackend for BlockingOutput {
+        fn configure(&mut self, format: crate::ffmpeg::PcmFormat) -> crate::audio::Result<()> {
+            self.output.configure(format)
+        }
+        fn start(&mut self) -> crate::audio::Result<()> {
+            self.output.start()
+        }
+        fn pause(&mut self) -> crate::audio::Result<()> {
+            self.output.pause()
+        }
+        fn stop(&mut self) -> crate::audio::Result<()> {
+            if self.fail_stop {
+                return Err(crate::audio::AudioError::Backend(
+                    "injected stop failure".into(),
+                ));
+            }
+            self.output.stop()
+        }
+        fn set_volume(&mut self, volume: f32) {
+            self.output.set_volume(volume);
+        }
+        fn volume(&self) -> f32 {
+            self.output.volume()
+        }
+        fn push(
+            &mut self,
+            frame: crate::ffmpeg::PcmAudioFrame,
+        ) -> crate::audio::Result<crate::audio::AudioPushResult> {
+            if self.block_next {
+                self.block_next = false;
+                self.entered.send(()).unwrap();
+                self.release.recv_timeout(Duration::from_secs(1)).unwrap();
+            }
+            self.output.push(frame)
+        }
+        fn state(&self) -> crate::audio::AudioOutputState {
+            self.output.state()
+        }
+        fn stats(&self) -> crate::audio::AudioRingBufferStats {
+            self.output.stats()
+        }
+        fn clock_snapshot(&self) -> Option<AudioClockSnapshot> {
+            Some(self.output.clock_snapshot())
+        }
+        fn runtime_stats(&self) -> AudioOutputRuntimeStats {
+            if !self.recover_on_push {
+                return AudioOutputRuntimeStats::default();
+            }
+            let recovered = self.output.stats().written_frames > 0;
+            AudioOutputRuntimeStats {
+                recovery_state: if recovered {
+                    crate::audio::AudioRecoveryState::Stable
+                } else {
+                    crate::audio::AudioRecoveryState::Disconnected
+                },
+                transition_sequence: if recovered { 2 } else { 1 },
+                recovery_count: u64::from(recovered),
+                ..Default::default()
+            }
+        }
+    }
+
+    fn test_frame(generation: u64) -> PlayerAudioFrame {
+        PlayerAudioFrame {
+            generation,
+            frame: crate::ffmpeg::PcmAudioFrame {
+                format: crate::ffmpeg::PcmFormat::f32_interleaved(48000, 1),
+                pts: Some(Duration::ZERO),
+                frames: 480,
+                samples: vec![0.0; 480],
+            },
+        }
+    }
+
+    #[test]
+    fn quiesce_ack_waits_for_in_flight_push_and_fences_drain_and_reset() {
+        let player = Player::new(PlayerConfig::default());
+        let generation = player.playback_generation();
+        let (frames, receiver) = bounded(4);
+        let (entered, started) = bounded(1);
+        let (release, resume) = bounded(1);
+        let service = AudioService::with_factory(player, receiver, move || {
+            Box::new(BlockingOutput {
+                output: BufferedAudioOutput::new(AudioRingBufferConfig::default()),
+                entered,
+                release: resume,
+                block_next: true,
+                fail_stop: false,
+                recover_on_push: false,
+            })
+        })
+        .unwrap();
+        frames.send(test_frame(generation)).unwrap();
+        service.command(AudioCommand::Resume).unwrap();
+        started.recv_timeout(Duration::from_secs(1)).unwrap();
+        thread::scope(|scope| {
+            let (done, acknowledged) = bounded(1);
+            let service = &service;
+            scope.spawn(move || {
+                done.send(service.command(AudioCommand::Quiesce)).unwrap();
+            });
+            assert!(
+                acknowledged
+                    .recv_timeout(Duration::from_millis(20))
+                    .is_err()
+            );
+            release.send(()).unwrap();
+            acknowledged
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .unwrap();
+        });
+        let pushes = service.snapshot().pushed_audio_frames;
+        assert_eq!(pushes, 1);
+        frames.send(test_frame(generation)).unwrap();
+        service.command(AudioCommand::Drain).unwrap();
+        service.command(AudioCommand::Reset).unwrap();
+        service.command(AudioCommand::Resume).unwrap();
+        service.command(AudioCommand::Quiesce).unwrap();
+        assert_eq!(service.snapshot().pushed_audio_frames, pushes);
+        assert_eq!(service.snapshot().clock.unwrap().queued_frames, 0);
+    }
+
+    #[test]
+    fn expired_resume_cannot_reactivate_a_quiesced_owner() {
+        let player = Player::new(PlayerConfig::default());
+        let frames = player.subscribe_audio_frames();
+        let service = AudioService::with_factory(player, frames, || {
+            Box::new(BufferedAudioOutput::new(AudioRingBufferConfig::default()))
+        })
+        .unwrap();
+        let (reply, result) = bounded(1);
+        service
+            .commands
+            .send(Request {
+                command: AudioCommand::Resume,
+                reply,
+                deadline: Instant::now() - Duration::from_millis(1),
+            })
+            .unwrap();
+        assert!(
+            result
+                .recv_timeout(Duration::from_secs(1))
+                .unwrap()
+                .is_err()
+        );
+        service
+            .command(AudioCommand::Drain)
+            .expect("expired resume must leave owner quiesced");
+    }
+
+    #[test]
+    fn failed_device_reset_is_not_acknowledged_as_success() {
+        let (entered, _) = bounded(1);
+        let (_, release) = bounded(1);
+        let mut pump = test_pump();
+        pump.audio_output = Box::new(BlockingOutput {
+            output: BufferedAudioOutput::new(AudioRingBufferConfig::default()),
+            entered,
+            release,
+            block_next: false,
+            fail_stop: true,
+            recover_on_push: false,
+        });
+        pump.audio_configured = true;
+        assert!(pump.handle(AudioCommand::Reset).is_err());
+        assert!(pump.audio_configured);
+        assert_eq!(pump.stats.audio_failures, 1);
+    }
+
+    #[test]
+    fn device_recovery_events_are_published_even_without_a_presenter_tick() {
+        let (entered, _) = bounded(1);
+        let (_, release) = bounded(1);
+        let player = Player::new(PlayerConfig::default());
+        let events = player.subscribe();
+        let generation = player.playback_generation();
+        let (sender, frames) = bounded(1);
+        let mut pump = AudioPump::new(
+            player,
+            frames,
+            Box::new(BlockingOutput {
+                output: BufferedAudioOutput::new(AudioRingBufferConfig::default()),
+                entered,
+                release,
+                block_next: false,
+                fail_stop: false,
+                recover_on_push: true,
+            }),
+        );
+        sender.send(test_frame(generation)).unwrap();
+        pump.run_slice().unwrap();
+        let states: Vec<_> = events
+            .try_iter()
+            .filter_map(|event| match event {
+                crate::core::PlayerEvent::AudioOutputChanged(event) => {
+                    Some(event.stats.recovery_state)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            states,
+            vec![
+                crate::audio::AudioRecoveryState::Disconnected,
+                crate::audio::AudioRecoveryState::Stable
+            ]
+        );
+        assert_eq!(pump.last_audio_runtime_stats.recovery_count, 1);
+        assert_eq!(pump.player.state(), PlayerState::Idle);
+    }
+
+    #[test]
+    fn output_ignores_pcm_from_an_old_generation() {
+        let player = Player::new(PlayerConfig::default());
+        let generation = player.playback_generation();
+        let (sender, frames) = bounded(2);
+        let mut pump = AudioPump::new(
+            player,
+            frames,
+            Box::new(BufferedAudioOutput::new(AudioRingBufferConfig::default())),
+        );
+        sender.send(test_frame(generation - 1)).unwrap();
+        sender.send(test_frame(generation)).unwrap();
+        pump.pump_audio();
+        assert_eq!(pump.stats.pushed_audio_frames, 1);
+        assert_eq!(
+            pump.audio_output.clock_snapshot().unwrap().queued_frames,
+            480
+        );
+    }
+
+    #[test]
+    fn repeated_playback_rate_request_keeps_pending_transition_deadline() {
+        let deadline = Instant::now() + Duration::from_millis(250);
+        let pending = PendingPlaybackRate {
+            rate: 2.0,
+            commit_at: deadline,
+        };
+
+        assert!(playback_rate_request_is_idempotent(1.0, Some(pending), 2.0));
+        assert_eq!(pending.commit_at, deadline);
+        assert!(playback_rate_request_is_idempotent(2.0, None, 2.0));
+        assert!(!playback_rate_request_is_idempotent(
+            1.0,
+            Some(pending),
+            1.5
+        ));
+    }
+
+    #[test]
+    fn audio_transition_bridge_includes_platform_output_duration() {
+        let snapshot = AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
+            queued_duration: Some(Duration::from_millis(250)),
+            queued_frames: 12_000,
+            read_frames: 0,
+            written_frames: 12_000,
+            underflow_frames: 0,
+        };
+
+        assert_eq!(
+            audio_transition_bridge(Some(snapshot), Duration::from_millis(60)),
+            Some(Duration::from_millis(310))
+        );
+        assert_eq!(
+            audio_transition_bridge(
+                Some(AudioClockSnapshot {
+                    queued_duration: Some(Duration::ZERO),
+                    ..snapshot
+                }),
+                Duration::from_millis(60),
+            ),
+            Some(Duration::from_millis(60))
+        );
+    }
+
+    #[test]
+    fn audio_reset_preserves_pending_rate_for_transition() {
+        let mut presenter = test_pump();
+        presenter.pending_playback_rate = Some(PendingPlaybackRate {
+            rate: 2.0,
+            commit_at: Instant::now(),
+        });
+
+        presenter.reset_audio_output().unwrap();
+        assert_eq!(
+            presenter.pending_playback_rate.map(|pending| pending.rate),
+            Some(2.0)
+        );
+    }
+
+    #[test]
+    fn terminal_audio_reset_restores_committed_rate() {
+        use crate::audio::BufferedAudioOutput;
+        use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
+
+        let mut presenter = test_pump();
+        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
+        output.set_playback_rate(2.0);
+        presenter.audio_output = Box::new(output);
+        presenter.playback_rate = 1.0;
+        presenter.pending_playback_rate = Some(PendingPlaybackRate {
+            rate: 2.0,
+            commit_at: Instant::now(),
+        });
+
+        presenter.reset_audio_output_with_committed_rate().unwrap();
+        let format = PcmFormat::f32_interleaved(48_000, 2);
+        presenter
+            .audio_output
+            .push(PcmAudioFrame {
+                format,
+                pts: Some(Duration::ZERO),
+                frames: 24_000,
+                samples: vec![0.0; 48_000],
+            })
+            .unwrap();
+
+        assert_eq!(
+            presenter
+                .audio_output
+                .clock_snapshot()
+                .unwrap()
+                .queued_frames,
+            24_000
+        );
+        assert!(presenter.pending_playback_rate.is_none());
+    }
+
+    #[test]
+    fn failed_pending_rate_commit_clears_transition_state() {
+        let mut presenter = test_pump();
+        presenter.pending_playback_rate = Some(PendingPlaybackRate {
+            rate: 2.0,
+            commit_at: Instant::now(),
+        });
+
+        assert!(presenter.commit_pending_playback_rate_now().is_err());
+        assert!(presenter.pending_playback_rate.is_none());
+        assert_eq!(presenter.playback_rate, 1.0);
+    }
+
+    #[test]
+    fn playback_rate_uses_fast_audio_pump_limits() {
+        assert_eq!(
+            audio_pump_limits_for_rate(1.0),
+            (AUDIO_PUMP_FRAME_LIMIT, AUDIO_PUMP_TIME_BUDGET)
+        );
+        assert_eq!(
+            audio_pump_limits_for_rate(2.0),
+            (
+                AUDIO_FAST_RATE_PUMP_FRAME_LIMIT,
+                AUDIO_FAST_RATE_PUMP_TIME_BUDGET
+            )
+        );
+    }
+
+    #[test]
+    fn audio_clock_report_tracks_queue_and_underflow_changes() {
+        let mut presenter = test_pump();
+
+        let first = AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
+            queued_duration: Some(Duration::from_millis(500)),
+            queued_frames: 24_000,
+            read_frames: 0,
+            written_frames: 24_000,
+            underflow_frames: 0,
+        };
+        assert!(presenter.should_report_audio_clock(first));
+        assert!(!presenter.should_report_audio_clock(first));
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
+            queued_duration: Some(Duration::from_millis(300)),
+            queued_frames: 14_400,
+            read_frames: 0,
+            written_frames: 19_200,
+            underflow_frames: 0,
+        }));
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
+            media_time: Some(Duration::from_millis(100)),
+            queued_duration: Some(Duration::ZERO),
+            queued_frames: 0,
+            read_frames: 0,
+            written_frames: 24_000,
+            underflow_frames: 512,
+        }));
+
+        presenter.playback_rate = 2.0;
+        assert!(presenter.should_report_audio_clock(AudioClockSnapshot {
+            media_time: Some(Duration::from_secs(1)),
+            queued_duration: Some(Duration::from_millis(300)),
+            queued_frames: 14_400,
+            read_frames: 14_400,
+            written_frames: 28_800,
+            underflow_frames: 0,
+        }));
+    }
+
+    #[test]
+    fn audio_start_is_blocked_while_player_is_not_playing() {
+        use crate::audio::{AudioOutputState, BufferedAudioOutput};
+        use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
+
+        let mut presenter = test_pump();
+        let format = PcmFormat::f32_interleaved(48_000, 2);
+        let mut output = BufferedAudioOutput::new(AudioRingBufferConfig::default());
+        output.configure(format).unwrap();
+        output
+            .push(PcmAudioFrame {
+                format,
+                pts: Some(Duration::ZERO),
+                frames: 12_000,
+                samples: vec![0.0; 24_000],
+            })
+            .unwrap();
+        presenter.audio_output = Box::new(output);
+
+        presenter.ensure_audio_started();
+
+        assert!(!presenter.audio_started);
+        assert_eq!(presenter.audio_output.state(), AudioOutputState::Stopped);
+    }
+}

--- a/crates/erika/src/presenter/audio_integration.rs
+++ b/crates/erika/src/presenter/audio_integration.rs
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MPL-2.0
+// Real FFmpeg/Player/Presenter/audio-owner integration. Only rendering and the
+// device callback are simulated; there is no test-only PCM feeder.
+use super::*;
+use crate::audio::{
+    AudioClockSnapshot, AudioOutputBackend, AudioOutputState, AudioPushResult,
+    AudioRingBufferStats, BufferedAudioOutput,
+};
+use crate::ffmpeg::{PcmAudioFrame, PcmFormat};
+use crate::playback::VideoDecodePreference;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+struct Output {
+    ring: Arc<Mutex<BufferedAudioOutput>>,
+    owner: thread::ThreadId,
+}
+
+impl Output {
+    fn check_owner(&self) {
+        assert_eq!(self.owner, thread::current().id());
+    }
+}
+
+impl Drop for Output {
+    fn drop(&mut self) {
+        self.check_owner();
+    }
+}
+
+impl AudioOutputBackend for Output {
+    fn configure(&mut self, format: PcmFormat) -> crate::audio::Result<()> {
+        self.check_owner();
+        self.ring.lock().unwrap().configure(format)
+    }
+    fn start(&mut self) -> crate::audio::Result<()> {
+        self.check_owner();
+        self.ring.lock().unwrap().start()
+    }
+    fn pause(&mut self) -> crate::audio::Result<()> {
+        self.check_owner();
+        self.ring.lock().unwrap().pause()
+    }
+    fn stop(&mut self) -> crate::audio::Result<()> {
+        self.check_owner();
+        self.ring.lock().unwrap().stop()
+    }
+    fn set_volume(&mut self, value: f32) {
+        self.check_owner();
+        self.ring.lock().unwrap().set_volume(value);
+    }
+    fn volume(&self) -> f32 {
+        self.check_owner();
+        self.ring.lock().unwrap().volume()
+    }
+    fn set_playback_rate(&mut self, value: f64) {
+        self.check_owner();
+        self.ring.lock().unwrap().set_playback_rate(value);
+    }
+    fn push(&mut self, frame: PcmAudioFrame) -> crate::audio::Result<AudioPushResult> {
+        self.check_owner();
+        self.ring.lock().unwrap().push(frame)
+    }
+    fn state(&self) -> AudioOutputState {
+        self.check_owner();
+        self.ring.lock().unwrap().state()
+    }
+    fn stats(&self) -> AudioRingBufferStats {
+        self.check_owner();
+        self.ring.lock().unwrap().stats()
+    }
+    fn clock_snapshot(&self) -> Option<AudioClockSnapshot> {
+        self.check_owner();
+        Some(self.ring.lock().unwrap().clock_snapshot())
+    }
+}
+
+struct Renderer {
+    stall_ms: Arc<AtomicU64>,
+    uploaded: bool,
+}
+
+impl RendererBackend for Renderer {
+    fn attach_surface(&mut self, _: PlatformSurface) -> Result<()> {
+        Ok(())
+    }
+    fn detach_surface(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn resize_surface(&mut self, _: SurfaceMetrics) -> Result<()> {
+        Ok(())
+    }
+    fn render_test_frame(&mut self, _: f64) -> Result<()> {
+        Ok(())
+    }
+    fn upload_player_frame(&mut self, _: &PlayerVideoFrame) -> Result<()> {
+        self.uploaded = true;
+        Ok(())
+    }
+    fn render_current_frame(&mut self, _: RenderFrameContext<'_>) -> Result<bool> {
+        let millis = self.stall_ms.swap(0, Ordering::SeqCst);
+        if millis > 0 {
+            thread::sleep(Duration::from_millis(millis));
+        }
+        Ok(self.uploaded)
+    }
+
+    fn runtime_stats(&self) -> RendererRuntimeStats {
+        RendererRuntimeStats {
+            attached: true,
+            surface_width: 64,
+            surface_height: 36,
+            ..Default::default()
+        }
+    }
+}
+
+struct Harness {
+    presenter: PresenterRuntime,
+    ring: Arc<Mutex<BufferedAudioOutput>>,
+    stall_ms: Arc<AtomicU64>,
+    done: Arc<AtomicBool>,
+    callback: Option<thread::JoinHandle<()>>,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let mut config = PresenterConfig::default();
+        config.player.playback.video_decode = VideoDecodePreference::Software;
+        let mut presenter = PresenterRuntime::new(config).unwrap();
+        let ring = Arc::new(Mutex::new(BufferedAudioOutput::new(
+            AudioRingBufferConfig::default(),
+        )));
+        let output_ring = ring.clone();
+        presenter.audio = AudioService::with_factory(
+            presenter.player.clone(),
+            presenter.player.subscribe_audio_frames(),
+            move || {
+                Box::new(Output {
+                    ring: output_ring,
+                    owner: thread::current().id(),
+                })
+            },
+        )
+        .unwrap();
+        let stall_ms = Arc::new(AtomicU64::new(0));
+        presenter.renderer = Box::new(Renderer {
+            stall_ms: stall_ms.clone(),
+            uploaded: false,
+        });
+        presenter.current_surface_metrics = Some(SurfaceMetrics::new(64, 36, 1.0));
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("testdata/playback/playback-fixture.mkv");
+        presenter
+            .open(MediaRequest::new(fixture.to_string_lossy()))
+            .unwrap();
+        let done = Arc::new(AtomicBool::new(false));
+        let callback_ring = ring.clone();
+        let callback_done = done.clone();
+        let callback = thread::spawn(move || {
+            let mut last = Instant::now();
+            let mut fractional = 0.0;
+            while !callback_done.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(2));
+                let now = Instant::now();
+                let elapsed = now.duration_since(last);
+                last = now;
+                let mut output = callback_ring.lock().unwrap();
+                if output.state() == AudioOutputState::Playing {
+                    let format = output.buffer().format().unwrap();
+                    let exact = elapsed.as_secs_f64() * format.sample_rate as f64 + fractional;
+                    let frames = exact.floor() as usize;
+                    fractional = exact - frames as f64;
+                    output
+                        .read_interleaved(&mut vec![0.0; frames * format.channels as usize])
+                        .unwrap();
+                } else {
+                    fractional = 0.0;
+                }
+            }
+        });
+        Self {
+            presenter,
+            ring,
+            stall_ms,
+            done,
+            callback: Some(callback),
+        }
+    }
+
+    fn tick_for(&mut self, duration: Duration) {
+        let started = Instant::now();
+        while started.elapsed() < duration {
+            self.presenter
+                .render_tick(started.elapsed().as_secs_f64())
+                .unwrap();
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn snapshot(&self) -> AudioClockSnapshot {
+        self.ring.lock().unwrap().clock_snapshot()
+    }
+
+    fn start(&mut self) {
+        self.presenter.play().unwrap();
+        self.tick_for(Duration::from_millis(1000));
+        assert_eq!(self.ring.lock().unwrap().state(), AudioOutputState::Playing);
+        assert!(self.snapshot().read_frames > 0);
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        let _ = self.presenter.close();
+        self.done.store(true, Ordering::SeqCst);
+        if let Some(callback) = self.callback.take() {
+            let _ = callback.join();
+        }
+    }
+}
+
+#[test]
+fn render_stalls_do_not_starve_the_production_audio_owner() {
+    for stall_ms in [733, 1600] {
+        let mut h = Harness::new();
+        h.start();
+        let before = h.snapshot();
+        assert!(before.queued_duration.unwrap() < Duration::from_millis(300));
+        h.stall_ms.store(stall_ms, Ordering::SeqCst);
+        let started = Instant::now();
+        h.presenter.render_tick(1.0).unwrap();
+        assert!(started.elapsed() >= Duration::from_millis(stall_ms));
+        let after = h.snapshot();
+        let underflow = Duration::from_secs_f64(
+            (after.underflow_frames - before.underflow_frames) as f64 / 48000.0,
+        );
+        let gap = h
+            .presenter
+            .player
+            .current_media_time()
+            .abs_diff(after.media_time.unwrap());
+        eprintln!(
+            "audio-owner stall={stall_ms}ms queued_before={:?} underflow={underflow:?} clock_gap={gap:?}",
+            before.queued_duration
+        );
+        assert!(underflow < Duration::from_millis(30));
+        assert!(after.read_frames > before.read_frames + stall_ms * 40);
+        assert!(gap < Duration::from_millis(40));
+        h.tick_for(Duration::from_millis(100));
+    }
+}
+
+#[test]
+fn rate_commit_and_audio_progress_do_not_wait_for_rendering() {
+    let mut h = Harness::new();
+    h.start();
+    h.presenter.set_playback_rate(2.0).unwrap();
+    let before = h.snapshot();
+    h.stall_ms.store(1600, Ordering::SeqCst);
+    h.presenter.render_tick(1.0).unwrap();
+    let after = h.snapshot();
+    assert_eq!(h.presenter.audio.snapshot().playback_rate, 2.0);
+    assert_eq!(h.presenter.player.playback_snapshot().clock.rate(), 2.0);
+    assert!(after.media_time.unwrap() - before.media_time.unwrap() > Duration::from_secs(2));
+    assert!(after.underflow_frames - before.underflow_frames < 1440);
+    assert!(
+        h.presenter
+            .player
+            .current_media_time()
+            .abs_diff(after.media_time.unwrap())
+            < Duration::from_millis(50)
+    );
+}
+
+#[test]
+fn background_audio_continues_and_foreground_video_resume_keeps_audio_alive() {
+    let mut h = Harness::new();
+    h.start();
+    h.presenter.audio_only_tick().unwrap();
+    let before = h.snapshot();
+    // No host ticks are required to keep the opted-in audio path supplied.
+    thread::sleep(Duration::from_millis(400));
+    let background = h.snapshot();
+    assert!(background.read_frames > before.read_frames + 16000);
+    assert!(background.underflow_frames - before.underflow_frames < 1440);
+    h.tick_for(Duration::from_millis(500));
+    assert!(!h.presenter.audio_only_tick_active);
+    assert!(h.snapshot().read_frames > background.read_frames);
+    assert!(h.snapshot().underflow_frames - background.underflow_frames < 1440);
+    assert!(
+        h.presenter
+            .player
+            .current_media_time()
+            .abs_diff(h.snapshot().media_time.unwrap())
+            < Duration::from_millis(50)
+    );
+}
+
+#[test]
+fn track_switch_and_open_clear_queued_audio_and_pending_rate() {
+    let mut h = Harness::new();
+    h.start();
+    h.presenter.set_volume(0.35);
+    let before = h.snapshot();
+    let generation = h.presenter.player.playback_generation();
+    h.presenter.select_audio_track(Some(2)).unwrap();
+    h.tick_for(Duration::from_millis(500));
+    assert_eq!(h.presenter.player.track_selection().audio, Some(2));
+    assert!(h.presenter.player.playback_generation() > generation);
+    assert!(h.snapshot().media_time.unwrap() >= before.media_time.unwrap());
+    assert!(h.snapshot().read_frames > before.read_frames);
+    h.presenter.set_playback_rate(2.0).unwrap();
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/playback/playback-fixture.mkv");
+    h.presenter
+        .open(MediaRequest::new(fixture.to_string_lossy()))
+        .unwrap();
+    assert_eq!(h.snapshot().queued_frames, 0);
+    assert_eq!(h.presenter.player.state(), crate::core::PlayerState::Ready);
+    assert_eq!(h.presenter.audio.snapshot().playback_rate, 1.0);
+    assert!((h.presenter.volume() - 0.35).abs() < 0.00001);
+    h.presenter.play().unwrap();
+    h.tick_for(Duration::from_millis(500));
+    assert!(h.snapshot().media_time.unwrap() < Duration::from_secs(2));
+    assert_eq!(h.ring.lock().unwrap().state(), AudioOutputState::Playing);
+}
+
+#[test]
+fn natural_eof_drains_audio_and_replay_restarts_the_owner() {
+    let mut h = Harness::new();
+    h.start();
+    let duration = h.presenter.player.duration().unwrap();
+    h.presenter.seek(duration - Duration::from_secs(1)).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(4);
+    while Instant::now() < deadline && !h.presenter.player.is_stopped_at_end() {
+        h.tick_for(Duration::from_millis(20));
+    }
+    assert!(h.presenter.player.is_stopped_at_end());
+    let final_position = h.presenter.player.current_media_time();
+    h.tick_for(Duration::from_millis(400));
+    assert_eq!(h.presenter.player.current_media_time(), final_position);
+    assert_eq!(h.snapshot().queued_frames, 0);
+    let read_frames = h.snapshot().read_frames;
+    thread::sleep(Duration::from_millis(20));
+    assert_eq!(h.snapshot().read_frames, read_frames);
+    h.presenter.play().unwrap();
+    h.tick_for(Duration::from_millis(500));
+    assert_eq!(h.ring.lock().unwrap().state(), AudioOutputState::Playing);
+    assert!(h.snapshot().media_time.unwrap() < Duration::from_secs(2));
+}
+
+#[test]
+fn pause_seek_stop_and_replay_keep_audio_on_the_current_timeline() {
+    let mut h = Harness::new();
+    h.start();
+    let old = h
+        .presenter
+        .player
+        .capture_audio_clock(|| Some(h.snapshot()))
+        .unwrap();
+    h.presenter.set_playback_rate(2.0).unwrap();
+    h.presenter.pause().unwrap();
+    let paused = h.presenter.player.current_media_time();
+    let read = h.snapshot().read_frames;
+    h.tick_for(Duration::from_millis(60));
+    assert_eq!(h.presenter.player.current_media_time(), paused);
+    assert_eq!(h.snapshot().read_frames, read);
+    assert_ne!(h.ring.lock().unwrap().state(), AudioOutputState::Playing);
+    h.presenter.seek(Duration::from_secs(3)).unwrap();
+    h.presenter
+        .player
+        .update_audio_clock_observation(old)
+        .unwrap();
+    h.tick_for(Duration::from_millis(100));
+    assert_eq!(
+        h.presenter.player.current_media_time(),
+        Duration::from_secs(3)
+    );
+    assert_eq!(h.snapshot().read_frames, read);
+    assert!(
+        h.snapshot()
+            .media_time
+            .is_none_or(|time| time >= Duration::from_secs(3))
+    );
+    h.presenter.play().unwrap();
+    h.tick_for(Duration::from_millis(500));
+    assert!(h.snapshot().media_time.unwrap() >= Duration::from_secs(3));
+    assert!(h.snapshot().read_frames > read);
+    h.presenter.stop().unwrap();
+    assert_eq!(h.snapshot().queued_frames, 0);
+    assert_eq!(h.ring.lock().unwrap().state(), AudioOutputState::Stopped);
+    h.presenter.set_playback_rate(1.0).unwrap();
+    h.presenter.play().unwrap();
+    h.tick_for(Duration::from_millis(500));
+    assert!(h.snapshot().media_time.unwrap() < Duration::from_secs(2));
+    h.presenter.close().unwrap();
+    let closed = h.snapshot();
+    thread::sleep(Duration::from_millis(20));
+    assert_eq!(h.snapshot(), closed);
+    assert_eq!(closed.queued_frames, 0);
+    assert!(h.presenter.play().is_err());
+}

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -72,7 +72,7 @@ Decoder availability は session invariant です。video track が選択され�
 generation、command sequence、output epoch、単調な取得時刻を保持します。
 worker は現在の再生意図と実行済みコマンドの両方を照合し、取得から 500 ms で
 観測値を失効させます。キューと buffering の判断にも同じ検証を適用します。
-presenter は出力リセット、再設定、デバイス状態の遷移、速度変更で epoch を
+音声の所有者は出力リセット、再設定、デバイス状態の遷移、速度変更で epoch を
 更新します。取得と出力変更は引き続き出力の所有者が直列化します。
 
 engine は最初に基準値を記録し、消費した PCM frame 数と media time の両方が
@@ -84,12 +84,24 @@ background 再生と foreground の video 復帰中も、動作中の audio mast
 
 従来の Rust API `update_audio_clock(snapshot)` は現在の時間軸で即座に取得する
 同期フィードバック向けに残ります。保存済み snapshot の取得時の識別情報は
-復元できないため、遅延する呼び出しには観測 API を使います。C ABI とキューの
-目標量は変更せず、250 ms の速度変更 bridge と遷移中の混在した速度の観測を
-抑制する契約を維持します。音声供給はまだ presenter tick 内で行うため、描画が
-止まると underflow は発生し得ます。時刻の復旧と音声供給の独立化は別の処理です。
+復元できないため、遅延する呼び出しには観測 API を使います。C ABI は変えません。
+専用の音声スレッドが backend の作成、呼び出し、破棄をすべて担当し、backend の
+`Send` 実装は不要です。worker の有界 PCM channel を消費し、SoundTouch、時刻と
+デバイスの報告、速度変更の確定を描画から独立して行います。キューへの追加には
+既存の 250 ms bridge の目標を使い、速度が混在する期間の観測抑制を維持します。
 
-- **macOS**: ring buffer と PTS-tracking clock snapshot を持つ CoreAudio 出力。presenter は snapshot を player worker に返し、audio-master clock discipline を維持します。
+Presenter は ACK 付きの command channel で制御します。切替時は音声の消費者、
+再生の生産者の順に静止させ、両方の確認後に出力とキューをリセットします。
+再開時は生産者を先に戻します。backend 呼び出しや ACK 待ちの間、共有 snapshot の
+mutex は保持しません。現在の generation の video が正常に表示されてから音声を
+開始します。自然な EOF では残りの PCM を device に渡して command を待ちます。
+空の ring を hardware の再生完了とは判断しません。明示的な reset/stop/close で
+出力を解放し、破棄時に thread を join します。background 再生の opt-in は
+維持します。`audio_only_tick` は video の停止と foreground 復帰を制御し、開始済み
+音声の継続には host tick は不要です。音声の停止には pause/stop/close を使います。
+display timer を止めるだけでは音声供給は止まりません。
+
+- **macOS**: ring buffer と PTS-tracking clock snapshot を持つ CoreAudio 出力。音声の所有者は snapshot を player worker に返し、audio-master clock discipline を維持します。
 - **iOS**: 同じ ring buffer / clock snapshot model を持つ AudioQueue 出力。
 - Ring buffer: interleaved f32、容量可変、overflow は oldest drop、volume control 対応。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ Clock feedback uses `Player::capture_audio_clock` and
 playback generation, command sequence, output epoch, and monotonic capture time.
 The worker checks this identity against both the current intent and executed
 commands, and expires feedback after 500 ms measured from capture. The same
-validation protects queue and buffering decisions. The presenter invalidates
+validation protects queue and buffering decisions. The audio owner invalidates
 the output epoch on reset, reconfiguration, device transitions, and rate changes;
 reads and output changes remain serialized by the output owner.
 
@@ -109,13 +109,28 @@ active during background playback and foreground video recovery.
 The older `update_audio_clock(snapshot)` Rust API remains available for fresh,
 synchronous feedback on the current timeline; it cannot recover the capture
 identity of a previously cached snapshot. Delayed callers should use the
-observation API. This does not change the C ABI or queue targets: the 250 ms rate
-bridge and suppression of mixed-rate observations remain in place. Audio pumping
-still runs in the presenter tick, so a blocked renderer can still cause underflow;
-clock recovery does not replace independent audio delivery.
+observation API. The C ABI is unchanged. A dedicated audio owner creates, calls,
+and destroys each backend on its own thread, without requiring the backend to
+be `Send`. It consumes the bounded worker channel, performs SoundTouch processing,
+publishes clock/device feedback, and commits rate changes independently of
+rendering. Queue admission uses the existing 250 ms rate-bridge target;
+mixed-rate observations remain suppressed during the bridge.
+
+Presenter controls use an acknowledged command channel. A transition first
+quiesces the audio consumer, then the playback producer; only after both
+boundaries may it reset the output and drain queues. The producer resumes before
+the consumer. No snapshot mutex is held during a backend call or while waiting
+for an acknowledgement. A generation-specific successful video present releases
+the audio-start gate. At natural EOF the owner sleeps once remaining PCM reaches
+the device; it does not equate an empty ring with a fully played hardware tail.
+Explicit reset/stop/close still release the output; destruction joins the thread.
+Host background-playback opt-in remains unchanged: `audio_only_tick` controls
+video suspension and foreground recovery, while audio delivery needs no host
+tick once started. Hosts must use pause/stop/close to stop audio; stopping their
+display timer alone no longer starves it.
 
 - **macOS**: CoreAudio output with ring buffer and PTS-tracking clock snapshots.
-  The presenter feeds CoreAudio output snapshots back to the player worker for
+  The audio owner feeds CoreAudio output snapshots back to the player worker for
   audio-master clock discipline.
 - **iOS**: AudioQueue output with the same ring buffer and clock snapshot model.
 - Ring buffer: interleaved f32, configurable capacity, drop-oldest overflow

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -71,7 +71,7 @@ cargo run -p xtask -- deps status
 `update_audio_clock_observation` 传递。观测保留 player 身份、播放 generation、
 命令序号、输出 epoch 和单调采样时间。worker 同时核对当前意图与已执行命令，
 并从采样时刻计算 500 ms 有效期；队列与缓冲决策使用相同的有效性检查。
-presenter 在输出重置、重新配置、设备状态切换和倍速切换时使旧 epoch 失效；
+音频拥有者在输出重置、重新配置、设备状态切换和倍速切换时使旧 epoch 失效；
 输出拥有者仍需串行执行采样与输出变更。
 
 引擎先建立观测基线，随后要求已消耗 PCM 帧数与媒体时间同时推进，才校正共享的
@@ -81,12 +81,21 @@ presenter 在输出重置、重新配置、设备状态切换和倍速切换时�
 仍在运行的音频主时钟继续生效。
 
 原有 Rust API `update_audio_clock(snapshot)` 保留给当前时间线的即时同步反馈，
-无法还原缓存快照的原始采样身份；延迟反馈应使用新的观测 API。C ABI 与队列目标
-不变，保留 250 ms 倍速桥接及过渡期间抑制混合倍速反馈的契约。
-音频喂送仍在 presenter tick 中执行，渲染阻塞仍可能造成欠载；时钟恢复不能替代
-音频喂送与渲染的独立调度。
+无法还原缓存快照的原始采样身份；延迟反馈应使用新的观测 API。C ABI 不变。
+独立音频拥有者在自己的线程内创建、调用并销毁后端，无需强制后端实现 `Send`。
+它消费 worker 的有界 PCM 通道，处理 SoundTouch、发布时钟/设备反馈并提交倍速变更，
+不依赖渲染。队列准入沿用 250 ms 倍速桥接目标，过渡期间仍抑制混合倍速反馈。
 
-- **macOS**：CoreAudio 输出，带 ring buffer 和 PTS 跟踪的 clock snapshot。presenter 会把输出快照回传给 player worker 做音频主时钟约束。
+Presenter 通过带确认的命令通道控制音频。切换时先静止音频消费者，再静止播放生产者，
+两个边界确认后才重置输出、清理队列；恢复时先恢复生产者，再恢复消费者。
+等待确认或调用后端期间不持有共享快照锁。当前 generation 的视频成功呈现后才解除
+音频启动门控。自然 EOF 将剩余 PCM 交给设备后，音频线程等待命令，不把空环误当作
+硬件尾音已播放完毕；显式 reset/stop/close 仍释放输出，销毁时 join。
+宿主后台播放仍须显式启用：`audio_only_tick` 保留视频暂停及前台恢复
+的控制职责，而启动后的持续供音不再需要宿主 tick。停止声音应调用 pause/stop/close；
+仅停止显示定时器不会再让音频断供。
+
+- **macOS**：CoreAudio 输出，带 ring buffer 和 PTS 跟踪的 clock snapshot。音频拥有者会把输出快照回传给 player worker 做音频主时钟约束。
 - **iOS**：AudioQueue 输出，使用同样的 ring buffer 和 clock snapshot 模型。
 - Ring buffer：interleaved f32、容量可配、溢出丢最旧、支持音量控制。
 

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -532,6 +532,12 @@ Windows のフレームスケジューラなど）。`time_seconds` はそのフ
 ラインカウンタのスナップショットが書き込まれます。`poll_event` は非ブロッキングで、
 アイドル時は `NoEvent` を返します。
 
+PCM 供給と音声時刻の報告は専用スレッドで実行するため、描画の停止で音声供給は
+止まりません。`erika_presenter_audio_only_tick` は background の video 停止と
+foreground 復帰の状態を制御します。通常の video 再生中に別の timer から呼ばないで
+ください。host は引き続き background 再生の許可を管理し、音声を止めるときは
+pause/stop/close を呼びます。display timer の停止だけでは音声は止まりません。
+
 `get_stats` は同じ `ErikaPresenterStats` スナップショットを、フレームを描画せずに
 書き込みます。ホストが表示ループとは別の周期でカウンタをサンプリングする場合に
 使ってください。プレゼンテーションは進みません。

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -578,8 +578,13 @@ animation, so pass the presentation timestamp, not wall-clock deltas. If
 `out_stats` is non-`NULL` it is filled with a snapshot of pipeline counters.
 `poll_event` is non-blocking and returns `NoEvent` when idle.
 
-`audio_only_tick` advances audio output without rendering, for hosts that have
-no surface attached:
+`audio_only_tick` selects background video suspension and refreshes playback
+state without rendering. PCM delivery and audio-clock feedback run on the
+independent audio owner, so a render stall does not stop sound. Hosts still
+apply their background-playback policy and call pause/stop/close when audio must
+stop; merely stopping the display timer does not stop audio. Do not call this
+entry point from a second timer during normal video playback, because it changes
+video suspension and foreground-resume state:
 
 ```c
 ErikaStatus erika_presenter_audio_only_tick(ErikaPresenterHandle *, ErikaPresenterStats *out_stats);

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -503,6 +503,11 @@ ErikaStatus erika_presenter_poll_event(ErikaPresenterHandle *, ErikaEvent *out_e
 所以传**呈现时间戳**，不是 wall-clock 增量。若 `out_stats` 非 `NULL`，会填入流水线
 计数器快照。`poll_event` 非阻塞，空闲时返回 `NoEvent`。
 
+PCM 供给和音频时钟反馈由独立音频线程执行，渲染阻塞不会停止供音。
+`erika_presenter_audio_only_tick` 保留后台视频暂停及前台恢复的状态控制职责；
+不要在正常视频播放时另开定时器调用它。宿主仍负责后台播放许可，并在需要停止声音时
+调用 pause/stop/close；仅停止显示定时器不会停止供音。
+
 `get_stats` 填入同样的 `ErikaPresenterStats` 快照，但不渲染帧。当宿主采样计数器的
 节奏与显示循环不同时用它；它不推进呈现。
 


### PR DESCRIPTION
## Problem and behavior

Presenter currently supplies PCM and renders on the same host tick. A blocked
render call therefore stops PCM delivery even though decoding and the audio device
can continue. This PR gives audio delivery its own owner so rendering stalls do
not interrupt an otherwise running audio stream. Video remains scheduled against
the shared playback clock when rendering becomes available again.

## Dependency and review scope

Validated clock observations and foreground audio continuity are provided by
#131, which is now merged into `main`. This PR targets `main` and contains only
the audio ownership refactor and its tests/documentation. There are no changes to
`core.rs`, `playback.rs`, Metal, or clock-validity rules in this diff.

This remains a draft for independent architecture review.

## Implementation

- A dedicated `erika-audio` thread creates, calls and destroys the backend. A
  factory creates the platform object inside that thread, so no unsafe backend
  `Send` implementation is required. It owns the bounded PCM receiver, SoundTouch,
  clock/device reports, and pending playback-rate commits.
- Acknowledged commands fence lifecycle transitions: quiesce the consumer before
  the producer, reset/drain after both ACKs, then resume producer before consumer.
  Expired queued commands do not execute later; failed resets return errors.
  No shared snapshot lock spans a backend operation or an ACK wait.
- Existing pause, seek, track changes, open/close, stop/replay, device recovery,
  background opt-in and foreground video recovery contracts remain in force.
  A successful video present for the current generation releases the audio-start
  gate. Natural EOF hands remaining PCM to the device and parks the feeder without
  cutting off the hardware tail; explicit stop/close still release output.
- Queue admission retains the 250 ms high-water target and #82's old-rate bridge.
  Pending rates commit even while rendering is blocked, and mixed-rate feedback
  remains suppressed.
- The C ABI and host bindings are unchanged. Documentation in English, Chinese and
  Japanese explains that hosts use pause/stop/close to stop audio; stopping a
  display timer alone no longer starves it. `audio_only_tick` retains its video
  suspension/foreground recovery role.

## Validation

The integration harness uses real FFmpeg fixture decoding, Player worker,
Presenter, the production audio owner and BufferedAudioOutput ring. Only render
stalls and the wall-time device callback are simulated; there is no extra feeder.

| Render stall | Queue before stall | Underflow | Core/ring clock gap after return |
| --- | ---: | ---: | ---: |
| 733 ms | 158.292 ms | 0 ms | 2.850 ms absolute |
| 1600 ms | 154.563 ms | 0 ms | 1.206 ms absolute |

- Default core library tests: **511 passed**.
- Core library with `wgpu`: **557 passed**. Includes the render-stall/rate tests,
  pause/seek/stop/replay/close, natural EOF, track changes/open, foreground recovery,
  quiesce during an in-flight push, command expiry, failed reset and device events.
- Core Clippy with all targets/features and formatting pass, with existing Clippy
  warnings. Tests were rerun on the exact head after incorporating the Windows
  changes from #129 through the updated #131 base.
- C API tests: **41 passed** on Windows. The earlier upscaler-status failure no
  longer occurs after incorporating #129.

These measurements concern core/ring clocks, not physical DAC/display latency or
macOS native fullscreen animation. See this PR's checks for platform build results.
