### PR TITLE
fix(renderer): pre-scale P010 UNORM samples before range expansion

### DIFF
--- a/crates/erika/src/renderer/d3d11.rs
+++ b/crates/erika/src/renderer/d3d11.rs
@@ -261,6 +261,12 @@ float4 final_output(float3 rgb, float alpha) {
 }
 
 void expand_ycbcr_range(float y_in, float2 cbcr_in, out float y, out float2 cbcr) {
+    if (is_p010 != 0u) {
+        // P010 stores 10-bit codes as code << 6 in a 16-bit UNORM texture.
+        const float p010_scale = 65535.0 / 65472.0;
+        y_in *= p010_scale;
+        cbcr_in *= p010_scale;
+    }
     if (full_range != 0u) {
         y = y_in;
         cbcr = cbcr_in - float2(0.5, 0.5);

--- a/crates/erika/src/renderer/metal/apple.rs
+++ b/crates/erika/src/renderer/metal/apple.rs
@@ -2969,6 +2969,12 @@ struct RangeExpandedYCbCr {
 };
 
 RangeExpandedYCbCr expand_ycbcr_range(float y, float2 cbcr, constant VideoUniforms& uniforms) {
+    if (uniforms.is_p010 != 0) {
+        // P010 stores 10-bit codes as code << 6 in a 16-bit UNORM texture.
+        constexpr float p010_scale = 65535.0 / 65472.0;
+        y *= p010_scale;
+        cbcr *= p010_scale;
+    }
     if (uniforms.full_range != 0) {
         return RangeExpandedYCbCr { y, cbcr - float2(0.5) };
     }

--- a/crates/erika/src/renderer/pipeline.rs
+++ b/crates/erika/src/renderer/pipeline.rs
@@ -929,6 +929,23 @@ mod tests {
     }
 
     #[test]
+    fn p010_unorm_prescale_is_present_across_video_shaders() {
+        // P010 packs 10-bit codes as code << 6, so the UNORM sampler reads
+        // 64/65472 for full black instead of the nominal 64/1023. Every
+        // backend must undo this before range expansion, or limited-range
+        // P010 renders slightly lifted and slightly dull.
+        let shaders = [
+            include_str!("wgpu_video.wgsl"),
+            include_str!("metal/apple.rs"),
+            include_str!("d3d11.rs"),
+        ];
+        for shader in shaders {
+            assert!(shader.contains("65535.0 / 65472.0"));
+            assert!(shader.contains("P010 stores 10-bit codes as code << 6"));
+        }
+    }
+
+    #[test]
     fn overlay_shaders_handle_sdr_ui_for_hdr_targets() {
         let metal = include_str!("metal/apple.rs");
         let d3d11 = include_str!("d3d11.rs");

--- a/crates/erika/src/renderer/wgpu_video.wgsl
+++ b/crates/erika/src/renderer/wgpu_video.wgsl
@@ -194,19 +194,27 @@ struct RangeExpandedYCbCr {
 };
 
 fn expand_ycbcr_range(y_in: f32, cbcr_in: vec2<f32>) -> RangeExpandedYCbCr {
+    var y = y_in;
+    var cbcr = cbcr_in;
+    if (uniforms.is_p010 != 0u) {
+        // P010 stores 10-bit codes as code << 6 in a 16-bit UNORM texture.
+        let p010_scale = 65535.0 / 65472.0;
+        y *= p010_scale;
+        cbcr *= p010_scale;
+    }
     var out: RangeExpandedYCbCr;
     if (uniforms.full_range != 0u) {
-        out.y = y_in;
-        out.cbcr = cbcr_in - vec2<f32>(0.5);
+        out.y = y;
+        out.cbcr = cbcr - vec2<f32>(0.5);
         return out;
     }
     if (uniforms.is_p010 != 0u) {
-        out.y = (y_in - (64.0 / 1023.0)) * (1023.0 / 876.0);
-        out.cbcr = (cbcr_in - vec2<f32>(512.0 / 1023.0)) * (1023.0 / 896.0);
+        out.y = (y - (64.0 / 1023.0)) * (1023.0 / 876.0);
+        out.cbcr = (cbcr - vec2<f32>(512.0 / 1023.0)) * (1023.0 / 896.0);
         return out;
     }
-    out.y = (y_in - (16.0 / 255.0)) * (255.0 / 219.0);
-    out.cbcr = (cbcr_in - vec2<f32>(128.0 / 255.0)) * (255.0 / 224.0);
+    out.y = (y - (16.0 / 255.0)) * (255.0 / 219.0);
+    out.cbcr = (cbcr - vec2<f32>(128.0 / 255.0)) * (255.0 / 224.0);
     return out;
 }
 


### PR DESCRIPTION
## 概要

修复 P010 的 UNORM 采样预缩放缺失：三端视频 shader（WGSL / Metal MSL / D3D11 HLSL）在范围展开前统一补上 `65535.0 / 65472.0` 的反打包缩放。

## 背景

P010 将 10 位采样码以 `code << 6` 形式存入 16 位 UNORM 纹理。采样器按 16 位 UNORM 归一化得到 `sample / 65535`，而范围展开常数（`64.0/1023.0`、`1023.0/876.0` 等）假设输入是 `sample / 1023`。不补偿时每个采样读暗约 0.096%：黑位略微负值后被钳到 0，参考白落在 0.9989，对比度整体轻微压缩；全范围与有限范围 P010 都受影响。

## 改动

- `wgpu_video.wgsl` / `metal/apple.rs` / `d3d11.rs` 的 `expand_ycbcr_range`：在范围展开前对 P010 采样乘 `65535.0 / 65472.0`（`1023 × 64` 正是 16 位容器中 10 位码的实际满幅）。
- 新增跨端一致性测试 `p010_unorm_prescale_is_present_across_video_shaders`。
- 不依赖 Dolby Vision；对 HDR10 / SDR 的 P010 内容同样生效。

## 验证

- fork CI 全部通过（Ubuntu、macOS arm64/x64、Windows 双架构、iOS、tvOS、rustfmt、clippy、核心测试）：[run 34049275141](https://github.com/1824239290/Erika/actions/runs/34049275141)。
- 与 #130 的关系：该预缩放目前也包含在 #130 中（作为 DV P5 的 P010 基础层渲染前提）。本 PR 合并后 #130 会 rebase 去除重叠部分。