### PR TITLE
fix(ohos): align alpha bindings, C headers and API docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
         run: sha256sum --check SHA256SUMS
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
+      - name: Check C API and package binding alignment
+        env:
+          CXX: g++
+        run: python3 packaging/tests/test_api_alignment.py -v
       - name: Check license policy
         run: cargo run --locked -p xtask -- check license
       - name: Verify vendored Cargo patches

--- a/.github/workflows/ohpm-package.yml
+++ b/.github/workflows/ohpm-package.yml
@@ -31,6 +31,11 @@ on:
         required: true
         default: false
         type: boolean
+      build_flutter_bridge:
+        description: Also rebuild the Flutter OHOS bridge against the released core
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       version:
@@ -114,6 +119,46 @@ jobs:
           test -n "$runtime"
           cp "$runtime" packages/erika_ohos/src/main/cpp/liberika_capi.so
           test -f packages/erika_ohos/src/main/cpp/liberika_capi.so
+
+      - name: Rebuild Flutter OHOS bridge with the released core
+        if: github.event_name == 'workflow_dispatch' && inputs.build_flutter_bridge
+        shell: bash
+        env:
+          OHOS_SDK_NATIVE: ${{ steps.ohos_sdk.outputs.ohos_sdk_native }}
+        run: |
+          set -euo pipefail
+          cmake -S packages/erika_flutter/ohos/src/main/cpp \
+            -B "$RUNNER_TEMP/erika-flutter-bridge" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="$OHOS_SDK_NATIVE/build/cmake/ohos.toolchain.cmake" \
+            -DOHOS_ARCH=arm64-v8a \
+            -DOHOS_SDK_NATIVE="$OHOS_SDK_NATIVE"
+          cmake --build "$RUNNER_TEMP/erika-flutter-bridge" --target erika_flutter_plugin
+          bridge="$RUNNER_TEMP/erika-flutter-bridge/liberika_flutter.so"
+          test -s "$bridge"
+          "$OHOS_SDK_NATIVE/llvm/bin/llvm-readelf" -h "$bridge" | grep -Eq 'Machine:.*AArch64'
+          cmp packages/erika_ohos/src/main/cpp/liberika_capi.so \
+            "$RUNNER_TEMP/erika-flutter-bridge/liberika_capi.so"
+          output="$RUNNER_TEMP/erika-flutter-ohos-rebuild"
+          mkdir -p "$output"
+          cp "$bridge" "$output/"
+          git archive --format=tar.gz HEAD:packages/erika_flutter \
+            > "$output/erika_flutter-${ERIKA_NATIVE_VERSION}-source.tar.gz"
+          {
+            echo "version: $ERIKA_NATIVE_VERSION"
+            echo "bridge/source commit: $(git rev-parse HEAD)"
+            echo "core: reused unchanged from v${ERIKA_NATIVE_VERSION}"
+            echo "Use the matching ArkTS source; replacing only the native bridge does not fix argument forwarding."
+          } > "$output/MANIFEST.txt"
+          (cd "$output" && sha256sum liberika_flutter.so *.tar.gz MANIFEST.txt > SHA256SUMS)
+
+      - name: Upload rebuilt Flutter bridge and matching source
+        if: github.event_name == 'workflow_dispatch' && inputs.build_flutter_bridge
+        uses: actions/upload-artifact@v4
+        with:
+          name: erika-flutter-ohos-rebuild-${{ env.ERIKA_NATIVE_VERSION }}
+          path: ${{ runner.temp }}/erika-flutter-ohos-rebuild/*
+          if-no-files-found: error
 
       - name: Install Hvigor
         working-directory: packages/erika_ohos

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -175,7 +175,9 @@ Windows のネイティブ renderer（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` は 2 つの handle family で 88 関数を export します。
+正本のヘッダーは `crates/erika_capi/include/erika.h` で、各 package のコピーは一致させます。2 つの `erika_presenter_windows_*_iunknown` getter は Windows のみで export されますが、共通ヘッダーには全 platform で宣言されます。
+
+`erika_capi` は 2 つの handle family を提供します。
 
 - **`ErikaHandle`**: player control と event polling。rendering は host 管理です。
 - **`ErikaPresenterHandle`**: Erika が full stack を所有します。host は surface を渡して `render_tick` を呼びます。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,9 @@ DanmakuEngine, and audio output. The host supplies a native surface and drives
 
 ## C ABI
 
-`erika_capi` exports 88 functions through two handle families:
+The canonical header is `crates/erika_capi/include/erika.h`; package copies must match it. The two `erika_presenter_windows_*_iunknown` getters are exported only on Windows, even though the shared header declares them on all platforms.
+
+`erika_capi` exposes two handle families:
 
 - **`ErikaHandle`** — player control and event polling. The host owns rendering.
 - **`ErikaPresenterHandle`** — Erika owns the full stack. The host provides a

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -172,7 +172,9 @@ Windows 平台的原生渲染器（`renderer/d3d11.rs`）：
 
 ## C ABI
 
-`erika_capi` 通过两组 handle family 导出 88 个函数：
+主头文件为 `crates/erika_capi/include/erika.h`，各包的副本须与其一致。两个 `erika_presenter_windows_*_iunknown` getter 仅在 Windows 导出；共用头文件在所有平台都保留其声明。
+
+`erika_capi` 提供两组 handle family：
 
 - **`ErikaHandle`**：播放器控制与事件轮询，渲染由宿主管理。
 - **`ErikaPresenterHandle`**：Erika 持有完整栈，宿主只需提供 surface 并调用 `render_tick`。

--- a/docs/capi_reference.ja.md
+++ b/docs/capi_reference.ja.md
@@ -172,9 +172,10 @@ typedef struct ErikaOpenOptions {
 } ErikaOpenOptions;
 ```
 
-`open` と `play` は
-非同期にキューへ投入されます。ホスト UI スレッドをブロックせず、`StateChanged`、
-`DurationChanged`、`Error` イベントで最終結果を確認してください。
+`open` は同期的にストリームを調査して `Ready` に遷移し、`play` は非同期に
+キューへ投入されます。ブロックする open はホスト UI スレッド以外で実行し、
+同じ handle への呼び出しはすべて直列化してください。以後の再生状態は
+`StateChanged`、`DurationChanged`、`Error` イベントで確認します。
 
 ### トラックと字幕
 
@@ -243,6 +244,11 @@ ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t 
                                                                         int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
+
+v0.1.8 の `ErikaPresenterConfig` は 4 フィールド、16 bytes です。v0.1.7 は
+3 フィールド、12 bytes でした。値渡しする構造体のため、この間にバイナリ互換性は
+ありません。C/C++ の呼び出し側と手書き Swift/FFI mirror は対応するヘッダーと
+native library で再ビルドし、不透明 video では `video_alpha_mode` を `0` にします。
 
 `ErikaPresenterConfig` は出力モード（`Sdr`、Apple `AppleEdr`、Android
 `ExtendedLinear`）、requested EDR/scRGB content-headroom ceiling、初期輝度アップスケーラ、そして
@@ -517,6 +523,14 @@ swap chain を作成します。この getter は **AddRef 済みの `IUnknown*`
 喪失の後は再取得してください——Erika は swap chain を再構築し、新しいオブジェクトを
 公開します。ポインタが同じなら再構築はありません。
 
+### Windows Flutter texture
+
+```c
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(ErikaPresenterHandle *, void **out_texture);
+```
+
+Windows 専用で、他の platform ではこの symbol は export されません。最新の完了済みで不変な SDR Flutter GPU frame を **AddRef 済みの `IUnknown*`** として返します。呼び出し側が参照を所有し、`Release` が必要です。frame の使用中は参照を保持してください。texture の内容はその寿命中に変更されません。出力ポインターが null なら `NullPointer`、有効な presenter に完了済み Flutter texture がなければ `PlayerError` を返して出力を null にします。frame を要求する前に描画を駆動してください。
+
 ### レンダーループとイベント
 
 ```c
@@ -624,8 +638,8 @@ Fallback value は ABI-stable です。新しい reason は末尾へ追加し、
 | 7 | `SurfaceConfigureFailed` | `surface_configure_failed` | requested output surface configure failure。 |
 | 8 | `LegacyAppleEdrUnsupported` | `legacy_apple_edr_unsupported` | Apple EDR 未実装 backend でこの mode を要求。 |
 
-`capture_frame_rgba` は**スクリーンショット**です。現在の合成フレーム（映像 + 字幕（弾幕は含みません） +
-弾幕）を、要求した `width`×`height`（表示 surface サイズとは独立）で呼び出し側確保の
+`capture_frame_rgba` は**スクリーンショット**です。現在の合成フレーム（映像 + 字幕、
+弾幕は含みません）を、要求した `width`×`height`（表示 surface サイズとは独立）で呼び出し側確保の
 RGBA8 バッファにオフスクリーン描画します。`out_capacity` は少なくとも `width*height*4`。
 フレームがまだ無いときは `PlayerError` を返します。Metal と wgpu（Android を含む）は
 capture を実装済みで、現在の D3D11 backend は未実装です。capture は常に SDR RGBA8

--- a/docs/capi_reference.md
+++ b/docs/capi_reference.md
@@ -180,9 +180,10 @@ typedef struct ErikaOpenOptions {
 } ErikaOpenOptions;
 ```
 
-`open` and `play` enqueue work asynchronously. Watch for `StateChanged`,
-`DurationChanged`, and `Error` events for the authoritative result instead of
-blocking the host UI thread.
+`open` synchronously probes streams and transitions to `Ready`; `play` enqueues
+work asynchronously. Run blocking opens off the host UI thread and serialize
+all calls on the same handle. Observe `StateChanged`, `DurationChanged`, and
+`Error` events for subsequent playback changes.
 
 ### Tracks and subtitles
 
@@ -262,6 +263,12 @@ ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t 
                                                                         int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
+
+Since v0.1.8, `ErikaPresenterConfig` has four fields (16 bytes); v0.1.7 used
+three fields (12 bytes). This by-value structure is not binary-compatible
+across those versions. Rebuild C/C++ callers and manual Swift/FFI mirrors
+with the matching header and native library, and initialize `video_alpha_mode`
+to `0` for opaque video.
 
 `ErikaPresenterConfig` selects the output mode (`Sdr`, Apple `AppleEdr`, or
 Android `ExtendedLinear`), the requested EDR/scRGB content-headroom ceiling,
@@ -562,6 +569,14 @@ target HWND. This getter returns it as an **AddRef'd `IUnknown*`**: the caller
 owns the returned COM reference and must `Release` it. Re-fetch it after
 decoder/device loss — Erika recreates the swap chain and exposes the new
 object; the same pointer means nothing was rebuilt.
+
+### Windows Flutter texture
+
+```c
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(ErikaPresenterHandle *, void **out_texture);
+```
+
+Windows only; this symbol is not exported on other platforms. Returns the latest completed, immutable SDR Flutter GPU frame as an **AddRef'd `IUnknown*`**. The caller owns the reference and must `Release` it. Keep the reference while consuming the frame; its texture contents remain unchanged throughout its lifetime. A null output pointer returns `NullPointer`. With a valid presenter but no completed Flutter texture, it returns `PlayerError` and clears the output pointer. Drive rendering before requesting a frame.
 
 ### Render loop and events
 

--- a/docs/capi_reference.zh.md
+++ b/docs/capi_reference.zh.md
@@ -164,9 +164,9 @@ typedef struct ErikaOpenOptions {
 } ErikaOpenOptions;
 ```
 
-`open` 和 `play` 都会
-异步入队；应观察 `StateChanged`、`DurationChanged` 和 `Error` 事件获取最终结果，
-不要阻塞宿主 UI 线程。
+`open` 会同步探测媒体流并转入 `Ready`；`play` 才是异步入队。
+应在宿主 UI 线程之外执行可能阻塞的 open，并串行调用同一 handle 的所有接口。
+通过 `StateChanged`、`DurationChanged` 和 `Error` 事件观察后续播放变化。
 
 ### 轨道与字幕
 
@@ -240,6 +240,11 @@ ErikaPresenterHandle *erika_presenter_create_with_output_mode_and_alpha(int32_t 
                                                                         int32_t video_alpha_mode);
 void                  erika_presenter_destroy(ErikaPresenterHandle *handle);
 ```
+
+从 v0.1.8 起，`ErikaPresenterConfig` 为四字段、16 字节；v0.1.7 为三字段、
+12 字节。此结构体按值传递，两个版本不具备二进制兼容性。C/C++ 调用方及手写
+Swift/FFI 镜像必须使用配套头文件和原生库重新编译，不透明视频应将
+`video_alpha_mode` 初始化为 `0`。
 
 `ErikaPresenterConfig` 选择输出模式（`Sdr`、Apple `AppleEdr`、Android
 `ExtendedLinear`）、请求的 EDR/scRGB 内容 headroom 上限、初始亮度超分，以及
@@ -489,6 +494,14 @@ ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(ErikaPresente
 composition swap chain。此 getter 以 **AddRef 后的 `IUnknown*`** 返回它：调用者拥有返回的
 COM 引用，必须自行 `Release`。解码器/设备丢失后应重新获取——Erika 会重建 swap chain
 并暴露新对象；指针未变说明没有重建。
+
+### Windows Flutter 纹理
+
+```c
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(ErikaPresenterHandle *, void **out_texture);
+```
+
+仅限 Windows，其他平台不导出此符号。返回最新已完成且不可变的 SDR Flutter GPU 帧，类型为 **已 AddRef 的 `IUnknown*`**。调用方拥有该引用，必须 `Release`；使用帧期间应保留引用，纹理内容在其整个生命周期内不会改变。输出指针为空时返回 `NullPointer`；presenter 有效但尚无已完成 Flutter 纹理时返回 `PlayerError`，并将输出置空。应先驱动渲染再请求帧。
 
 ### 渲染循环与事件
 

--- a/docs/flutter_embedding.ja.md
+++ b/docs/flutter_embedding.ja.md
@@ -39,7 +39,7 @@ touch events は両方の native video strategy を通過するので、Flutter 
 
 ### ErikaTextureVideoView (Flutter Texture)
 
-`ErikaTextureVideoView` は platform view ではなく Flutter の texture registrar 経由で描画します。macOS では plugin が IOSurface-backed の `CVPixelBuffer` pool を確保し、その Metal texture に直接描画（フレームごとの CPU readback なし）して Flutter へ frame を publish するため、`Opacity`、clipping、transform、color filter といった通常の Flutter effect が video に適用されます。OpenHarmony では登録済みの external texture を再利用します。それ以外の platform では `ErikaVideoView` に fallback します。
+`ErikaTextureVideoView` は platform view ではなく Flutter の texture registrar 経由で描画します。macOS では plugin が IOSurface-backed の `CVPixelBuffer` pool を確保し、その Metal texture に直接描画（フレームごとの CPU readback なし）して Flutter へ frame を publish するため、`Opacity`、clipping、transform、color filter といった通常の Flutter effect が video に適用されます。OpenHarmony では登録済みの external texture を再利用します。Windows は SDR BGRA8 GPU texture 出力を提供します。それ以外の platform では `ErikaVideoView` に fallback します。
 
 macOS で `blendMode` が `srcOver` 以外の場合、widget は native platform view に切り替え、Core Animation に実際の背景に対する blending を任せます（下記「透明 video と blend mode」を参照）。
 
@@ -154,7 +154,7 @@ Flutter Texture は機能が限定された compatibility path です。
 用途:
 - SDR fallback。
 - native view composition がまだ使えない platform。
-- Flutter compositor に入るべき透明 video（macOS / OpenHarmony の `ErikaTextureVideoView`）。
+- Flutter compositor に入るべき透明 video（macOS / Windows / OpenHarmony の `ErikaTextureVideoView`）。
 - test surface や制約の強い embedding 環境。
 
 HDR/EDR の推奨 path ではありません。video が Flutter compositor に入ってしまうためです。Apple では surface は IOSurface-backed の `CVPixelBuffer` です。host が Flutter texture を登録し、毎 render tick の前に `erika_presenter_attach_flutter_texture` と `erika_presenter_set_flutter_texture_buffer` でその frame の Metal texture を選択すると、Flutter が同じ buffer を CPU readback なしで合成します。pixel buffer の所有権は host 側にあります。
@@ -192,7 +192,7 @@ await player.play();
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
 
-// Flutter 合成の video。opacity / clipping / filter に対応（macOS/OpenHarmony）:
+// Flutter 合成の video。opacity / clipping / filter に対応（macOS/Windows/OpenHarmony）:
 ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility/diagnostic platform-view path:

--- a/docs/flutter_embedding.md
+++ b/docs/flutter_embedding.md
@@ -235,7 +235,7 @@ Useful for:
 - SDR fallback.
 - Platforms where native view composition is not ready.
 - Transparent video that should participate in Flutter's compositor
-  (`ErikaTextureVideoView` on macOS and OpenHarmony).
+  (`ErikaTextureVideoView` on macOS, Windows, and OpenHarmony).
 - Test surfaces or constrained embedding environments.
 
 It is not the preferred HDR/EDR route because video enters Flutter's
@@ -280,7 +280,7 @@ await player.play();
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
 
-// Flutter-composited video with opacity/clipping/filters (macOS/OpenHarmony):
+// Flutter-composited video with opacity/clipping/filters (macOS/Windows/OpenHarmony):
 ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility/diagnostic platform-view path:

--- a/docs/flutter_embedding.zh.md
+++ b/docs/flutter_embedding.zh.md
@@ -39,7 +39,7 @@ Apple HDR 路径使用 native Metal-backed surface，而不是 Flutter Texture�
 
 ### ErikaTextureVideoView (Flutter Texture)
 
-`ErikaTextureVideoView` 通过 Flutter 的 texture registrar 渲染，而不是 platform view。macOS 上 plugin 会分配 IOSurface-backed 的 `CVPixelBuffer` 池，直接渲染进其 Metal texture（无逐帧 CPU 回读），再把帧发布给 Flutter，因此 `Opacity`、裁剪、变换和颜色滤镜等常规 Flutter 效果都作用在视频上。OpenHarmony 上复用已注册的外部纹理。其他平台回退到 `ErikaVideoView`。
+`ErikaTextureVideoView` 通过 Flutter 的 texture registrar 渲染，而不是 platform view。macOS 上 plugin 会分配 IOSurface-backed 的 `CVPixelBuffer` 池，直接渲染进其 Metal texture（无逐帧 CPU 回读），再把帧发布给 Flutter，因此 `Opacity`、裁剪、变换和颜色滤镜等常规 Flutter 效果都作用在视频上。OpenHarmony 上复用已注册的外部纹理。Windows 提供 SDR BGRA8 GPU 纹理输出（详见下文）。其他平台回退到 `ErikaVideoView`。
 
 macOS 上当 `blendMode` 不是 `srcOver` 时，widget 会改走 native platform view，让 Core Animation 基于真实背景做混合（见下文"透明视频与混合模式"）。
 
@@ -154,7 +154,7 @@ Flutter Texture 是一个能力更低的兼容路径。
 适合：
 - SDR fallback。
 - native view composition 尚未准备好的平台。
-- 需要进入 Flutter compositor 的透明视频（macOS/OpenHarmony 上的 `ErikaTextureVideoView`）。
+- 需要进入 Flutter compositor 的透明视频（macOS/Windows/OpenHarmony 上的 `ErikaTextureVideoView`）。
 - 测试 surface 或受限 embedding 环境。
 
 它不是首选 HDR/EDR 路径，因为视频会进入 Flutter compositor。Apple 上 surface 是 IOSurface-backed 的 `CVPixelBuffer`：宿主注册 Flutter texture，在每个 render tick 前用 `erika_presenter_attach_flutter_texture` 和 `erika_presenter_set_flutter_texture_buffer` 选定该帧的 Metal texture，Flutter 随后合成同一个 buffer，无 CPU 回读。pixel buffer 的所有权始终在宿主侧。
@@ -191,7 +191,7 @@ await player.play();
 // Preferred for full-player UIs on macOS/iOS/tvOS:
 ErikaWindowOverlayVideoView(player: player)
 
-// Flutter 合成的视频，支持不透明度/裁剪/滤镜（macOS/OpenHarmony）：
+// Flutter 合成的视频，支持不透明度/裁剪/滤镜（macOS/Windows/OpenHarmony）：
 ErikaTextureVideoView(player: player, opacity: 0.8)
 
 // Compatibility / diagnostic platform-view path:

--- a/docs/investigations/v0.1.8-api-alignment.md
+++ b/docs/investigations/v0.1.8-api-alignment.md
@@ -1,0 +1,71 @@
+# v0.1.8 接口与文档对齐审计
+
+审计日期：2026-09-07。发布基线：`91406690405f87f03b9ddddbc48179426bf5abea`
+（v0.1.8）；修复基于 `3d79d0d87c363576b3aeb9ecfc6a3ea8f9834653`。
+
+## 结论与修复
+
+v0.1.8 存在绑定和文档遗漏，不能概括为“所有平台都已对齐”。本次不改播放核心。
+
+| 层面 | 发现 | 本次处理 |
+| --- | --- | --- |
+| OpenHarmony Flutter | Dart 传出 `videoAlphaMode`，ArkTS 和 N-API 创建函数丢弃该参数，核心收到的始终是 opaque | 补齐第四参数及类型声明；旧三参数调用继续默认 opaque |
+| 独立 OHPM SDK | 配置接口和 N-API 创建函数均没有透明视频参数 | 添加可选配置并传至 `ErikaPresenterConfig.video_alpha_mode` |
+| 头文件副本 | OHPM 副本缺少 Windows Flutter texture getter；Flutter 副本正确 | 与主头文件同步。该 getter 是 Windows 专用，并非 OHOS 运行时缺少应有功能 |
+| 三语 C API 文档 | 漏掉 Windows texture getter；把同步 open 写成异步 | 补充接口、COM 引用所有权、错误行为及同步 open 约束 |
+| ABI 说明 | v0.1.7 的配置为 12 字节，v0.1.8 为 16 字节，按值传递不能混用 | 三语参考文档明确要求配套头文件、绑定和库一起重编译 |
+| 架构和 Flutter 文档 | 固定写 88 个函数；部分平台列表遗漏 Windows texture | 去掉过时数量，明确 Windows 专用导出边界并同步三语平台说明 |
+| 日语截图文档 | 同时出现“不含弹幕”和“加弹幕”的矛盾文字 | 与实现及英中文档统一为视频加字幕，不含弹幕 |
+| 独立 ErikaSwift SDK | main 仍绑定 v0.1.7，创建函数使用三字段配置，公开 open 无 read-ahead 参数 | 已确认，未在本仓库修复；需要独立 SDK 的升级提交和 Apple 构建验证 |
+
+核心 wgpu 的 `video_uniforms_for_frame`、逻辑视频宽度和透明清屏已消费 alpha mode。
+OHOS AVCodec 的 Vulkan 转换结果继续进入这条合成路径，因此参数丢失发生在绑定层。
+这不等于已完成 OHOS 透明窗口或 Flutter compositor 的真机验收。
+
+## PR 范围
+
+按 v0.1.7 至 v0.1.8 的 29 个合并 PR 归类核对：
+
+- 接口、绑定及 GPU 合成：#105、#119、#123、#124、#126、#127、#128、#129。
+  #127/#128 已修复 Apple 配置镜像；本次补齐 OHOS 参数及 #129 后遗漏的头文件副本。
+- 核心播放行为：#82、#115、#121、#122、#131。无需新增 C 入口，本次不改变这些修复。
+- 产物、SDK 发布与文档：#98、#99、#100、#101、#102、#103、#104、#106、
+  #108、#109、#110、#111、#112、#113、#114、#117。
+  打包成功与每个平台的二进制/设备运行验证是不同结论。
+
+本版本新增七个 C 函数：两个 `open_with_options`、
+`create_with_output_mode_and_alpha`、`attach_flutter_texture`、
+`set_flutter_texture_buffer` 和两个 Windows `IUnknown` getter。
+主头文件的 98 个函数与 Rust 导出函数名称及参数/返回类型对应；检查涵盖源码中的
+平台实现和不支持平台的 stub（opaque presenter 指针按 ABI 等价处理）。
+这项检查不证明所有结构体布局或所有目标的链接结果。
+
+本版新增 `ErikaOpenOptions` 的字段顺序/宽度与 Rust 及 Apple 三个平台的手写镜像一致：
+headers 指针、指针宽度计数、u64 read-ahead、三个 u64 reserved。
+修改后的 `ErikaPresenterConfig` 为 i32/f32/i32/i32；Apple 镜像匹配。
+Windows 和 Android 的创建绑定已传递 alpha mode；HTTP read-ahead 在 Apple、Windows、
+Android、OHOS JSON 路径均有接收处理。
+
+## 验证记录与边界
+
+- 五项定向测试通过：头文件镜像、函数名称、C/Rust 函数签名、ArkTS 参数链、
+  两个原始 N-API `NativeCreate` 函数的宿主模拟执行。
+- 原始创建函数测试直接编译仓库函数，以假 N-API 输入和 presenter 捕获端检查
+  四参数 alpha=1、三参数默认 alpha=0、其他配置不丢失及少于三参数拒绝创建。
+  v0.1.8 两个旧函数都在 alpha=1 断言处失败，修复版通过。
+  此测试不替代 OHOS N-API SDK 编译或真机运行。
+- 已下载的 v0.1.8 `erika-capi-openharmony-arm64.zip` 中 `liberika_capi.so`，
+  使用 `llvm-nm -D --defined-only` 检查：96 个预期 C 符号全部存在，无额外 C 符号。
+  两个 `erika_presenter_windows_*_iunknown` 由 Rust Windows cfg 限定，不应出现在 OHOS。
+- 本轮没有读取其余平台发布库的完整符号表，不对这些未检查项目作全量保证。
+- 独立 `AimesSoft/ErikaSwift` main `96159140b3be7cd4623ffb6f4d009502422d66ae`
+  已通过 GitHub API 核对：`Package.swift` 的 binary target 仍指向 v0.1.7；
+  `ErikaPlayer.swift` 按三字段创建配置，公开 open 只有 HTTP headers，没有 read-ahead。
+  它目前使用配套旧库，不能据此称为运行时 ABI 混用，但尚未对齐 v0.1.8。
+  不能只改下载 URL；还须更新配置初始化、公开新参数，并验证 Apple 构建。
+- `git diff --check` 通过。回归检查接入现有 Ubuntu quality job，不新增 CI 矩阵；
+  本轮没有触发远端 CI，也没有修改已发布的 v0.1.8 产物。
+
+本地运行：`CXX=g++ python3 packaging/tests/test_api_alignment.py -v`。
+修复需要后续合并并发布含更新 ArkTS 和 N-API bridge 的 Flutter/OHPM 包后，
+才能对注册表用户生效；仅更新核心库不能修复旧桥接的参数丢失。

--- a/packages/erika_flutter/ohos/src/main/cpp/erika_flutter_plugin.cpp
+++ b/packages/erika_flutter/ohos/src/main/cpp/erika_flutter_plugin.cpp
@@ -91,8 +91,8 @@ void ReleaseWindow(OhosPlayer& player) {
 }
 
 napi_value NativeCreate(napi_env env, napi_callback_info info) {
-  size_t argc = 3;
-  napi_value args[3] = {};
+  size_t argc = 4;
+  napi_value args[4] = {};
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
   if (argc < 3) {
     return Int64(env, 0);
@@ -101,6 +101,7 @@ napi_value NativeCreate(napi_env env, napi_callback_info info) {
   config.output_mode = GetInt32(env, args[0]);
   config.edr_headroom = static_cast<float>(GetDouble(env, args[1]));
   config.luma_upscaler = GetInt32(env, args[2]);
+  config.video_alpha_mode = argc > 3 ? GetInt32(env, args[3]) : 0;
   auto* presenter = erika_presenter_create_with_config(config);
   if (presenter == nullptr) {
     return Int64(env, 0);

--- a/packages/erika_flutter/ohos/src/main/cpp/types/liberika_flutter/Index.d.ts
+++ b/packages/erika_flutter/ohos/src/main/cpp/types/liberika_flutter/Index.d.ts
@@ -1,4 +1,4 @@
-export const nativeCreate: (outputMode: number, headroom: number, upscaler: number) => number;
+export const nativeCreate: (outputMode: number, headroom: number, upscaler: number, videoAlphaMode?: number) => number;
 export const nativeLastError: () => string | null;
 export const nativeDestroy: (playerId: number) => void;
 export const nativeInvoke: (playerId: number, method: string, argumentsJson: string) => string;

--- a/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
+++ b/packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets
@@ -212,7 +212,8 @@ export default class ErikaFlutterPlugin implements FlutterPlugin, MethodCallHand
       outputMode === 2 ? 4.0 : 1.0,
     );
     const upscaler = this.numberArg(args, 'upscaler', 0);
-    const playerId = erikaNative.nativeCreate(outputMode, headroom, upscaler) as number;
+    const videoAlphaMode = this.numberArg(args, 'videoAlphaMode', 0);
+    const playerId = erikaNative.nativeCreate(outputMode, headroom, upscaler, videoAlphaMode) as number;
     if (playerId <= 0) {
       result.error(
         'ERIKA_ERROR',

--- a/packages/erika_ohos/README.md
+++ b/packages/erika_ohos/README.md
@@ -14,6 +14,15 @@ provides an `XComponent` surface id through `attachSurface()` and drives
 ohpm install erika
 ```
 
+## Player configuration
+
+`ErikaPlayerConfig` accepts `outputMode`, `edrHeadroom`, `upscaler`, and
+`videoAlphaMode`. The alpha mode defaults to `0` (opaque); `1` decodes a frame
+with color in the left half and alpha in the right half. The host surface must
+support transparent composition for the background to remain visible.
+The alpha option requires the updated ArkTS wrapper and N-API bridge together;
+the published 0.1.8 OHPM wrapper does not forward it.
+
 ## Usage
 
 The package owns the native presenter, while the ArkTS host owns the

--- a/packages/erika_ohos/src/main/cpp/erika_ohos.cpp
+++ b/packages/erika_ohos/src/main/cpp/erika_ohos.cpp
@@ -100,8 +100,8 @@ void ReleaseWindow(OhosPlayer& player) {
 }
 
 napi_value NativeCreate(napi_env env, napi_callback_info info) {
-  size_t argc = 3;
-  napi_value args[3] = {};
+  size_t argc = 4;
+  napi_value args[4] = {};
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
   if (argc < 3) {
     return Int64(env, 0);
@@ -110,6 +110,7 @@ napi_value NativeCreate(napi_env env, napi_callback_info info) {
   config.output_mode = GetInt32(env, args[0]);
   config.edr_headroom = static_cast<float>(GetDouble(env, args[1]));
   config.luma_upscaler = GetInt32(env, args[2]);
+  config.video_alpha_mode = argc > 3 ? GetInt32(env, args[3]) : 0;
   auto* presenter = erika_presenter_create_with_config(config);
   if (presenter == nullptr) {
     return Int64(env, 0);

--- a/packages/erika_ohos/src/main/cpp/include/erika.h
+++ b/packages/erika_ohos/src/main/cpp/include/erika.h
@@ -752,6 +752,13 @@ ErikaStatus erika_presenter_windows_composition_swapchain_iunknown(
     ErikaPresenterHandle *handle,
     void **out_swapchain);
 
+/* Windows only. Returns an AddRef'd IUnknown for the latest completed,
+ * immutable SDR Flutter GPU frame. The caller owns the COM reference and
+ * must Release it. The texture remains unchanged for its entire lifetime. */
+ErikaStatus erika_presenter_windows_flutter_texture_iunknown(
+    ErikaPresenterHandle *handle,
+    void **out_texture);
+
 ErikaStatus erika_presenter_resize_surface(
     ErikaPresenterHandle *handle,
     uint32_t width,

--- a/packages/erika_ohos/src/main/ets/ErikaPlayer.ets
+++ b/packages/erika_ohos/src/main/ets/ErikaPlayer.ets
@@ -18,6 +18,8 @@ export interface ErikaPlayerConfig {
   outputMode?: number;
   edrHeadroom?: number;
   upscaler?: number;
+  /** 0 = opaque (default), 1 = packed alpha in the right half of the frame. */
+  videoAlphaMode?: number;
 }
 
 export interface ErikaOpenOptions {
@@ -39,7 +41,8 @@ export class ErikaPlayer {
     const outputMode: number = config.outputMode ?? 0;
     const edrHeadroom: number = config.edrHeadroom ?? 1.0;
     const upscaler: number = config.upscaler ?? 0;
-    this.nativeId = erikaNative.nativeCreate(outputMode, edrHeadroom, upscaler) as number;
+    const videoAlphaMode: number = config.videoAlphaMode ?? 0;
+    this.nativeId = erikaNative.nativeCreate(outputMode, edrHeadroom, upscaler, videoAlphaMode) as number;
     if (this.nativeId <= 0) {
       throw new Error('Erika player creation failed: ' + (erikaNative.nativeLastError() as string));
     }

--- a/packaging/tests/test_api_alignment.py
+++ b/packaging/tests/test_api_alignment.py
@@ -1,0 +1,136 @@
+"""Focused API packaging checks. Run with Python; CXX enables native bridge tests."""
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class ApiAlignmentTests(unittest.TestCase):
+    def test_header_copies(self):
+        canonical = read("crates/erika_capi/include/erika.h")
+        for path in ["packages/erika_flutter/native/include/erika.h",
+                     "packages/erika_ohos/src/main/cpp/include/erika.h"]:
+            with self.subTest(path=path):
+                self.assertEqual(canonical, read(path))
+
+    def test_declared_and_exported_names(self):
+        header = re.sub(r"/\*.*?\*/", "", read("crates/erika_capi/include/erika.h"), flags=re.S)
+        declared = set(re.findall(r"\b(erika_\w+)\s*\(", header))
+        exported = set()
+        for path in (ROOT / "crates/erika_capi/src").glob("*.rs"):
+            exported.update(re.findall(r'pub (?:unsafe )?extern "C" fn (erika_\w+)', path.read_text(encoding="utf-8")))
+        self.assertEqual(declared, exported)
+
+    def test_ohos_alpha_reaches_native_call(self):
+        flutter = read("packages/erika_flutter/ohos/src/main/ets/components/plugin/ErikaFlutterPlugin.ets")
+        self.assertIn("this.numberArg(args, 'videoAlphaMode', 0)", flutter)
+        self.assertIn("nativeCreate(outputMode, headroom, upscaler, videoAlphaMode)", flutter)
+        sdk = read("packages/erika_ohos/src/main/ets/ErikaPlayer.ets")
+        self.assertIn("config.videoAlphaMode ?? 0", sdk)
+        self.assertIn("nativeCreate(outputMode, edrHeadroom, upscaler, videoAlphaMode)", sdk)
+        self.assertIn("videoAlphaMode?: number", read("packages/erika_flutter/ohos/src/main/cpp/types/liberika_flutter/Index.d.ts"))
+
+    def test_c_and_rust_function_signatures(self):
+        # These entry points use scalar/named types and pointers, not callbacks.
+        # Keep this deliberately strict: an unfamiliar signature must be reviewed.
+        scalar = {"i32": "int32_t", "u32": "uint32_t", "i64": "int64_t",
+                  "u64": "uint64_t", "u8": "uint8_t", "usize": "uintptr_t",
+                  "f32": "float", "f64": "double", "c_char": "char",
+                  "std::ffi::c_void": "void", "c_void": "void",
+                  "ErikaPresenterHandle": "void"}
+
+        def compact(value):
+            # Unsupported-platform stubs use void* for this opaque handle.
+            return re.sub(r"\s+", "", value).replace("ErikaPresenterHandle", "void")
+
+        def c_type(value):
+            value = value.strip()
+            if value.startswith("*mut "):
+                return c_type(value[5:]) + "*"
+            if value.startswith("*const "):
+                return "const" + c_type(value[7:]) + "*"
+            return scalar.get(value, value)
+
+        header = re.sub(r"/\*.*?\*/", "", read("crates/erika_capi/include/erika.h"), flags=re.S)
+        declarations = {}
+        for ret, name, args in re.findall(r"^([\w *]+?)\b(erika_\w+)\s*\((.*?)\);", header, re.M | re.S):
+            params = [] if args.strip() == "void" else [compact(re.sub(r"\w+\s*$", "", arg.strip())) for arg in args.split(",")]
+            declarations[name] = (compact(ret), params)
+        checked = set()
+        for path in (ROOT / "crates/erika_capi/src").glob("*.rs"):
+            source = path.read_text(encoding="utf-8")
+            for name, args, ret in re.findall(r'pub (?:unsafe )?extern "C" fn (erika_\w+)\((.*?)\)\s*(?:->\s*([^{}]+))?\s*\{', source, re.S):
+                params = [c_type(arg.split(":", 1)[1]) for arg in args.split(",") if arg.strip()]
+                with self.subTest(name=name):
+                    self.assertEqual(declarations[name], (c_type(ret or "void"), params))
+                checked.add(name)
+        self.assertEqual(checked, set(declarations))
+
+    @unittest.skipUnless(os.environ.get("CXX"), "Set CXX to a C++ compiler to execute NativeCreate with a fake N-API host")
+    def test_native_create_preserves_config_and_legacy_default(self):
+        # Execute the actual bridge function with a fake N-API argument source
+        # and capture what reaches the presenter. No OHOS SDK/device is needed.
+        for path in ["packages/erika_flutter/ohos/src/main/cpp/erika_flutter_plugin.cpp",
+                     "packages/erika_ohos/src/main/cpp/erika_ohos.cpp"]:
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as temp:
+                source = read(path)
+                start = source.index("napi_value NativeCreate(")
+                end = source.index("\nnapi_value NativeLastError", start)
+                harness = r'''
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include "erika.h"
+using napi_env = void*;
+using napi_callback_info = void*;
+using napi_value = double;
+size_t supplied;
+void napi_get_cb_info(napi_env, napi_callback_info, size_t* n, napi_value* args, void*, void*) {
+  double values[] = {2, 4.0, 3, 1};
+  *n = supplied < *n ? supplied : *n;
+  for (size_t i = 0; i < *n; ++i) args[i] = values[i];
+}
+int GetInt32(napi_env, napi_value v) { return static_cast<int>(v); }
+double GetDouble(napi_env, napi_value v) { return v; }
+napi_value Int64(napi_env, int64_t v) { return static_cast<double>(v); }
+struct OhosPlayer { ErikaPresenterHandle* presenter; void* window; };
+std::map<int64_t, OhosPlayer> g_players;
+ErikaPresenterConfig captured;
+int creates = 0;
+extern "C" ErikaPresenterHandle* erika_presenter_create_with_config(ErikaPresenterConfig c) {
+  captured = c; ++creates;
+  return reinterpret_cast<ErikaPresenterHandle*>(16);
+}
+'''
+                harness += source[start:end]
+                harness += r'''
+int main() {
+  for (size_t count : {size_t(3), size_t(4)}) {
+    supplied = count;
+    assert(NativeCreate(nullptr, nullptr) == 16);
+    assert(captured.output_mode == 2 && captured.edr_headroom == 4.0f);
+    assert(captured.luma_upscaler == 3);
+    assert(captured.video_alpha_mode == (count == 4 ? 1 : 0));
+  }
+  supplied = 2;
+  assert(NativeCreate(nullptr, nullptr) == 0);
+  assert(creates == 2);
+}
+'''
+                cpp = Path(temp) / "bridge.cpp"
+                cpp.write_text(harness, encoding="utf-8")
+                exe = Path(temp) / ("bridge.exe" if os.name == "nt" else "bridge")
+                subprocess.run([os.environ["CXX"], "-std=c++17", "-I", str(ROOT / "crates/erika_capi/include"), str(cpp), "-o", str(exe)], check=True)
+                subprocess.run([str(exe)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
OpenHarmony discarded `videoAlphaMode` before presenter creation, so transparent video requests always used opaque mode. Forward the optional parameter through both Flutter and standalone OHPM bindings, retaining the three-argument default.

Synchronize the OHPM header mirror and correct English, Chinese and Japanese API documentation, including synchronous open behavior, Windows texture ownership and the v0.1.8 configuration ABI change. Add focused header/signature checks and execute both native creation functions with a fake N-API host to verify forwarding and legacy behavior.

Validation: five focused tests pass; the unmodified v0.1.8 native functions fail the new alpha assertion. Workflow actionlint and whitespace checks pass. The v0.1.8 OHOS runtime exports all 96 expected C symbols. Device rendering is not verified.

The manual OHPM workflow can also build the Flutter bridge while reusing the existing v0.1.8 core. It saves the bridge and matching source as separate artifacts. Version numbers and existing release assets stay unchanged. The maintainer requested a narrow rebuild, so automatic matrices are skipped for this merge; the targeted OHOS package workflow will run explicitly.
